### PR TITLE
Simplify the view holder factory interface

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapter.kt
@@ -27,7 +27,7 @@ import com.google.android.fhir.datacapture.views.QuestionnaireItemViewItem
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
 
-class QuestionnaireItemAdapter(
+internal class QuestionnaireItemAdapter(
   private val questionnaireItemViewItemList: List<QuestionnaireItemViewItem>
 ) : RecyclerView.Adapter<QuestionnaireItemViewHolder>() {
     /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
@@ -16,40 +16,34 @@
 
 package com.google.android.fhir.datacapture.views
 
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.CheckBox
 import com.google.android.fhir.datacapture.R
 import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
-object QuestionnaireItemCheckBoxViewHolderFactory : QuestionnaireItemViewHolderFactory {
-    override fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.questionnaire_item_check_box_view, parent, false)
-        return QuestionnaireItemCheckBoxViewHolder(view)
-    }
-}
+object QuestionnaireItemCheckBoxViewHolderFactory : QuestionnaireItemViewHolderFactory(
+  R.layout.questionnaire_item_check_box_view
+) {
+  override fun getQuestionnaireItemViewHolderDelegate() =
+    object : QuestionnaireItemViewHolderDelegate {
+      private lateinit var checkBox: CheckBox
+      private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
-private class QuestionnaireItemCheckBoxViewHolder(
-  itemView: View
-) : QuestionnaireItemViewHolder(itemView) {
-    private val checkBox = itemView.findViewById<CheckBox>(R.id.check_box)
-    init {
+      override fun init(itemView: View) {
+        checkBox = itemView.findViewById<CheckBox>(R.id.check_box)
         checkBox.setOnClickListener {
-            questionnaireItemViewItem.questionnaireResponseItemComponent.answer = listOf(
-                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    value = BooleanType(checkBox.isChecked)
-                }
-            )
+          questionnaireItemViewItem.questionnaireResponseItemComponent.answer = listOf(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+              value = BooleanType(checkBox.isChecked)
+            }
+          )
         }
-    }
+      }
 
-    private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
-
-    override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+      override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         checkBox.text = questionnaireItemViewItem.questionnaireItemComponent.text
+      }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
@@ -31,7 +31,7 @@ object QuestionnaireItemCheckBoxViewHolderFactory : QuestionnaireItemViewHolderF
       private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        checkBox = itemView.findViewById<CheckBox>(R.id.check_box)
+        checkBox = itemView.findViewById(R.id.check_box)
         checkBox.setOnClickListener {
           questionnaireItemViewItem.questionnaireResponseItemComponent.answer = listOf(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -18,72 +18,63 @@ package com.google.android.fhir.datacapture.views
 
 import android.os.Build
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentResultListener
 import com.google.android.fhir.datacapture.R
 import java.util.Calendar
 import org.hl7.fhir.r4.model.DateType
-import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
 
-object QuestionnaireItemDatePickerViewHolderFactory : QuestionnaireItemViewHolderFactory {
-    override fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.questionnaire_item_date_picker_view, parent, false)
-        return QuestionnaireItemDatePickerViewHolder(view)
-    }
-}
+object QuestionnaireItemDatePickerViewHolderFactory : QuestionnaireItemViewHolderFactory(
+  R.layout.questionnaire_item_date_picker_view
+) {
+  override fun getQuestionnaireItemViewHolderDelegate() =
+    object : QuestionnaireItemViewHolderDelegate {
+      private lateinit var textView: TextView
+      private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
-private class QuestionnaireItemDatePickerViewHolder(
-  itemView: View
-) : QuestionnaireItemViewHolder(itemView) {
-    private val textView = itemView.findViewById<TextView>(R.id.text)
-    private val input = itemView.findViewById<TextView>(R.id.input)
-    private val button = itemView.findViewById<TextView>(R.id.button)
-    init {
+      override fun init(itemView: View) {
+        textView = itemView.findViewById<TextView>(R.id.text)
+        val input = itemView.findViewById<TextView>(R.id.input)
+        val button = itemView.findViewById<TextView>(R.id.button)
         button.setOnClickListener {
-            // TODO: find a more robust way to do this.
-            val context = itemView.context as AppCompatActivity
-            DatePickerFragment().show(context.supportFragmentManager, DatePickerFragment.TAG)
-            context.supportFragmentManager.setFragmentResultListener(
-                DatePickerFragment.RESULT_REQUEST_KEY,
-                context,
-                object : FragmentResultListener {
-                    override fun onFragmentResult(requestKey: String, result: Bundle) {
-                        val year = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_YEAR)
-                        val month = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_MONTH)
-                        val dayOfMonth =
-                            result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
-                        val date = Calendar.getInstance().apply {
-                            set(year, month, dayOfMonth)
-                        }.time
+          // TODO: find a more robust way to do this.
+          val context = itemView.context as AppCompatActivity
+          DatePickerFragment().show(context.supportFragmentManager, DatePickerFragment.TAG)
+          context.supportFragmentManager.setFragmentResultListener(
+            DatePickerFragment.RESULT_REQUEST_KEY,
+            context,
+            object : FragmentResultListener {
+              override fun onFragmentResult(requestKey: String, result: Bundle) {
+                val year = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_YEAR)
+                val month = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_MONTH)
+                val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
+                val date = Calendar.getInstance().apply { set(year, month, dayOfMonth) }.time
 
-                        // Prefer the ICU library on Android N or above.
-                        input.text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                            android.icu.text.DateFormat.getDateInstance().format(date)
-                        } else {
-                            java.text.DateFormat.getDateInstance().format(date)
-                        }
-                        questionnaireItemViewItem.questionnaireResponseItemComponent.answer =
-                            listOf(
-                                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
-                                    .apply {
-                                        value = DateType(year, month, dayOfMonth)
-                                    }
-                            )
-                    }
+                // Prefer the ICU library on Android N or above.
+                input.text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                  android.icu.text.DateFormat.getDateInstance().format(date)
+                } else {
+                  java.text.DateFormat.getDateInstance().format(date)
                 }
-            )
+                questionnaireItemViewItem.questionnaireResponseItemComponent.answer =
+                  listOf(
+                    QuestionnaireResponseItemAnswerComponent()
+                      .apply {
+                        value = DateType(year, month, dayOfMonth)
+                      }
+                  )
+              }
+            }
+          )
         }
