### PR TITLE
Remove @JvmStatic annotations in internal classes (not needed for Java interop)

### DIFF
--- a/core/src/main/java/com/google/android/fhir/db/impl/DbTypeConverters.kt
+++ b/core/src/main/java/com/google/android/fhir/db/impl/DbTypeConverters.kt
@@ -34,26 +34,32 @@ internal object DbTypeConverters {
      * Converts a [ResourceType] into a String to be persisted in the database. This allows us to
      * save [ResourceType] into the database while keeping it as the real type in entities.
      */
+    @JvmStatic
     @TypeConverter
     fun typeToString(resourceType: ResourceType) = resourceType.name
 
     /**
      * Converts a String into a [ResourceType]. Called when a query returns a [ResourceType].
      */
+    @JvmStatic
     @TypeConverter
     fun stringToResourceType(data: String) = resourceTypeLookup[data]
         ?: throw IllegalArgumentException("invalid resource type: $data")
 
+    @JvmStatic
     @TypeConverter
     fun bigDecimalToString(value: BigDecimal): String = value.toString()
 
+    @JvmStatic
     @TypeConverter
     fun stringToBigDecimal(value: String): BigDecimal = value.toBigDecimal()
 
+    @JvmStatic
     @TypeConverter
     fun temporalPrecisionToInt(temporalPrecision: TemporalPrecisionEnum): Int =
         temporalPrecision.calendarConstant
 
+    @JvmStatic
     @TypeConverter
     fun intToTemporalPrecision(intTp: Int): TemporalPrecisionEnum {
         return when (intTp) {
@@ -67,9 +73,11 @@ internal object DbTypeConverters {
         }
     }
 
+    @JvmStatic
     @TypeConverter
     fun localChangeTypeToInt(updateType: LocalChange.Type): Int = updateType.value
 
+    @JvmStatic
     @TypeConverter
     fun intToLocalChangeType(value: Int): LocalChange.Type = LocalChange.Type.from(value)
 }

--- a/core/src/main/java/com/google/android/fhir/db/impl/DbTypeConverters.kt
+++ b/core/src/main/java/com/google/android/fhir/db/impl/DbTypeConverters.kt
@@ -34,32 +34,26 @@ internal object DbTypeConverters {
      * Converts a [ResourceType] into a String to be persisted in the database. This allows us to
      * save [ResourceType] into the database while keeping it as the real type in entities.
      */
-    @JvmStatic
     @TypeConverter
     fun typeToString(resourceType: ResourceType) = resourceType.name
 
     /**
      * Converts a String into a [ResourceType]. Called when a query returns a [ResourceType].
      */
-    @JvmStatic
     @TypeConverter
     fun stringToResourceType(data: String) = resourceTypeLookup[data]
         ?: throw IllegalArgumentException("invalid resource type: $data")
 
-    @JvmStatic
     @TypeConverter
     fun bigDecimalToString(value: BigDecimal): String = value.toString()
 
-    @JvmStatic
     @TypeConverter
     fun stringToBigDecimal(value: String): BigDecimal = value.toBigDecimal()
 
-    @JvmStatic
     @TypeConverter
     fun temporalPrecisionToInt(temporalPrecision: TemporalPrecisionEnum): Int =
         temporalPrecision.calendarConstant
 
-    @JvmStatic
     @TypeConverter
     fun intToTemporalPrecision(intTp: Int): TemporalPrecisionEnum {
         return when (intTp) {
@@ -73,11 +67,9 @@ internal object DbTypeConverters {
         }
     }
 
-    @JvmStatic
     @TypeConverter
     fun localChangeTypeToInt(updateType: LocalChange.Type): Int = updateType.value
 
-    @JvmStatic
     @TypeConverter
     fun intToLocalChangeType(value: Int): LocalChange.Type = LocalChange.Type.from(value)
 }

--- a/core/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeUtils.kt
+++ b/core/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeUtils.kt
@@ -30,14 +30,10 @@ import org.json.JSONObject
 
 object LocalChangeUtils {
 
-    /**
-     * Squash the changes by merging them two at a time.
-     */
-    @JvmStatic
+    /** Squash the changes by merging them two at a time. */
     fun squash(localChanges: List<LocalChange>): LocalChange =
-            localChanges.reduce { first, second -> mergeLocalChanges(first, second) }
+        localChanges.reduce { first, second -> mergeLocalChanges(first, second) }
 
-    @JvmStatic
     fun mergeLocalChanges(first: LocalChange, second: LocalChange): LocalChange {
         val type: LocalChange.Type
         val payload: String
@@ -75,10 +71,7 @@ object LocalChangeUtils {
         )
     }
 
-    /**
-     * Update a JSON object with a JSON patch (RFC 6902).
-     */
-    @JvmStatic
+    /** Update a JSON object with a JSON patch (RFC 6902). */
     private fun applyPatch(resourceString: String, patchString: String): String {
         val objectMapper = ObjectMapper()
         val resourceJson = objectMapper.readValue(resourceString, JsonNode::class.java)
@@ -86,10 +79,7 @@ object LocalChangeUtils {
         return patchJson.apply(resourceJson).toString()
     }
 
-    /**
-     * Merge two JSON patch strings by concatenating their elements into a new JSON array.
-     */
-    @JvmStatic
+    /**  Merge two JSON patch strings by concatenating their elements into a new JSON array. */
     private fun mergePatches(firstPatch: String, secondPatch: String): String {
         // TODO: validate patches are RFC 6902 compliant JSON patches
         val firstMap = JSONArray(firstPatch).patchMergeMap()
@@ -98,10 +88,7 @@ object LocalChangeUtils {
         return JSONArray(firstMap.values).toString()
     }
 
-    /**
-     * Calculates the JSON patch between two [Resource]s.
-     */
-    @JvmStatic
+    /** Calculates the JSON patch between two [Resource]s. */
     internal fun diff(parser: IParser, source: Resource, target: Resource): String {
         val objectMapper = ObjectMapper()
         val jsonDiff = JsonDiff.asJson(
@@ -116,8 +103,8 @@ object LocalChangeUtils {
         )
         if (jsonDiff.size() == 0) {
             Log.i(
-            "ResourceDao",
-            "Target ${target.resourceType}/${target.id} is same as source."
+                "ResourceDao",
+                "Target ${target.resourceType}/${target.id} is same as source."
             )
         }
         return jsonDiff.toString()


### PR DESCRIPTION
@JvmStatic is used for the compiler to generate static methods for Java clients to use. Since internal kotlin classes are never exposed to any users, there's no need to have @JvmStatic annotations on them.