### PR TITLE
Create network security config that allows cleartext traffic

### DIFF
--- a/reference/src/main/AndroidManifest.xml
+++ b/reference/src/main/AndroidManifest.xml
@@ -18,12 +18,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.android.fhir.reference"
 >
-    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name="com.google.android.fhir.reference.FhirApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
@@ -51,4 +52,5 @@
             />
         </activity>
     </application>
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/reference/src/main/res/xml/network_security_config.xml
+++ b/reference/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">hapi.fhir.org</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #443 

**Description**
Create network security config xml file in res that allows cleartext traffic in the reference application.

**Alternative(s) considered**
N/A

**Type**
Bug fix

**Screenshots (if applicable)**
N/A

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