-    }
+      }
 
-    private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
-
-    override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+      override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         textView.text = questionnaireItemViewItem.questionnaireItemComponent.text
+      }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -36,7 +36,7 @@ object QuestionnaireItemDatePickerViewHolderFactory : QuestionnaireItemViewHolde
       private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        textView = itemView.findViewById<TextView>(R.id.text)
+        textView = itemView.findViewById(R.id.text)
         val input = itemView.findViewById<TextView>(R.id.input)
         val button = itemView.findViewById<TextView>(R.id.button)
         button.setOnClickListener {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -34,7 +34,7 @@ object QuestionnaireItemEditTextViewHolderFactory : QuestionnaireItemViewHolderF
       private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        textView = itemView.findViewById<TextView>(R.id.text)
+        textView = itemView.findViewById(R.id.text)
         itemView.findViewById<EditText>(R.id.input)
           .doAfterTextChanged { editable: Editable? ->
             questionnaireItemViewItem.questionnaireResponseItemComponent.answer =

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -17,9 +17,7 @@
 package com.google.android.fhir.datacapture.views
 
 import android.text.Editable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.TextView
 import androidx.core.widget.doAfterTextChanged
@@ -27,33 +25,31 @@ import com.google.android.fhir.datacapture.R
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 
-object QuestionnaireItemEditTextViewHolderFactory : QuestionnaireItemViewHolderFactory {
-    override fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.questionnaire_item_edit_text_view, parent, false)
-        return QuestionnaireItemEditTextViewHolder(view)
-    }
-}
+object QuestionnaireItemEditTextViewHolderFactory : QuestionnaireItemViewHolderFactory(
+  R.layout.questionnaire_item_edit_text_view
+) {
+  override fun getQuestionnaireItemViewHolderDelegate() =
+    object : QuestionnaireItemViewHolderDelegate {
+      private lateinit var textView: TextView
+      private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
-class QuestionnaireItemEditTextViewHolder(
-  itemView: View
-) : QuestionnaireItemViewHolder(itemView) {
-    private val textView = itemView.findViewById<TextView>(R.id.text)
-    private val editText = itemView.findViewById<EditText>(R.id.input)
-    init {
-        editText.doAfterTextChanged { editable: Editable? ->
-            questionnaireItemViewItem.questionnaireResponseItemComponent.answer = listOf(
-                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+      override fun init(itemView: View) {
+        textView = itemView.findViewById<TextView>(R.id.text)
+        itemView.findViewById<EditText>(R.id.input)
+          .doAfterTextChanged { editable: Editable? ->
+            questionnaireItemViewItem.questionnaireResponseItemComponent.answer =
+              listOf(
+                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+                  .apply {
                     value = StringType(editable.toString())
-                }
-            )
-        }
-    }
+                  }
+              )
+          }
+      }
 
-    private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
-
-    override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+      override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         textView.text = questionnaireItemViewItem.questionnaireItemComponent.text
+      }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
@@ -28,7 +28,7 @@ object QuestionnaireItemGroupViewHolderFactory : QuestionnaireItemViewHolderFact
       private lateinit var groupHeader: TextView
 
       override fun init(itemView: View) {
-        groupHeader = itemView.findViewById<TextView>(R.id.group_header)
+        groupHeader = itemView.findViewById(R.id.group_header)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
@@ -16,26 +16,23 @@
 
 package com.google.android.fhir.datacapture.views
 
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import com.google.android.fhir.datacapture.R
 
-object QuestionnaireItemGroupViewHolderFactory : QuestionnaireItemViewHolderFactory {
-    override fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.questionnaire_item_group_header_view, parent, false)
-        return QuestionnaireItemGroupViewHolder(view)
-    }
-}
+object QuestionnaireItemGroupViewHolderFactory : QuestionnaireItemViewHolderFactory(
+  R.layout.questionnaire_item_group_header_view
+) {
+  override fun getQuestionnaireItemViewHolderDelegate() =
+    object : QuestionnaireItemViewHolderDelegate {
+      private lateinit var groupHeader: TextView
 
-private class QuestionnaireItemGroupViewHolder(
-  itemView: View
-) : QuestionnaireItemViewHolder(itemView) {
-    private val groupHeader = itemView.findViewById<TextView>(R.id.group_header)
+      override fun init(itemView: View) {
+        groupHeader = itemView.findViewById<TextView>(R.id.group_header)
+      }
 
-    override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+      override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         groupHeader.text = questionnaireItemViewItem.questionnaireItemComponent.text
+      }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
@@ -16,15 +16,68 @@
 
 package com.google.android.fhir.datacapture.views
 
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.RecyclerView
 
-interface QuestionnaireItemViewHolderFactory {
-    fun create(parent: ViewGroup): QuestionnaireItemViewHolder
+/**
+ * Factory for [QuestionnaireItemViewHolder].
+ *
+ * @param resId the layout resource for the view
+ */
+abstract class QuestionnaireItemViewHolderFactory(@LayoutRes val resId: Int) {
+  fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
+    return QuestionnaireItemViewHolder(
+      LayoutInflater.from(parent.context).inflate(resId, parent, false),
+      getQuestionnaireItemViewHolderDelegate()
+    )
+  }
+
+  /**
+   * Returns a [QuestionnaireItemViewHolderDelegate] that handles the initialization of views and
+   * binding of items in [RecyclerView].
+   */
+  abstract fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate
 }
 
-/** The [RecyclerView.ViewHolder] for [QuestionnaireItemViewItem]. */
-abstract class QuestionnaireItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    abstract fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem)
+/**
+ * The [RecyclerView.ViewHolder] for [QuestionnaireItemViewItem].
+ *
+ * This is used by [QuestionnaireItemAdapter] to initialize views and bind items in [RecyclerView].
+ */
+class QuestionnaireItemViewHolder(
+  itemView: View,
+  val delegate: QuestionnaireItemViewHolderDelegate
+) : RecyclerView.ViewHolder(itemView) {
+  init {
+    delegate.init(itemView)
+  }
+
+  fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+    delegate.bind(questionnaireItemViewItem)
+  }
+}
+
+/**
+ * Delegate for [QuestionnaireItemViewHolder].
+ *
+ * This interface provides an abstraction of the operations that need to be implemented for a type
+ * of view in the questionnaire.
+ *
+ * There is a 1:1 relationship between this and
+ * [QuestionnaireItemViewHolder]. In other words, there is a unique
+ * [QuestionnaireItemViewHolderDelegate] for each [QuestionnaireItemViewHolder]. This is critical
+ * for the correctness of the recycler view.
+ */
+interface QuestionnaireItemViewHolderDelegate {
+  /**
+   * Initializes the view in [QuestionnaireItemViewHolder]. Any listeners to record user input
+   * should be set in this function.
+   */
+  fun init(itemView: View)
+
+  /** Binds a [QuestionnaireItemViewItem] to the view. */
+  fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem)
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
@@ -28,7 +28,7 @@ import androidx.recyclerview.widget.RecyclerView
  * @param resId the layout resource for the view
  */
 abstract class QuestionnaireItemViewHolderFactory(@LayoutRes val resId: Int) {
-  fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
+  internal fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
     return QuestionnaireItemViewHolder(
       LayoutInflater.from(parent.context).inflate(resId, parent, false),
       getQuestionnaireItemViewHolderDelegate()
@@ -47,9 +47,9 @@ abstract class QuestionnaireItemViewHolderFactory(@LayoutRes val resId: Int) {
  *
  * This is used by [QuestionnaireItemAdapter] to initialize views and bind items in [RecyclerView].
  */
-class QuestionnaireItemViewHolder(
+internal class QuestionnaireItemViewHolder(
   itemView: View,
-  val delegate: QuestionnaireItemViewHolderDelegate
+  private val delegate: QuestionnaireItemViewHolderDelegate
 ) : RecyclerView.ViewHolder(itemView) {
   init {
     delegate.init(itemView)


### PR DESCRIPTION
This makes it easier for users to implement a new view type: 

1. the user does not need to handle the creation of QuestionnaireItemViewHolder (i.e. they won't be able to make a mistake passing the wrong view)
2. the user does not need to handle the inflation of the layout; it is handled by the factory itself now

Also mark QuestionnaireItemViewHolder, QuestionnaireItemViewHolderFactory#create, QuestionnaireItemAdapter as internal.