### PR TITLE
API 29 CI OOM fix

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -16,5 +16,5 @@
 
  org.gradle.daemon=false
  org.gradle.parallel=true
- org.gradle.jvmargs=-Xmx5120m
+ org.gradle.jvmargs=-Xmx3072m
  org.gradle.workers.max=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       with:
         api-level: ${{ matrix.api-level }}
         arch: x86_64
-        script: ./gradlew connectedCheck --stacktrace
+        script: ./gradlew connectedCheck
       
     - name: Upload build reports
       if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -55,10 +55,10 @@ ext {
     workManagerVersion = '2.3.4'
 
     // testing
-    junitVersion = '4.13'
+    junitVersion = '4.13.1'
     roboelectricVersion = '4.3.1'
-    testVersion = '1.2.0'
+    testVersion = '1.3.0'
     truthVersion = '1.0.1'
-    androidTestJunitVersion = '1.1.1'
+    androidTestJunitVersion = '1.1.2'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,10 +55,10 @@ ext {
     workManagerVersion = '2.3.4'
 
     // testing
-    junitVersion = '4.13.1'
+    junitVersion = '4.13'
     roboelectricVersion = '4.3.1'
-    testVersion = '1.3.0'
+    testVersion = '1.2.0'
     truthVersion = '1.0.1'
-    androidTestJunitVersion = '1.1.2'
+    androidTestJunitVersion = '1.1.1'
 
 }

--- a/fhirengine/build.gradle
+++ b/fhirengine/build.gradle
@@ -15,8 +15,12 @@ android {
 
         // Required when setting minSdkVersion to 20 or lower
         multiDexEnabled true
-        // need to specify this to prevent junit runner from going deep into our dependencies
-        testInstrumentationRunnerArguments = ['package': 'com.google.fhirengine']
+        // Need to specify 'package' to prevent junit runner from going deep into our dependencies.
+        // 'clearPackageData' makes the Android Test Orchestrator run its
+        // "pm clear" command after each test invocation. This command ensures
+        // that the app's state is completely cleared between tests.
+        testInstrumentationRunnerArguments = ['package'         : 'com.google.fhirengine',
+                                              'clearPackageData': 'true']
     }
     sourceSets {
         // shared code between junit and instrumentation tests
@@ -41,6 +45,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 }
 
@@ -83,6 +90,8 @@ dependencies {
     androidTestImplementation "androidx.test:core:$testVersion"
     androidTestImplementation "junit:junit:$junitVersion"
     androidTestImplementation "com.google.truth:truth:$truthVersion"
+
+    androidTestUtil "androidx.test:orchestrator:$testVersion"
 }
 
 repositories {

--- a/fhirengine/build.gradle
+++ b/fhirengine/build.gradle
@@ -59,6 +59,10 @@ configurations {
     }
 }
 
+tasks.withType(Test) {
+    maxHeapSize = '256m'
+}
+
 dependencies {
     api ("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:$hapiFhirStructuresR4Version") {
         exclude module:'junit'

--- a/fhirengine/build.gradle
+++ b/fhirengine/build.gradle
@@ -15,12 +15,8 @@ android {
 
         // Required when setting minSdkVersion to 20 or lower
         multiDexEnabled true
-        // Need to specify 'package' to prevent junit runner from going deep into our dependencies.
-        // 'clearPackageData' makes the Android Test Orchestrator run its
-        // "pm clear" command after each test invocation. This command ensures
-        // that the app's state is completely cleared between tests.
-        testInstrumentationRunnerArguments = ['package'         : 'com.google.fhirengine',
-                                              'clearPackageData': 'true']
+        // need to specify this to prevent junit runner from going deep into our dependencies
+        testInstrumentationRunnerArguments = ['package': 'com.google.fhirengine']
     }
     sourceSets {
         // shared code between junit and instrumentation tests
@@ -45,9 +41,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-    testOptions {
-        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 }
 
@@ -90,8 +83,6 @@ dependencies {
     androidTestImplementation "androidx.test:core:$testVersion"
     androidTestImplementation "junit:junit:$junitVersion"
     androidTestImplementation "com.google.truth:truth:$truthVersion"
-
-    androidTestUtil "androidx.test:orchestrator:$testVersion"
 }
 
 repositories {


### PR DESCRIPTION
Attempting to fix `./gradlew connectedCheck` OOM errors in Github Actions by reducing gradle and gradle test JVM max heap. This should make more RAM available for emulator.

Gradle JVM heap reduced from 5 GB to 3 GB.
Gradle test JVM heap reduced from default to 256 MB.