### PR TITLE
Bump emulator runner action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       if: matrix.api-level == 29 # don't run full build on older APIs
       run: ./gradlew build
     - name: Run Integration Tests
-      uses: ReactiveCircus/android-emulator-runner@v2.11.0
+      uses: ReactiveCircus/android-emulator-runner@v2.13.0
       with:
         api-level: ${{ matrix.api-level }}
         arch: x86_64


### PR DESCRIPTION
This fixes issues with Github actions. See this [github blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) for details.

This could fix #73.