### PR TITLE
Add API and implementation for upload sync

### DIFF
--- a/core/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/core/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -56,12 +56,15 @@ interface FhirEngine {
   suspend fun <R : Resource> remove(clazz: Class<R>, id: String)
 
   /**
-   * One time sync.
+   * One time download of resources.
    *
    * @param syncConfiguration
    * - configuration of data that needs to be synchronised
    */
   suspend fun sync(syncConfiguration: SyncConfiguration): Result
+
+  /** Attempts to upload locally created and modified resources. */
+  suspend fun syncUpload(): Result
 
   suspend fun periodicSync(): Result
 

--- a/core/src/main/java/com/google/android/fhir/Util.kt
+++ b/core/src/main/java/com/google/android/fhir/Util.kt
@@ -21,7 +21,9 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
+import org.hl7.fhir.r4.model.OperationOutcome
 import org.hl7.fhir.r4.model.Resource
+import org.hl7.fhir.r4.model.ResourceType
 
 /** Utility function to format a [Date] object using the system's default locale. */
 @SuppressLint("NewApi")
@@ -40,3 +42,17 @@ val Resource.logicalId: String
   get() {
     return this.idElement?.idPart.orEmpty()
   }
+
+/**
+ * Determines if the upload operation was successful or not.
+ *
+ * Current HAPI FHIR implementation does not give any signal other than 'severity' level for
+ * operation success/failure. TODO: pass along the HTTP result (or any other signal) to determine
+ * the outcome of an instance level RESTful operation.
+ */
+fun Resource.isUploadSuccess(): Boolean {
+  if (!this.resourceType.equals(ResourceType.OperationOutcome)) return false
+  val outcome: OperationOutcome = this as OperationOutcome
+  return outcome.issue.isNotEmpty() &&
+    outcome.issue.all { it.severity.equals(OperationOutcome.IssueSeverity.INFORMATION) }
+}

--- a/core/src/main/java/com/google/android/fhir/Util.kt
+++ b/core/src/main/java/com/google/android/fhir/Util.kt
@@ -36,5 +36,7 @@ internal fun Date.toTimeZoneString(): String {
  * The logical (unqualified) part of the ID. For example, if the ID is
  * "http://example.com/fhir/Patient/123/_history/456", then this value would be "123".
  */
-internal val Resource.logicalId: String
-  get() = this.idElement.idPart
+val Resource.logicalId: String
+  get() {
+    return if (this.hasIdElement() && this.idElement.hasIdPart()) this.idElement.idPart else ""
+  }

--- a/core/src/main/java/com/google/android/fhir/Util.kt
+++ b/core/src/main/java/com/google/android/fhir/Util.kt
@@ -38,5 +38,5 @@ internal fun Date.toTimeZoneString(): String {
  */
 val Resource.logicalId: String
   get() {
-    return if (this.hasIdElement() && this.idElement.hasIdPart()) this.idElement.idPart else ""
+    return this.idElement?.idPart.orEmpty()
   }

--- a/core/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/core/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -73,6 +73,10 @@ constructor(
     return FhirSynchronizer(syncConfiguration, dataSource, database).sync()
   }
 
+  override suspend fun syncUpload(): Result {
+    return FhirSynchronizer(SyncConfiguration(), dataSource, database).upload()
+  }
+
   override suspend fun periodicSync(): Result {
     val syncConfig =
       periodicSyncConfiguration

--- a/core/src/test/java/com/google/android/fhir/UtilTest.kt
+++ b/core/src/test/java/com/google/android/fhir/UtilTest.kt
@@ -1,9 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.android.fhir
 
 import android.os.Build
 import com.google.common.truth.Truth.assertThat
 import junit.framework.TestCase
 import org.hl7.fhir.r4.model.IdType
+import org.hl7.fhir.r4.model.OperationOutcome
 import org.hl7.fhir.r4.model.Patient
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,37 +31,73 @@ import org.robolectric.annotation.Config
 @Config(sdk = [Build.VERSION_CODES.P])
 class UtilTest : TestCase() {
 
-    @Test
-    fun logicalId_patient_missing_id_shouldReturnEmptyString() {
-        val patient = Patient()
-        assertThat(patient.logicalId).isEmpty()
-    }
+  @Test
+  fun logicalId_patient_missing_id_shouldReturnEmptyString() {
+    val patient = Patient()
+    assertThat(patient.logicalId).isEmpty()
+  }
 
-    @Test
-    fun logicalId_patient_null_id_shouldReturnEmptyString() {
-        val patient = Patient()
-        patient.idElement = null
-        assertThat(patient.logicalId).isEmpty()
-    }
+  @Test
+  fun logicalId_patient_null_id_shouldReturnEmptyString() {
+    val patient = Patient()
+    patient.idElement = null
+    assertThat(patient.logicalId).isEmpty()
+  }
 
-    @Test
-    fun logicalId_patient_blank_id_shouldReturnEmptyString() {
-        val patient = Patient()
-        patient.idElement = IdType()
-        assertThat(patient.logicalId).isEmpty()
-    }
+  @Test
+  fun logicalId_patient_blank_id_shouldReturnEmptyString() {
+    val patient = Patient()
+    patient.idElement = IdType()
+    assertThat(patient.logicalId).isEmpty()
+  }
 
-    @Test
-    fun logicalId_patient_stringId_shouldReturnId() {
-        val patient = Patient()
-        patient.id = "test_patient"
-        assertThat(patient.logicalId).isEqualTo("test_patient")
-    }
+  @Test
+  fun logicalId_patient_stringId_shouldReturnId() {
+    val patient = Patient()
+    patient.id = "test_patient"
+    assertThat(patient.logicalId).isEqualTo("test_patient")
+  }
 
-    @Test
-    fun logicalId_patient_fullyQualifiedId_shouldReturnUnqualifiedId() {
-        val patient = Patient()
-        patient.idElement = IdType("http://hapi.fhir.org/baseR4/Patient/Nemo")
-        assertThat(patient.logicalId).isEqualTo("Nemo")
+  @Test
+  fun logicalId_patient_fullyQualifiedId_shouldReturnUnqualifiedId() {
+    val patient = Patient()
+    patient.idElement = IdType("http://hapi.fhir.org/baseR4/Patient/Nemo")
+    assertThat(patient.logicalId).isEqualTo("Nemo")
+  }
+
+  @Test
+  fun operationOutcomeIsSuccess_noIssue_shouldReturnFalse() {
+    val outcome = OperationOutcome()
+    assertThat(outcome.isUploadSuccess()).isFalse()
+  }
+
+  @Test
+  fun operationOutcomeIsSuccess_errorIssue_shouldReturnFalse() {
+    assertThat(TEST_OPERATION_OUTCOME_ERROR.isUploadSuccess()).isFalse()
+  }
+
+  @Test
+  fun operationOutcomeIsSuccess_infoIssue_shouldReturnTrue() {
+    assertThat(TEST_OPERATION_OUTCOME_INFO.isUploadSuccess()).isTrue()
+  }
+
+  @Test
+  fun operationOutcomeIsSuccess_patient_shouldReturnFalse() {
+    assertThat(Patient().isUploadSuccess()).isFalse()
+  }
+
+  companion object {
+    val TEST_OPERATION_OUTCOME_ERROR = OperationOutcome()
+    val TEST_OPERATION_OUTCOME_INFO = OperationOutcome()
+    init {
+      TEST_OPERATION_OUTCOME_ERROR.addIssue(
+        OperationOutcome.OperationOutcomeIssueComponent()
+          .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+      )
+      TEST_OPERATION_OUTCOME_INFO.addIssue(
+        OperationOutcome.OperationOutcomeIssueComponent()
+          .setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+      )
     }
+  }
 }

--- a/core/src/test/java/com/google/android/fhir/UtilTest.kt
+++ b/core/src/test/java/com/google/android/fhir/UtilTest.kt
@@ -1,0 +1,50 @@
+package com.google.android.fhir
+
+import android.os.Build
+import com.google.common.truth.Truth.assertThat
+import junit.framework.TestCase
+import org.hl7.fhir.r4.model.IdType
+import org.hl7.fhir.r4.model.Patient
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class UtilTest : TestCase() {
+
+    @Test
+    fun logicalId_patient_missing_id_shouldReturnEmptyString() {
+        val patient = Patient()
+        assertThat(patient.logicalId).isEmpty()
+    }
+
+    @Test
+    fun logicalId_patient_null_id_shouldReturnEmptyString() {
+        val patient = Patient()
+        patient.idElement = null
+        assertThat(patient.logicalId).isEmpty()
+    }
+
+    @Test
+    fun logicalId_patient_blank_id_shouldReturnEmptyString() {
+        val patient = Patient()
+        patient.idElement = IdType()
+        assertThat(patient.logicalId).isEmpty()
+    }
+
+    @Test
+    fun logicalId_patient_stringId_shouldReturnId() {
+        val patient = Patient()
+        patient.id = "test_patient"
+        assertThat(patient.logicalId).isEqualTo("test_patient")
+    }
+
+    @Test
+    fun logicalId_patient_fullyQualifiedId_shouldReturnUnqualifiedId() {
+        val patient = Patient()
+        patient.idElement = IdType("http://hapi.fhir.org/baseR4/Patient/Nemo")
+        assertThat(patient.logicalId).isEqualTo("Nemo")
+    }
+}


### PR DESCRIPTION
Fixes #366

**Description**

Added basic upload sync API and implementation in `FhirEngine`.

* Sync resources by squashed change type
* Rudimentary check for upload success



**Alternative(s) considered**
Basic feature implemented but needs augmentation to support periodic sync using work manager ala download sync.

**Type**
Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
