### PR TITLE
Add basic revision management support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ ext {
     retrofitVersion = '2.7.2'
     roomVersion = '2.2.5'
     workManagerVersion = '2.3.4'
+    jsonToolsVersion = '1.13'
 
     // testing
     junitVersion = '4.13'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -30,6 +30,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    packagingOptions {
+        exclude 'META-INF/ASL-2.0.txt'
+        exclude 'META-INF/LGPL-3.0.txt'
+    }
 }
 
 configurations {

--- a/fhirengine/build.gradle
+++ b/fhirengine/build.gradle
@@ -42,6 +42,10 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    packagingOptions {
+        exclude 'META-INF/ASL-2.0.txt'
+        exclude 'META-INF/LGPL-3.0.txt'
+    }
 }
 
 configurations {
@@ -72,6 +76,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.opencds.cqf:cql-engine-fhir:$cqlEngineVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
+    implementation "com.github.java-json-tools:json-patch:$jsonToolsVersion"
 
     testImplementation "androidx.test:core:$testVersion"
     testImplementation "org.robolectric:robolectric:$roboelectricVersion"

--- a/fhirengine/src/main/java/com/google/fhirengine/FhirEngine.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/FhirEngine.kt
@@ -62,7 +62,7 @@ interface FhirEngine {
      *
      * @param <R> The resource type which should be a subtype of [Resource].
      */
-    fun <R : Resource> remove(clazz: Class<R>, id: String): R
+    fun <R : Resource> remove(clazz: Class<R>, id: String)
 
     /** Returns the result of a CQL evaluation provided with the ID of the library.  */
     fun evaluateCql(libraryVersionId: String, context: String, expression: String): EvaluationResult

--- a/fhirengine/src/main/java/com/google/fhirengine/Util.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/Util.kt
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.fhirengine
 
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
+import java.util.Locale
 
 fun Date.toTimeZoneString(): String {
     val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)

--- a/fhirengine/src/main/java/com/google/fhirengine/Util.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/Util.kt
@@ -20,6 +20,9 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+/**
+ * Utility function to add timestamps to database rows, e.g. last local update timestamp.
+ */
 fun Date.toTimeZoneString(): String {
     val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)
     return simpleDateFormat.format(this)

--- a/fhirengine/src/main/java/com/google/fhirengine/Util.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/Util.kt
@@ -1,0 +1,9 @@
+package com.google.fhirengine
+
+import java.text.SimpleDateFormat
+import java.util.*
+
+fun Date.toTimeZoneString(): String {
+    val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)
+    return simpleDateFormat.format(this)
+}

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/DbTypeConverters.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/DbTypeConverters.kt
@@ -18,6 +18,7 @@ package com.google.fhirengine.db.impl
 
 import androidx.room.TypeConverter
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum
+import com.google.fhirengine.db.impl.entities.LocalChange
 import java.math.BigDecimal
 import java.util.Calendar
 import org.hl7.fhir.r4.model.ResourceType
@@ -69,5 +70,17 @@ internal object DbTypeConverters {
             Calendar.MILLISECOND -> TemporalPrecisionEnum.MILLI
             else -> throw IllegalArgumentException("Unknown TemporalPrecision int $intTp")
         }
+    }
+
+    @JvmStatic
+    @TypeConverter
+    fun localChangeTypeToInt(updateType: LocalChange.Type): Int {
+        return updateType.value
+    }
+
+    @JvmStatic
+    @TypeConverter
+    fun intToLocalChangeType(value: Int): LocalChange.Type {
+        return LocalChange.Type.from(value)
     }
 }

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/DbTypeConverters.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/DbTypeConverters.kt
@@ -72,13 +72,11 @@ internal object DbTypeConverters {
         }
     }
 
-    @JvmStatic
     @TypeConverter
     fun localChangeTypeToInt(updateType: LocalChange.Type): Int {
         return updateType.value
     }
 
