### PR TITLE
Fix maven publish plugin for `datacapture` module and add source jar to `engine` module

### DIFF
--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -4,24 +4,21 @@ plugins {
   id(Plugins.BuildPlugins.mavenPublish)
 }
 
-val group = "com.google.android.fhir"
-val version = "0.1.0-alpha02"
-
-tasks {
-  val sourcesJar by creating(Jar::class) {
-    archiveClassifier.set("sources")
-    from(android.sourceSets.getByName("main").java.srcDirs)
-  }
-  artifacts { add("archives", sourcesJar) }
-}
-
 afterEvaluate {
   publishing {
     publications {
       register("release", MavenPublication::class) {
         from(components["release"])
         artifactId = "data-capture"
-        // Also publish source code for developers" convenience
+        groupId = "com.google.android.fhir"
+        version = "0.1.0-alpha02"
+        // Also publish source code for developers' convenience
+        artifact(
+          tasks.create<Jar>("androidSourcesJar") {
+            archiveClassifier.set("sources")
+            from(android.sourceSets.getByName("main").java.srcDirs)
+          }
+        )
         pom {
           name.set("Android FHIR Structured Data Capture Library")
           licenses {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -5,18 +5,21 @@ plugins {
   id(Plugins.BuildPlugins.mavenPublish)
 }
 
-val artifactGroup = "com.google.android.fhir"
-val artifactVersion = "0.1.0-alpha01"
-
 afterEvaluate {
   publishing {
     publications {
       register("release", MavenPublication::class) {
         from(components["release"])
         artifactId = "engine"
-        groupId = artifactGroup
-        version = artifactVersion
-        // Also publish source code for developers" convenience
+        groupId = "com.google.android.fhir"
+        version = "0.1.0-alpha01"
+        // Also publish source code for developers' convenience
+        artifact(
+          tasks.create<Jar>("androidSourcesJar") {
+            archiveClassifier.set("sources")
+            from(android.sourceSets.getByName("main").java.srcDirs)
+          }
+        )
         pom {
           name.set("Android FHIR Engine Library")
           licenses {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #307 #391 

**Description**
Maven publish module does not work for the `datacapture` module after the kotlin migration due to missing group ID and version. The `datacapture` module release also misses the source jar.

This PR also adds source jar to the `engine` module release.

**Alternative(s) considered**
N/A

**Type**
Bug fix

**Screenshots (if applicable)**
N/A

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
