### PR TITLE
Update the PR template to guide contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,24 @@
-**Fixes**: 
-Add issue number here
+**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straighforward changes).**
 
-**Description:**
+**Fixes** #[issue number]
+
+**Description**
 Clear and concise code change description. 
 
+**Alternative(s) considered**
+Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
+
 **Type**
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Documentation
-- [ ] Builds
-- [ ] Releases
-- [ ] Other (please specify)
+Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)
 
 **Screenshots (if applicable)**
+
+**Checklist**
+- [ ] I have read and acknowledge the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
+- [ ] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
+- [ ] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
+- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
+- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
+- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
+- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
+- [ ] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)


### PR DESCRIPTION
Improve the current PR template to include more guidance and a checklist to help contributors and reviews save time