### PR TITLE
Fix for refreshing patient list.

### DIFF
--- a/example/src/main/java/com/google/fhirengine/example/PatientListActivity.kt
+++ b/example/src/main/java/com/google/fhirengine/example/PatientListActivity.kt
@@ -72,7 +72,7 @@ class PatientListActivity : AppCompatActivity() {
                 // the MutableLiveData (list of PatientItems) has changed.
                 // submit a copy of the list, otherwise adapter still thinks it's same unchanged
                 // list.
-                adapter.submitList(it?.toMutableList())
+                adapter.submitList(it)
             })
 
         patientListViewModel.getObservations().observe(this,

--- a/example/src/main/java/com/google/fhirengine/example/PatientListActivity.kt
+++ b/example/src/main/java/com/google/fhirengine/example/PatientListActivity.kt
@@ -69,7 +69,10 @@ class PatientListActivity : AppCompatActivity() {
         patientListViewModel.getSearchedPatients().observe(this,
             Observer<List<PatientListViewModel.PatientItem>> {
                 Log.d("PatientListActivity", "Submitting ${it.count()} patient records")
-                adapter.submitList(it)
+                // the MutableLiveData (list of PatientItems) has changed.
+                // submit a copy of the list, otherwise adapter still thinks it's same unchanged
+                // list.
+                adapter.submitList(it?.toMutableList())
             })
 
         patientListViewModel.getObservations().observe(this,

--- a/example/src/main/java/com/google/fhirengine/example/PatientListActivity.kt
+++ b/example/src/main/java/com/google/fhirengine/example/PatientListActivity.kt
@@ -69,9 +69,6 @@ class PatientListActivity : AppCompatActivity() {
         patientListViewModel.getSearchedPatients().observe(this,
             Observer<List<PatientListViewModel.PatientItem>> {
                 Log.d("PatientListActivity", "Submitting ${it.count()} patient records")
-                // the MutableLiveData (list of PatientItems) has changed.
-                // submit a copy of the list, otherwise adapter still thinks it's same unchanged
-                // list.
                 adapter.submitList(it)
             })
 

--- a/example/src/main/java/com/google/fhirengine/example/PatientListViewModel.kt
+++ b/example/src/main/java/com/google/fhirengine/example/PatientListViewModel.kt
@@ -52,7 +52,7 @@ class PatientListViewModel(application: Application, private val fhirEngine: Fhi
     private var patientResults: List<Patient> = getSearchResults()
     private var searchedPatients = samplePatients.getPatientItems(patientResults)
     private val _liveSearchedPatients: MutableLiveData<List<PatientItem>> = MutableLiveData()
-    val liveSearchedPatients:LiveData<List<PatientItem>> = _liveSearchedPatients
+    val liveSearchedPatients: LiveData<List<PatientItem>> = _liveSearchedPatients
 
     fun getSearchedPatients(): LiveData<List<PatientItem>> {
         searchedPatients = samplePatients.getPatientItems(patientResults)

--- a/example/src/main/java/com/google/fhirengine/example/PatientListViewModel.kt
+++ b/example/src/main/java/com/google/fhirengine/example/PatientListViewModel.kt
@@ -51,11 +51,12 @@ class PatientListViewModel(application: Application, private val fhirEngine: Fhi
 
     private var patientResults: List<Patient> = getSearchResults()
     private var searchedPatients = samplePatients.getPatientItems(patientResults)
-    private val liveSearchedPatients: MutableLiveData<List<PatientItem>> = MutableLiveData()
+    private val _liveSearchedPatients: MutableLiveData<List<PatientItem>> = MutableLiveData()
+    val liveSearchedPatients:LiveData<List<PatientItem>> = _liveSearchedPatients
 
     fun getSearchedPatients(): LiveData<List<PatientItem>> {
         searchedPatients = samplePatients.getPatientItems(patientResults)
-        liveSearchedPatients.value = searchedPatients
+        _liveSearchedPatients.value = searchedPatients
         Log.d("PatientListViewModel", "getSearchedPatients(): " +
             "patientResults[${patientResults.count()}], searchedPatients[${searchedPatients
                 .count()}]")
@@ -90,7 +91,7 @@ class PatientListViewModel(application: Application, private val fhirEngine: Fhi
     fun searchPatients() {
         patientResults = getSearchResults()
         searchedPatients = samplePatients.getPatientItems(patientResults)
-        liveSearchedPatients.value = searchedPatients
+        _liveSearchedPatients.value = searchedPatients
     }
 
     private fun getAssetFileAsString(filename: String): String {

--- a/example/src/main/java/com/google/fhirengine/example/data/SamplePatients.kt
+++ b/example/src/main/java/com/google/fhirengine/example/data/SamplePatients.kt
@@ -32,9 +32,6 @@ private const val MAX_RESOURCE_COUNT = 20
  * PatientListViewModel.
  */
 class SamplePatients {
-    private val patients: MutableList<PatientListViewModel.PatientItem> = mutableListOf()
-    private val observations: MutableList<PatientListViewModel.ObservationItem> = ArrayList()
-
     // The resource bundle with Patient objects.
     private var fhirBundle: Bundle? = null
 
@@ -47,6 +44,8 @@ class SamplePatients {
      * Returns list of PatientItem objects based on patients from the json string.
      */
     fun getPatientItems(jsonString: String): List<PatientListViewModel.PatientItem> {
+        val patients: MutableList<PatientListViewModel.PatientItem> = mutableListOf()
+
         fhirBundle = fhirJsonParser.parseResource(Bundle::class.java, jsonString) as Bundle
 
         // Create a list of PatientItems from fhirPatients. The display index is 1 based.
@@ -58,15 +57,15 @@ class SamplePatients {
     }
 
     fun getPatientItems(fhirPatients: List<Patient>): List<PatientListViewModel.PatientItem> {
+        val patients: MutableList<PatientListViewModel.PatientItem> = mutableListOf()
 
-        patients.clear()
         // Create a list of PatientItems from fhirPatients. The display index is 1 based.
         fhirPatients.take(MAX_RESOURCE_COUNT)?.mapIndexed { index, fhirPatient ->
             createPatientItem(index + 1, fhirPatient)
         }?.let { patients.addAll(it) }
 
         // Return a cloned List
-        return patients.toMutableList()
+        return patients
     }
 
     /**
@@ -96,6 +95,8 @@ class SamplePatients {
      * Returns list of ObservationItem objects based on observations from the json string.
      */
     fun getObservationItems(jsonString: String): MutableList<PatientListViewModel.ObservationItem> {
+        val observations = ArrayList<PatientListViewModel.ObservationItem>()
+
         fhirBundle = fhirJsonParser.parseResource(Bundle::class.java, jsonString) as Bundle
 
         // Create a list of ObservationItems from fhirObservations. The display index is 1 based.

--- a/example/src/main/java/com/google/fhirengine/example/data/SamplePatients.kt
+++ b/example/src/main/java/com/google/fhirengine/example/data/SamplePatients.kt
@@ -65,7 +65,8 @@ class SamplePatients {
             createPatientItem(index + 1, fhirPatient)
         }?.let { patients.addAll(it) }
 
-        return patients
+        // Return a cloned List
+        return patients.toMutableList()
     }
 
     /**


### PR DESCRIPTION
PatientListActivity observes a MutableLiveData reference, and on change submits the list to the PatientItemRecyclerViewAdapter. The RecyclerViewAdapter only compares and diffs when the list reference being submitted changes, otherwise it doesn't take any action.

Submitting a copy of the list to circumvent the RecyclerViewAdapter optimisation.

Please suggest if there's a better way to handle this.