### PR TITLE
Update the UI using the answers in the view model

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
@@ -33,24 +33,18 @@ object QuestionnaireItemCheckBoxViewHolderFactory : QuestionnaireItemViewHolderF
       override fun init(itemView: View) {
         checkBox = itemView.findViewById(R.id.check_box)
         checkBox.setOnClickListener {
-          questionnaireItemViewItem.questionnaireResponseItemComponent.answer = listOf(
+          questionnaireItemViewItem.singleAnswerOrNull =
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
               value = BooleanType(checkBox.isChecked)
             }
-          )
         }
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         checkBox.text = questionnaireItemViewItem.questionnaireItemComponent.text
-        questionnaireItemViewItem.questionnaireResponseItemComponent.answer.also {
-          if (it.size == 1 && it[0].hasValueBooleanType()) {
-            checkBox.isChecked = it[0].valueBooleanType.value
-          } else {
-            checkBox.isChecked = false
-          }
-        }
+        checkBox.isChecked =
+          questionnaireItemViewItem.singleAnswerOrNull?.valueBooleanType?.booleanValue() ?: false
       }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactory.kt
@@ -44,6 +44,13 @@ object QuestionnaireItemCheckBoxViewHolderFactory : QuestionnaireItemViewHolderF
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         checkBox.text = questionnaireItemViewItem.questionnaireItemComponent.text
+        questionnaireItemViewItem.questionnaireResponseItemComponent.answer.also {
+          if (it.size == 1 && it[0].hasValueBooleanType()) {
+            checkBox.isChecked = it[0].valueBooleanType.value
+          } else {
+            checkBox.isChecked = false
+          }
+        }
       }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -23,10 +23,10 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentResultListener
 import com.google.android.fhir.datacapture.R
-import org.hl7.fhir.r4.model.DateType
-import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import org.hl7.fhir.r4.model.DateType
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
 
 object QuestionnaireItemDatePickerViewHolderFactory : QuestionnaireItemViewHolderFactory(
   R.layout.questionnaire_item_date_picker_view

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -63,13 +63,12 @@ object QuestionnaireItemDatePickerViewHolderFactory : QuestionnaireItemViewHolde
                   dayOfMonth
                 ).format(LOCAL_DATE_FORMATTER)
 
-                questionnaireItemViewItem.questionnaireResponseItemComponent.answer =
-                  listOf(
-                    QuestionnaireResponseItemAnswerComponent()
-                      .apply {
-                        value = DateType(year, month, dayOfMonth)
-                      }
-                  )
+                questionnaireItemViewItem.singleAnswerOrNull =
+                  QuestionnaireResponseItemAnswerComponent()
+                    .apply {
+                      value = DateType(year, month, dayOfMonth)
+                    }
+
               }
             }
           )
@@ -80,20 +79,14 @@ object QuestionnaireItemDatePickerViewHolderFactory : QuestionnaireItemViewHolde
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         textView.text = questionnaireItemViewItem.questionnaireItemComponent.text
-        questionnaireItemViewItem.questionnaireResponseItemComponent.answer.also {
-          if (it.size == 1 && it[0].hasValueDateType()) {
-            input.text = it[0].valueDateType.let { date ->
-              LocalDate.of(
-                date.year,
-                // month values are 1-12 in java.time but 0-11 in DateType (FHIR)
-                date.month + 1,
-                date.day
-              )
-            }.format(LOCAL_DATE_FORMATTER)
-          } else {
-            input.text = ""
-          }
-        }
+        input.text = questionnaireItemViewItem.singleAnswerOrNull?.valueDateType?.let {
+          LocalDate.of(
+            it.year,
+            // month values are 1-12 in java.time but 0-11 in DateType (FHIR)
+            it.month + 1,
+            it.day
+          )
+        }?.format(LOCAL_DATE_FORMATTER) ?: ""
       }
     }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -68,7 +68,6 @@ object QuestionnaireItemDatePickerViewHolderFactory : QuestionnaireItemViewHolde
                     .apply {
                       value = DateType(year, month, dayOfMonth)
                     }
-
               }
             }
           )

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -39,26 +39,21 @@ object QuestionnaireItemEditTextViewHolderFactory : QuestionnaireItemViewHolderF
         editText = itemView.findViewById(R.id.input)
         itemView.findViewById<EditText>(R.id.input)
           .doAfterTextChanged { editable: Editable? ->
-            questionnaireItemViewItem.questionnaireResponseItemComponent.answer =
-              listOf(
-                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
-                  .apply {
-                    value = StringType(editable.toString())
-                  }
-              )
+            questionnaireItemViewItem.singleAnswerOrNull =
+              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+                .apply {
+                  value = StringType(editable.toString())
+                }
+
           }
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         textView.text = questionnaireItemViewItem.questionnaireItemComponent.text
-        questionnaireItemViewItem.questionnaireResponseItemComponent.answer.also {
-          if (it.size == 1 && it[0].hasValueStringType()) {
-            editText.setText(it[0].valueStringType.value)
-          } else {
-            editText.setText("")
-          }
-        }
+        editText.setText(
+          questionnaireItemViewItem.singleAnswerOrNull?.valueStringType?.value ?: ""
+        )
       }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -31,10 +31,12 @@ object QuestionnaireItemEditTextViewHolderFactory : QuestionnaireItemViewHolderF
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
       private lateinit var textView: TextView