-    @JvmStatic
     @TypeConverter
     fun intToLocalChangeType(value: Int): LocalChange.Type {
         return LocalChange.Type.from(value)

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/DbTypeConverters.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/DbTypeConverters.kt
@@ -72,11 +72,13 @@ internal object DbTypeConverters {
         }
     }
 
+    @JvmStatic
     @TypeConverter
     fun localChangeTypeToInt(updateType: LocalChange.Type): Int {
         return updateType.value
     }
 
+    @JvmStatic
     @TypeConverter
     fun intToLocalChangeType(value: Int): LocalChange.Type {
         return LocalChange.Type.from(value)

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
@@ -25,10 +25,29 @@ import org.hl7.fhir.r4.model.ResourceType
  * When a local change to a resource happens, the lastUpdated timestamp in
  * [ResourceEntity] is updated and the diff itself is inserted in this table.
  * The value of the diff depends upon the type of change and can be:
- * * The empty string (DELETE),
- * * The full resource in JSON form (INSERT)
- * * A RFC 6902 JSON patch (UPDATE).
- *
+ * * DELETE: The empty string, "".
+ * * INSERT: The full resource in JSON form, e.g.
+ * {
+ *      "resourceType": "Patient",
+ *      "id": "animal",
+ *      "name": [
+ *              {
+ *               "use": "usual",
+ *               "given": [
+ *               "Kenzi"
+ *              ]
+ *              }
+ *        ],
+ *      ...
+ * }
+ * * UPDATE: A RFC 6902 JSON patch. e.g. a patch that changes the given name of a patient:
+ * [
+ *      {
+ *      "op": "replace",
+ *      "path": "/name/0/given/0",
+ *      "value": "Binny"
+ *      }
+ * ]
  *  For resource that is fully synced with server this table should be empty.
  */
 @Entity(

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.fhirengine.db.impl.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+import org.hl7.fhir.r4.model.ResourceType
+
+/**
+ * When a local change to a resource happens, the lastUpdated timestamp in
+ * [ResourceEntity] is updated and the diff itself is inserted in this table.
+ * The value of the diff depends upon the type of change and can be:
+ * * The empty string (DELETE),
+ * * The full resource in JSON form (INSERT)
+ * * A RFC 6902 JSON patch (UPDATE).
+ *
+ *  For resource that is fully synced with server this table should be empty.
+ */
+@Entity(
+        foreignKeys = [
+            ForeignKey(
+                    entity = ResourceEntity::class,
+                    parentColumns = ["resourceId", "resourceType"],
+                    childColumns = ["resourceId", "resourceType"],
+                    onDelete = ForeignKey.CASCADE,
+                    onUpdate = ForeignKey.NO_ACTION,
+                    deferred = true
+            )
+        ]
+)
+internal data class LocalChange(
+        @PrimaryKey(autoGenerate = true)
+        val id: Long = 0,
+        val resourceType: ResourceType,
+        val resourceId: String,
+        val timestamp: String = "",
+        val type: Type,
+        val diff: String
+) {
+    enum class Type(val value: Int) {
+        INSERT(1), // create a new resource. payload is the entire resource json.
+        UPDATE(2), // patch. payload is the json patch.
+        DELETE(3); // delete. payload is empty string.
+
+        companion object {
+            fun from(input: Int): Type = values().first { it.value == input }
+        }
+    }
+}

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
@@ -19,7 +19,6 @@ package com.google.fhirengine.db.impl.entities
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
-import org.hl7.fhir.r4.model.ResourceType
 
 /**
  * When a local change to a resource happens, the lastUpdated timestamp in
@@ -65,7 +64,7 @@ import org.hl7.fhir.r4.model.ResourceType
 internal data class LocalChange(
   @PrimaryKey(autoGenerate = true)
   val id: Long = 0,
-  val resourceType: ResourceType,
+  val resourceType: String,
   val resourceId: String,
   val timestamp: String = "",
   val type: Type,

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/LocalChange.kt
@@ -44,13 +44,13 @@ import org.hl7.fhir.r4.model.ResourceType
         ]
 )
 internal data class LocalChange(
-        @PrimaryKey(autoGenerate = true)
-        val id: Long = 0,
-        val resourceType: ResourceType,
-        val resourceId: String,
-        val timestamp: String = "",
-        val type: Type,
-        val diff: String
+  @PrimaryKey(autoGenerate = true)
+  val id: Long = 0,
+  val resourceType: ResourceType,
+  val resourceId: String,
+  val timestamp: String = "",
+  val type: Type,
+  val diff: String
 ) {
     enum class Type(val value: Int) {
         INSERT(1), // create a new resource. payload is the entire resource json.

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/ResourceDatabase.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/ResourceDatabase.kt
@@ -19,9 +19,11 @@ package com.google.fhirengine.db.impl
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.google.fhirengine.db.impl.dao.LocalChangeDao
 import com.google.fhirengine.db.impl.dao.ResourceDao
 import com.google.fhirengine.db.impl.dao.SyncedResourceDao
 import com.google.fhirengine.db.impl.entities.DateIndexEntity
+import com.google.fhirengine.db.impl.entities.LocalChange
 import com.google.fhirengine.db.impl.entities.NumberIndexEntity
 import com.google.fhirengine.db.impl.entities.QuantityIndexEntity
 import com.google.fhirengine.db.impl.entities.ReferenceIndexEntity
@@ -41,7 +43,8 @@ import com.google.fhirengine.db.impl.entities.UriIndexEntity
             UriIndexEntity::class,
             DateIndexEntity::class,
             NumberIndexEntity::class,
-            SyncedResourceEntity::class
+            SyncedResourceEntity::class,
+            LocalChange::class
         ],
         version = 1,
         exportSchema = false
@@ -52,4 +55,5 @@ import com.google.fhirengine.db.impl.entities.UriIndexEntity
 internal abstract class ResourceDatabase : RoomDatabase() {
     abstract fun resourceDao(): ResourceDao
     abstract fun syncedResourceDao(): SyncedResourceDao
+    abstract fun localChangeDao(): LocalChangeDao
 }

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/dao/LocalChangeDao.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/dao/LocalChangeDao.kt
@@ -1,0 +1,186 @@
+package com.google.fhirengine.db.impl.dao
+
+import android.util.Log
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import ca.uhn.fhir.parser.IParser
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.fge.jsonpatch.JsonPatch
+import com.github.fge.jsonpatch.diff.JsonDiff
+import com.google.fhirengine.db.impl.entities.LocalChange
+import com.google.fhirengine.db.impl.entities.LocalChange.Type
+import com.google.fhirengine.toTimeZoneString
+import org.hl7.fhir.r4.model.Resource
+import java.util.Date
+
+
+@Dao
+internal abstract class LocalChangeDao {
+
+    lateinit var iParser: IParser
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    abstract fun addLocalChange(localChange: LocalChange)
+
+    private fun addLocalInsert(resource: Resource) {
+        val resourceId = resource.id
+        val resourceType = resource.resourceType
+        val localChanges = getLocalChanges(
+                resourceId = resourceId,
+                resourceType = resourceType.name)
+        val timestamp = Date().toTimeZoneString()
+        val resourceString = iParser.encodeResourceToString(resource)
+
+        if (localChanges.isEmpty()
+                || localChanges.last().type == Type.DELETE) {
+            // Insert this change in the local changes table
+            addLocalChange(LocalChange(
+                    id = 0,
+                    resourceType = resourceType,
+                    resourceId = resourceId,
+                    timestamp = timestamp,
+                    type = LocalChange.Type.INSERT,
+                    diff = resourceString
+            ))
+        } else {
+            // Can't add an INSERT on top of an INSERT or UPDATE
+            throw InvalidLocalChangeException("Can not INSERT on top of $localChanges.last().type")
+        }
+    }
+
+    private fun addLocalUpdate(resource: Resource) {
+        val resourceId = resource.id
+        val resourceType = resource.resourceType
+        val localChanges = getLocalChanges(
+                resourceId = resourceId,
+                resourceType = resourceType.name)
+        val timestamp = Date().toTimeZoneString()
+
+        if (localChanges.isEmpty()
+                || localChanges.last().type in arrayOf(Type.UPDATE, Type.INSERT)) {
+            // squash all changes to get the resource to diff against
+            val squashedLocalChanges = squash(localChanges)
+
+            if (squashedLocalChanges.type.equals(Type.DELETE))
+                throw InvalidLocalChangeException("Unexpected DELETE when squashing $resourceType.name/$resourceId. UPDATE failed")
+
+            val squashedResource = iParser.parseResource(squashedLocalChanges.diff) as Resource
+
+            // insert the diff as an update
+            addLocalChange(LocalChange(
+                    id = 0,
+                    resourceType = resourceType,
+                    resourceId = resourceId,
+                    timestamp = timestamp,
+                    type = Type.UPDATE,
+                    diff = diff(squashedResource, resource)
+            ))
+
+        } else {
+            throw InvalidLocalChangeException("Can not UPDATE on top of $localChanges.type")
+        }
+    }
+
+    private fun deleteLocalChange(resource: Resource) {
+        val resourceId = resource.id
+        val localChanges = getLocalChanges(
+                resourceId = resourceId,
+                resourceType = resource.resourceType.name)
+
+        if (localChanges.isEmpty())
+            throw InvalidLocalChangeException("Can not DELETE non-existent resource $resource.resourceType.name/$resourceId")
+
+        val timestamp = Date().toTimeZoneString()
+        val resourceType = resource.resourceType
+        val topChange = localChanges.last()
+
+        if (topChange.type in arrayOf(Type.UPDATE, Type.INSERT)) {
+            addLocalChange(LocalChange(
+                    id = 0,
+                    resourceType = resourceType,
+                    resourceId = resourceId,
+                    timestamp = timestamp,
+                    type = Type.DELETE,
+                    diff = ""
+            ))
+        } else {
+            throw InvalidLocalChangeException("Can not DELETE on top of $topChange.type")
+        }
+    }
+
+    fun squash(localChanges: List<LocalChange>, forSync: Boolean = false): LocalChange {
+        val last = localChanges.last()
+
+        // Special case to handle remote-created resource which was
+        // updated locally
+        if (localChanges.size == 1 && last.type == Type.UPDATE) {
+            // TODO retrieve resource from ResourceEntity and
+            //  return as INSERT for local changes
+        }
+
+        return when (last.type) {
+            Type.DELETE -> LocalChange(
+                    resourceId = last.resourceId,
+                    resourceType = last.resourceType,
+                    type = Type.DELETE,
+                    diff = ""
+            )
+            Type.INSERT -> LocalChange(
+                    resourceId = last.resourceId,
+                    resourceType = last.resourceType,
+                    type = Type.INSERT,
+                    diff = last.diff
+            )
+            Type.UPDATE -> {
+                // assertion $first.type == INSERT
+                val first = squash(localChanges.dropLast(1))
+                LocalChange(
+                        resourceId = last.resourceId,
+                        resourceType = last.resourceType,
+                        type = Type.INSERT,
+                        diff = applyPatch(first.diff, last.diff)
+                )
+            }
+        }
+    }
+
+    private fun applyPatch(resourceString: String, patchString: String): String {
+        val objectMapper = ObjectMapper()
+        val resourceJson = objectMapper.readValue(resourceString, JsonNode::class.java)
+        val patchJson = objectMapper.readValue(patchString, JsonPatch::class.java)
+        return patchJson.apply(resourceJson).toString()
+    }
+
+    private fun diff(source: Resource, target: Resource): String {
+        val objectMapper = ObjectMapper()
+        val sourceJson = objectMapper.readValue(
+                iParser.encodeResourceToString(source),
+                JsonNode::class.java)
+        val targetJson = objectMapper.readValue(
+                iParser.encodeResourceToString(target),
+                JsonNode::class.java)
+        val jsonDiff = JsonDiff.asJson(sourceJson, targetJson);
+        if (jsonDiff.size() == 0) Log.w("ResourceDao", "Trying to UPDATE resource ${target.resourceType}/${target.id} with no changes")
+        return jsonDiff.toString()
+    }
+
+    @Query("""
+        SELECT *
+        FROM LocalChange
+        WHERE LocalChange.resourceId = (:resourceId)
+        AND LocalChange.resourceType  = (:resourceType)
+        ORDER BY LocalChange.timestamp ASC""")
+    abstract fun getLocalChanges(resourceId: String, resourceType: String): List<LocalChange>
+
+    @Query("""
+        DELETE FROM LocalChange
+        WHERE LocalChange.resourceId = (:resourceId)
+        AND LocalChange.resourceType  = (:resourceType)
+    """)
+    abstract fun discardLocalChanges(resourceId: String, resourceType: String)
+
+    class InvalidLocalChangeException(message: String?) : Exception(message)
+}

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/dao/ResourceDao.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/dao/ResourceDao.kt
@@ -46,8 +46,7 @@ internal abstract class ResourceDao {
 
     @Transaction
     open fun update(resource: Resource) {
-        deleteResource(resource.id, resource.resourceType)
-        insert(resource)
+        // TODO : update timestamp
     }
 
     @Transaction

--- a/fhirengine/src/main/java/com/google/fhirengine/db/impl/dao/ResourceDao.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/db/impl/dao/ResourceDao.kt
@@ -61,7 +61,7 @@ internal abstract class ResourceDao {
         }
     }
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     abstract fun insertResource(resource: ResourceEntity)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/fhirengine/src/main/java/com/google/fhirengine/impl/FhirEngineImpl.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/impl/FhirEngineImpl.kt
@@ -74,8 +74,13 @@ class FhirEngineImpl constructor(
         database.insertAll(resources)
     }
 
+    @Throws(ResourceNotFoundException::class)
     override fun <R : Resource> update(resource: R) {
-        database.update(resource)
+        try {
+            database.update(resource)
+        } catch (e: ResourceNotFoundInDbException) {
+            throw ResourceNotFoundException(resource.resourceType.name, resource.id, e)
+        }
     }
 
     @Throws(ResourceNotFoundException::class)

--- a/fhirengine/src/main/java/com/google/fhirengine/impl/FhirEngineImpl.kt
+++ b/fhirengine/src/main/java/com/google/fhirengine/impl/FhirEngineImpl.kt
@@ -92,8 +92,8 @@ class FhirEngineImpl constructor(
         }
     }
 
-    override fun <R : Resource> remove(clazz: Class<R>, id: String): R {
-        throw UnsupportedOperationException("Not implemented yet!")
+    override fun <R : Resource> remove(clazz: Class<R>, id: String) {
+        database.delete(clazz, id)
     }
 
     override fun evaluateCql(


### PR DESCRIPTION
* Added Dao for writing local changes to db
* Support FHIR resource insertion, updation and deletion locally
* Code for diffing and merging resources
* Merge/update done by applying RFC 6902 JSON patch to Resource JSON

This is the first of 3 PRs (planned). Other 2 PRs will add 1. Interfaces for `LocalChangeDao` and additional wiring (e.g. update Resource (i.e. `ResourceEntity` rows) timestamps when local changes occur and 2. Tests for revision management.

Feature PR to `master` will be created when all 3 PRs are resolved.