### PR TITLE
Add missing dependency on androidx activity library

### DIFF
--- a/deps.gradle
+++ b/deps.gradle
@@ -12,6 +12,7 @@ def build_tool_version = '30.0.2'
 ext.build_tool_version = build_tool_version
 
 def versions = [:]
+versions.activity = '1.2.1'
 versions.android_gradle_plugin = '4.2.0-beta02'
 versions.appcompat = '1.1.0'
 versions.atsl_core = '1.2.0'
@@ -45,6 +46,7 @@ versions.json_tools = '1.13'
 ext.versions = versions
 
 def deps = [:]
+deps.activity = "androidx.activity:activity:$versions.activity"
 deps.android_gradle_plugin = "com.android.tools.build:gradle:$versions.android_gradle_plugin"
 deps.appcompat = "androidx.appcompat:appcompat:$versions.appcompat"
 def atsl = [:]

--- a/reference/build.gradle
+++ b/reference/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     coreLibraryDesugaring deps.desugar
 
+    implementation deps.activity
     implementation deps.appcompat
     implementation deps.constraint_layout
     implementation deps.coroutines.android


### PR DESCRIPTION
This missing dependency was causing warnings in the activity classes in the reference application.