+      private lateinit var editText: EditText
       private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
         textView = itemView.findViewById(R.id.text)
+        editText = itemView.findViewById(R.id.input)
         itemView.findViewById<EditText>(R.id.input)
           .doAfterTextChanged { editable: Editable? ->
             questionnaireItemViewItem.questionnaireResponseItemComponent.answer =
@@ -50,6 +52,13 @@ object QuestionnaireItemEditTextViewHolderFactory : QuestionnaireItemViewHolderF
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         textView.text = questionnaireItemViewItem.questionnaireItemComponent.text
+        questionnaireItemViewItem.questionnaireResponseItemComponent.answer.also {
+          if (it.size == 1 && it[0].hasValueStringType()) {
+            editText.setText(it[0].valueStringType.value)
+          } else {
+            editText.setText("")
+          }
+        }
       }
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -44,7 +44,6 @@ object QuestionnaireItemEditTextViewHolderFactory : QuestionnaireItemViewHolderF
                 .apply {
                   value = StringType(editable.toString())
                 }
-
           }
       }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
@@ -18,6 +18,7 @@ package com.google.android.fhir.datacapture.views
 
 import androidx.recyclerview.widget.RecyclerView
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
+import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
 
 /**
@@ -27,4 +28,10 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComp
 data class QuestionnaireItemViewItem(
   val questionnaireItemComponent: QuestionnaireItemComponent,
   val questionnaireResponseItemComponent: QuestionnaireResponseItemComponent
-)
+) {
+  var singleAnswerOrNull
+    get() = questionnaireResponseItemComponent.answer.singleOrNull()
+    set(value) {
+      questionnaireResponseItemComponent.answer = listOf(value)
+    }
+}

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
@@ -28,6 +28,10 @@ data class QuestionnaireItemViewItem(
   val questionnaireItemComponent: QuestionnaireItemComponent,
   val questionnaireResponseItemComponent: QuestionnaireResponseItemComponent
 ) {
+  /**
+   * The single answer to the [QuestionnaireItemComponent], or `null` if there is none or more than
+   * one answer.
+   */
   var singleAnswerOrNull
     get() = questionnaireResponseItemComponent.answer.singleOrNull()
     set(value) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
@@ -18,7 +18,6 @@ package com.google.android.fhir.datacapture.views
 
 import androidx.recyclerview.widget.RecyclerView
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
-import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
 
 /**

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItemTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItemTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture.views
+
+import android.os.Build
+import com.google.common.truth.Truth.assertThat
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class QuestionnaireItemViewItemTest {
+  @Test
+  fun singleAnswerOrNull_noAnswer_shouldReturnNull() {
+    val questionnaireItemViewItem = QuestionnaireItemViewItem(
+      Questionnaire.QuestionnaireItemComponent(),
+      QuestionnaireResponse.QuestionnaireResponseItemComponent()
+    )
+    assertThat(questionnaireItemViewItem.singleAnswerOrNull).isNull()
+  }
+
+  @Test
+  fun singleAnswerOrNull_singleAnswer_shouldReturnSingleAnswer() {
+    val questionnaireItemViewItem = QuestionnaireItemViewItem(
+      Questionnaire.QuestionnaireItemComponent(),
+      QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+        answer = listOf(
+          QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+            value = BooleanType(true)
+          }
+        )
+      }
+    )
+    assertThat(
+      questionnaireItemViewItem.singleAnswerOrNull!!.equalsDeep(
+        QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+          value = BooleanType(true)
+        }
+      )
+    ).isTrue()
+  }
+
+  @Test
+  fun singleAnswerOrNull_multipleAnswers_shouldReturnNull() {
+    val questionnaireItemViewItem = QuestionnaireItemViewItem(
+      Questionnaire.QuestionnaireItemComponent(),
+      QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+        answer = listOf(
+          QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+            value = BooleanType(true)
+          },
+          QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+            value = BooleanType(true)
+          }
+        )
+      }
+    )
+    assertThat(questionnaireItemViewItem.singleAnswerOrNull).isNull()
+  }
+}


### PR DESCRIPTION
We had not implemented this because we assumed that it's ok to render the UI without providing an initial value until we implement the initial value to the SDC specification.

However, this already caused issue because the recycler view reuses the questionnaire item views, and if we don't try to set the answer the view might still carry what the user had input for a different question.