### PR TITLE
Hide group header if the text is empty

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactoryInstrumentedTest.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.fhir.datacapture.views
 
+import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
@@ -60,5 +61,38 @@ class QuestionnaireItemGroupViewHolderFactoryInstrumentedTest {
         assertThat(viewHolder.itemView.findViewById<TextView>(R.id.group_header).text).isEqualTo(
             "Group header"
         )
+    }
+
+    @Test
+    fun shouldSetTextViewVisible() {
+        viewHolder.bind(
+            QuestionnaireItemViewItem(
+                Questionnaire.Item.newBuilder().apply {
+                    text =
+                        com.google.fhir.r4.core.String.newBuilder().setValue("Group header").build()
+                }.build(),
+                QuestionnaireResponse.Item.newBuilder()
+            )
+        )
+
+        assertThat(
+            viewHolder.itemView.findViewById<TextView>(R.id.group_header).visibility
+        ).isEqualTo(View.VISIBLE)
+    }
+
+    @Test
+    fun shouldSetTextViewGone() {
+        viewHolder.bind(
+            QuestionnaireItemViewItem(
+                Questionnaire.Item.newBuilder().apply {
+                    text = com.google.fhir.r4.core.String.newBuilder().setValue("").build()
+                }.build(),
+                QuestionnaireResponse.Item.newBuilder()
+            )
+        )
+
+        assertThat(
+            viewHolder.itemView.findViewById<TextView>(R.id.group_header).visibility
+        ).isEqualTo(View.GONE)
     }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
@@ -33,6 +33,11 @@ object QuestionnaireItemGroupViewHolderFactory : QuestionnaireItemViewHolderFact
 
             override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
                 groupHeader.text = questionnaireItemViewItem.questionnaireItem.text.value
+                groupHeader.visibility = if (groupHeader.text.isEmpty()) {
+                    View.GONE
+                } else {
+                    View.VISIBLE
+                }
             }
         }
 }

--- a/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
  Copyright 2020 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
@@ -15,7 +15,6 @@
  limitations under the License.
 -->
 
-
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">

--- a/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2020 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,10 +14,14 @@
  limitations under the License.
 -->
 
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/group_header"
-        style="?attr/groupHeaderTextAppearance"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/item_margin_horizontal"
-        android:layout_marginVertical="@dimen/item_margin_vertical" />
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+    <TextView
+            android:id="@+id/group_header"
+            style="?attr/groupHeaderTextAppearance"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+</FrameLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
@@ -23,5 +23,7 @@
             android:id="@+id/group_header"
             style="?attr/groupHeaderTextAppearance"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/item_margin_horizontal"
+            android:layout_marginVertical="@dimen/item_margin_vertical" />
 </FrameLayout>


### PR DESCRIPTION
This is useful when the group isn't used as a header but for logical grouping purposes. In those cases we don't want to end up with a big gap (with height of one text line height).