### PR TITLE
Bug fix. Removed hard coded file name from utility function in datacapturegallery/QuestionnaireViewModel.kt

### DIFF
--- a/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireViewModel.kt
+++ b/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireViewModel.kt
@@ -46,7 +46,7 @@ class QuestionnaireViewModel(application: Application, private val state: SavedS
   private fun readFileFromAssets(filename: String): String {
     return getApplication<Application>()
       .assets
-      .open(state[QuestionnaireActivity.QUESTIONNAIRE_RESPONSE_FILE_PATH_KEY]!!)
+      .open(filename)
       .bufferedReader()
       .use { it.readText() }
   }

--- a/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireViewModel.kt
+++ b/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireViewModel.kt
@@ -44,10 +44,8 @@ class QuestionnaireViewModel(application: Application, private val state: SavedS
     }
 
   private fun readFileFromAssets(filename: String): String {
-    return getApplication<Application>()
-      .assets
-      .open(filename)
-      .bufferedReader()
-      .use { it.readText() }
+    return getApplication<Application>().assets.open(filename).bufferedReader().use {
+      it.readText()
+    }
   }
 }


### PR DESCRIPTION
Quick bug fix which caused last merge to crash when selecting the example with a Questionnaire and Questionnaire response