### PR TITLE
Create a radio button widget type to handle CHOICE type questions

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxViewHolderFactoryInstrumentedTest.kt
@@ -51,7 +51,7 @@ class QuestionnaireItemCheckBoxViewHolderFactoryInstrumentedTest {
     }
 
     @Test
-    fun noAnswer_shouldSetCheckBoxUnhecked() {
+    fun noAnswer_shouldSetCheckBoxUnchecked() {
         viewHolder.bind(
             QuestionnaireItemViewItem(
                 Questionnaire.Item.newBuilder().apply {
@@ -95,7 +95,7 @@ class QuestionnaireItemCheckBoxViewHolderFactoryInstrumentedTest {
                     QuestionnaireResponse.Item.Answer.newBuilder().apply {
                         value = QuestionnaireResponse.Item.Answer.ValueX.newBuilder()
                             .setBoolean(Boolean.newBuilder().setValue(false)).build()
-                }
+                    }
                 )
             )
         )

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest.kt
@@ -118,6 +118,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest {
     }
 
     @Test
+    @UiThreadTest
     fun shouldSetRadioButtonsChecked() {
         viewHolder.bind(
             QuestionnaireItemViewItem(

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture.views
+
+import android.widget.FrameLayout
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import android.widget.TextView
+import androidx.test.annotation.UiThreadTest
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.fhir.datacapture.R
+import com.google.common.truth.Truth.assertThat
+import com.google.fhir.r4.core.Coding
+import com.google.fhir.r4.core.Questionnaire
+import com.google.fhir.r4.core.QuestionnaireResponse
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest {
+    private val parent = FrameLayout(InstrumentationRegistry.getInstrumentation().context)
+    private val viewHolder = QuestionnaireItemRadioGroupViewHolderFactory.create(parent)
+
+    @Test
+    fun shouldSetHeaderText() {
+        viewHolder.bind(
+            QuestionnaireItemViewItem(
+                Questionnaire.Item.newBuilder().apply {
+                    text = com.google.fhir.r4.core.String.newBuilder().setValue("Question?").build()
+                }.build(),
+                QuestionnaireResponse.Item.newBuilder()
+            )
+        )
+
+        assertThat(viewHolder.itemView.findViewById<TextView>(R.id.radio_header).text).isEqualTo(
+            "Question?"
+        )
+    }
+
+    @Test
+    fun shouldCreateRadioButtons() {
+        viewHolder.bind(
+            QuestionnaireItemViewItem(
+                Questionnaire.Item.newBuilder().apply {
+                    addAllAnswerOption(mutableListOf(
+                        Questionnaire.Item.AnswerOption.newBuilder().apply {
+                            value = Questionnaire.Item.AnswerOption.ValueX.newBuilder().apply {
+                                coding = Coding.newBuilder().apply {
+                                    display = com.google.fhir.r4.core.String.newBuilder()
+                                        .setValue("Coding 1")
+                                        .build()
+                                }.build()
+                            }.build()
+                        }.build(),
+                        Questionnaire.Item.AnswerOption.newBuilder().apply {
+                            value = Questionnaire.Item.AnswerOption.ValueX.newBuilder().apply {
+                                coding = Coding.newBuilder().apply {
+                                    display = com.google.fhir.r4.core.String.newBuilder()
+                                        .setValue("Coding 2")
+                                        .build()
+                                }.build()
+                            }.build()
+                        }.build()
+                    ))
+                }.build(),
+                QuestionnaireResponse.Item.newBuilder()
+            )
+        )
+
+        val radioGroup = viewHolder.itemView.findViewById<RadioGroup>(R.id.radio_group)
+        assertThat(radioGroup.childCount).isEqualTo(2)
+        val radioButton1 = radioGroup.getChildAt(0) as RadioButton
+        assertThat(radioButton1.text).isEqualTo("Coding 1")
+        val radioButton2 = radioGroup.getChildAt(1) as RadioButton
+        assertThat(radioButton2.text).isEqualTo("Coding 2")
+    }
+
+    @Test
+    fun shouldSetRadioButtonsUnchecked() {
+        viewHolder.bind(
+            QuestionnaireItemViewItem(
+                Questionnaire.Item.newBuilder().apply {
+                    addAllAnswerOption(mutableListOf(
+                        Questionnaire.Item.AnswerOption.newBuilder().apply {
+                            value = Questionnaire.Item.AnswerOption.ValueX.newBuilder().apply {
+                                coding = Coding.newBuilder().apply {
+                                    display = com.google.fhir.r4.core.String.newBuilder()
+                                        .setValue("Coding 1")
+                                        .build()
+                                }.build()
+                            }.build()
+                        }.build()
+                    ))
+                }.build(),
+                QuestionnaireResponse.Item.newBuilder()
+            )
+        )
+
+        val radioButton =
+            viewHolder.itemView.findViewById<RadioGroup>(R.id.radio_group)
+                .getChildAt(0) as RadioButton
+        assertThat(radioButton.isChecked).isFalse()
+    }
+
+    @Test
+    fun shouldSetRadioButtonsChecked() {
+        viewHolder.bind(
+            QuestionnaireItemViewItem(
+                Questionnaire.Item.newBuilder().apply {
+                    addAllAnswerOption(mutableListOf(
+                        Questionnaire.Item.AnswerOption.newBuilder().apply {
+                            value = Questionnaire.Item.AnswerOption.ValueX.newBuilder().apply {
+                                coding = Coding.newBuilder().apply {
+                                    display = com.google.fhir.r4.core.String.newBuilder()
+                                        .setValue("Coding 1")
+                                        .build()
+                                }.build()
+                            }.build()
+                        }.build()
+                    ))
+                }.build(),
+                QuestionnaireResponse.Item.newBuilder().apply {
+                    addAnswer(QuestionnaireResponse.Item.Answer.newBuilder().apply {
+                        value = QuestionnaireResponse.Item.Answer.ValueX.newBuilder().apply {
+                            coding = Coding.newBuilder().apply {
+                                display = com.google.fhir.r4.core.String.newBuilder()
+                                    .setValue("Coding 1")
+                                    .build()
+                            }.build()
+                        }.build()
+                    })
+                }
+            )
+        )
+
+        val radioButton =
+            viewHolder.itemView.findViewById<RadioGroup>(R.id.radio_group)
+                .getChildAt(0) as RadioButton
+        assertThat(radioButton.isChecked).isTrue()
+    }
+
+    @Test
+    @UiThreadTest
+    fun shouldSetQuestionnaireResponseItemComponentAnswer() {
+        val questionnaireItemViewItem = QuestionnaireItemViewItem(
+            Questionnaire.Item.newBuilder().apply {
+                addAllAnswerOption(mutableListOf(
+                    Questionnaire.Item.AnswerOption.newBuilder().apply {
+                        value = Questionnaire.Item.AnswerOption.ValueX.newBuilder().apply {
+                            coding = Coding.newBuilder().apply {
+                                display = com.google.fhir.r4.core.String.newBuilder()
+                                    .setValue("Coding 1")
+                                    .build()
+                            }.build()
+                        }.build()
+                    }.build()
+                ))
+            }.build(),
+            QuestionnaireResponse.Item.newBuilder()
+        )
+        viewHolder.bind(questionnaireItemViewItem)
+        viewHolder.itemView.findViewById<RadioGroup>(R.id.radio_group).getChildAt(0).performClick()
+
+        val answer = questionnaireItemViewItem.questionnaireResponseItemBuilder.answerBuilderList
+        assertThat(answer.size).isEqualTo(1)
+        assertThat(answer[0].value.coding.display.value).isEqualTo("Coding 1")
+    }
+}

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapter.kt
@@ -25,6 +25,7 @@ import com.google.android.fhir.datacapture.views.QuestionnaireItemEditTextIntege
 import com.google.android.fhir.datacapture.views.QuestionnaireItemEditTextMultiLineViewHolderFactory
 import com.google.android.fhir.datacapture.views.QuestionnaireItemEditTextSingleLineViewHolderFactory
 import com.google.android.fhir.datacapture.views.QuestionnaireItemGroupViewHolderFactory
+import com.google.android.fhir.datacapture.views.QuestionnaireItemRadioGroupViewHolderFactory
 import com.google.android.fhir.datacapture.views.QuestionnaireItemViewHolder
 import com.google.android.fhir.datacapture.views.QuestionnaireItemViewItem
 import com.google.fhir.r4.core.QuestionnaireItemTypeCode
@@ -50,6 +51,8 @@ internal class QuestionnaireItemAdapter(
                 QuestionnaireItemEditTextIntegerViewHolderFactory
             QuestionnaireItemViewHolderType.EDIT_TEXT_DECIMAL ->
                 QuestionnaireItemEditTextDecimalViewHolderFactory
+            QuestionnaireItemViewHolderType.RADIO_GROUP ->
+                QuestionnaireItemRadioGroupViewHolderFactory
         }
         return viewHolder.create(parent)
     }
@@ -78,6 +81,8 @@ internal class QuestionnaireItemAdapter(
                 QuestionnaireItemViewHolderType.EDIT_TEXT_INTEGER
             QuestionnaireItemTypeCode.Value.DECIMAL ->
                 QuestionnaireItemViewHolderType.EDIT_TEXT_DECIMAL
+            QuestionnaireItemTypeCode.Value.CHOICE ->
+                QuestionnaireItemViewHolderType.RADIO_GROUP
             else -> throw NotImplementedError("Question type $type not supported.")
         }.value
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemViewHolderType.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemViewHolderType.kt
@@ -33,7 +33,8 @@ enum class QuestionnaireItemViewHolderType(val value: Int) {
     EDIT_TEXT_SINGLE_LINE(3),
     EDIT_TEXT_MULTI_LINE(4),
     EDIT_TEXT_INTEGER(5),
-    EDIT_TEXT_DECIMAL(6);
+    EDIT_TEXT_DECIMAL(6),
+    RADIO_GROUP(7);
 
     companion object {
         private val VALUES = values()

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture.views
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import android.widget.TextView
+import com.google.android.fhir.datacapture.R
+import com.google.fhir.r4.core.QuestionnaireResponse
+
+object QuestionnaireItemRadioGroupViewHolderFactory : QuestionnaireItemViewHolderFactory(
+    R.layout.questionnaire_item_radio_group_view
+) {
+    override fun getQuestionnaireItemViewHolderDelegate() =
+        object : QuestionnaireItemViewHolderDelegate {
+            private lateinit var radioHeader: TextView
+            private lateinit var radioGroup: RadioGroup
+            private lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
+
+            override fun init(itemView: View) {
+                radioGroup = itemView.findViewById(R.id.radio_group)
+                radioHeader = itemView.findViewById(R.id.radio_header)
+            }
+
+            override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+                this.questionnaireItemViewItem = questionnaireItemViewItem
+                val questionnaireItem = questionnaireItemViewItem.questionnaireItem
+                val questionnaireResponseItemBuilder =
+                    questionnaireItemViewItem.questionnaireResponseItemBuilder
+                val answer =
+                    questionnaireResponseItemBuilder.answerList.singleOrNull()?.value?.coding
+                radioHeader.text = questionnaireItem.text.value
+                radioGroup.removeAllViews()
+
+                // TODO: support other answer types besides coding
+                questionnaireItem.answerOptionList.forEach {
+                    radioGroup.addView(RadioButton(radioGroup.context).apply {
+                        text = it.value.coding.display.value
+                        layoutParams = ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT
+                        )
+                        if (questionnaireItemViewItem.singleAnswerOrNull
+                                ?.value?.coding?.equals(answer) == true) {
+                            this.isChecked = true
+                        }
+                        setOnCheckedChangeListener { buttonView, isChecked ->
+                            if (isChecked) {
+                                questionnaireResponseItemBuilder.clearAnswer().addAnswer(
+                                    QuestionnaireResponse.Item.Answer.newBuilder().apply {
+                                        value =
+                                            QuestionnaireResponse.Item.Answer.ValueX.newBuilder()
+                                                .apply {
+                                                    coding = it.value.coding
+                                                }.build()
+                                    }
+                                )
+                            }
+                        }
+                    })
+                }
+            }
+        }
+}

--- a/datacapture/src/main/res/layout/questionnaire_item_check_box_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_check_box_view.xml
@@ -17,7 +17,7 @@
 
 <CheckBox xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/check_box"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/item_margin_horizontal"
         android:layout_marginVertical="@dimen/item_margin_vertical" />

--- a/datacapture/src/main/res/layout/questionnaire_item_radio_group_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_radio_group_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/item_margin_horizontal"
+        android:layout_marginVertical="@dimen/item_margin_vertical"
+        android:orientation="vertical">
+
+    <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/radio_header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    <RadioGroup
+            android:id="@+id/radio_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+</LinearLayout>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapterTest.kt
@@ -171,14 +171,14 @@ class QuestionnaireItemAdapterTest {
     }
 
     @Test
-    fun getItemViewType_choiceItemType_shouldReturnEditTextDecimalViewHolderType() {
+    fun getItemViewType_choiceItemType_shouldReturnRadioGroupViewHolderType() {
         val questionnaireItemAdapter = QuestionnaireItemAdapter(
             listOf(
                 QuestionnaireItemViewItem(
                     Questionnaire.Item.newBuilder()
                         .setType(
                             Questionnaire.Item.TypeCode.newBuilder()
-                                .setValue(QuestionnaireItemTypeCode.Value.DECIMAL)
+                                .setValue(QuestionnaireItemTypeCode.Value.CHOICE)
                         )
                         .build(),
                     QuestionnaireResponse.Item.newBuilder()
@@ -186,7 +186,7 @@ class QuestionnaireItemAdapterTest {
             )
         )
         assertThat(questionnaireItemAdapter.getItemViewType(0)).isEqualTo(
-            QuestionnaireItemViewHolderType.EDIT_TEXT_DECIMAL.value
+            QuestionnaireItemViewHolderType.RADIO_GROUP.value
         )
     }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapterTest.kt
@@ -170,5 +170,25 @@ class QuestionnaireItemAdapterTest {
         )
     }
 
+    @Test
+    fun getItemViewType_choiceItemType_shouldReturnEditTextDecimalViewHolderType() {
+        val questionnaireItemAdapter = QuestionnaireItemAdapter(
+            listOf(
+                QuestionnaireItemViewItem(
+                    Questionnaire.Item.newBuilder()
+                        .setType(
+                            Questionnaire.Item.TypeCode.newBuilder()
+                                .setValue(QuestionnaireItemTypeCode.Value.DECIMAL)
+                        )
+                        .build(),
+                    QuestionnaireResponse.Item.newBuilder()
+                )
+            )
+        )
+        assertThat(questionnaireItemAdapter.getItemViewType(0)).isEqualTo(
+            QuestionnaireItemViewHolderType.EDIT_TEXT_DECIMAL.value
+        )
+    }
+
     // TODO: test errors thrown for unsupported types
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemViewHolderTypeTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemViewHolderTypeTest.kt
@@ -28,7 +28,7 @@ import org.robolectric.annotation.Config
 class QuestionnaireItemViewHolderTypeTest {
     @Test
     fun size_shouldReturnNumberOfQuestionnaireViewHolderTypes() {
-        assertThat(QuestionnaireItemViewHolderType.values().size).isEqualTo(7)
+        assertThat(QuestionnaireItemViewHolderType.values().size).isEqualTo(8)
     }
 
     @Test


### PR DESCRIPTION
Future work:

- handling the selection of widget type for CHOICE type questions (e.g. radio button group vs drop down) is handled in PR #188 
- handling different answer types besides coding is to be done in a subsequent PR

closing #152 