### PR TITLE
Upgrade to Kotlin Version 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlinVersion = '1.3.72'
+    ext.kotlinVersion = '1.4.20'
     ext.spotlessVersion = '3.27.1'
 
     repositories {

--- a/fhirengine/src/test/java/com/google/fhirengine/index/impl/FhirIndexerImplTest.java
+++ b/fhirengine/src/test/java/com/google/fhirengine/index/impl/FhirIndexerImplTest.java
@@ -230,8 +230,8 @@ public class FhirIndexerImplTest {
   }
 
   @Test
-  public void index_null_shouldThrowIllegalArgumentException() throws Exception {
-    Assert.assertThrows(IllegalArgumentException.class, () -> fhirIndexer.index(null));
+  public void index_null_shouldThrowNullPointerException() throws Exception {
+    Assert.assertThrows(NullPointerException.class, () -> fhirIndexer.index(null));
   }
 
   @Test


### PR DESCRIPTION
With move to Kotlin 1.4, Kotlin itself is able to convert the default observe() to lambada syntax.