### PR TITLE
Database: Store BigDecimals as doubles (SQLite REAL) instead of Strings

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/db/impl/DbTypeConverters.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DbTypeConverters.kt
@@ -42,9 +42,11 @@ internal object DbTypeConverters {
   fun stringToResourceType(data: String) =
     resourceTypeLookup[data] ?: throw IllegalArgumentException("invalid resource type: $data")
 
-  @JvmStatic @TypeConverter fun bigDecimalToString(value: BigDecimal): String = value.toString()
+  // Since we're narrowing BigDecimal to double, search/sort precision is limited.
+  // Search/sort for values that are close enough to resolve to the same double will be undefined.
+  @JvmStatic @TypeConverter fun bigDecimalToDouble(value: BigDecimal): Double = value.toDouble()
 
-  @JvmStatic @TypeConverter fun stringToBigDecimal(value: String): BigDecimal = value.toBigDecimal()
+  @JvmStatic @TypeConverter fun doubleToBigDecimal(value: Double): BigDecimal = value.toBigDecimal()
 
   @JvmStatic
   @TypeConverter

--- a/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
@@ -16,6 +16,8 @@
 
 package com.google.android.fhir.search
 
+import ca.uhn.fhir.rest.gclient.NumberClientParam
+import ca.uhn.fhir.rest.gclient.StringClientParam
 import com.google.android.fhir.db.Database
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
@@ -28,16 +30,22 @@ fun Search.getQuery(): SearchQuery {
   var sortJoinStatement = ""
   var sortOrderStatement = ""
   val sortArgs = mutableListOf<Any>()
-  if (sort != null) {
+  sort?.let { sort ->
+    val sortTableName =
+      when (sort) {
+        is StringClientParam -> "StringIndexEntity"
+        is NumberClientParam -> "NumberIndexEntity"
+        else -> error("Unhandled sort parameter of type ${sort::class}: $sort")
+      }
     sortJoinStatement =
       """
-      LEFT JOIN StringIndexEntity b
+      LEFT JOIN $sortTableName b
       ON a.resourceType = b.resourceType AND a.resourceId = b.resourceId AND b.index_name = ?
       """.trimIndent()
     sortOrderStatement = """
       ORDER BY b.index_value ${order.sqlString}
       """.trimIndent()
-    sortArgs += sort!!.paramName
+    sortArgs += sort.paramName
   }
 
   var filterStatement = ""

--- a/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
@@ -35,7 +35,7 @@ fun Search.getQuery(): SearchQuery {
       when (sort) {
         is StringClientParam -> "StringIndexEntity"
         is NumberClientParam -> "NumberIndexEntity"
-        else -> error("Unhandled sort parameter of type ${sort::class}: $sort")
+        else -> throw NotImplementedError("Unhandled sort parameter of type ${sort::class}: $sort")
       }
     sortJoinStatement =
       """

--- a/engine/src/main/java/com/google/android/fhir/search/SearchDsl.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/SearchDsl.kt
@@ -16,6 +16,8 @@
 
 package com.google.android.fhir.search
 
+import ca.uhn.fhir.rest.gclient.IParam
+import ca.uhn.fhir.rest.gclient.NumberClientParam
 import ca.uhn.fhir.rest.gclient.ReferenceClientParam
 import ca.uhn.fhir.rest.gclient.StringClientParam
 import ca.uhn.fhir.rest.param.ParamPrefixEnum
@@ -25,7 +27,7 @@ import org.hl7.fhir.r4.model.ResourceType
 data class Search(val type: ResourceType, var count: Int? = null, var from: Int? = null) {
   internal val stringFilters = mutableListOf<StringFilter>()
   internal val referenceFilter = mutableListOf<ReferenceFilter>()
-  internal var sort: StringClientParam? = null
+  internal var sort: IParam? = null
   internal var order: Order? = null
 
   fun filter(stringParameter: StringClientParam, init: StringFilter.() -> Unit) {
@@ -41,6 +43,11 @@ data class Search(val type: ResourceType, var count: Int? = null, var from: Int?
   }
 
   fun sort(parameter: StringClientParam, order: Order) {
+    sort = parameter
+    this.order = order
+  }
+
+  fun sort(parameter: NumberClientParam, order: Order) {
     sort = parameter
     this.order = order
   }

--- a/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
@@ -22,6 +22,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.ResourceType
+import org.hl7.fhir.r4.model.RiskAssessment
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -120,7 +121,7 @@ class SearchTest {
   }
 
   @Test
-  fun search_sort_ascending() {
+  fun search_sort_string_ascending() {
     val query =
       Search(ResourceType.Patient).apply { sort(Patient.GIVEN, Order.ASCENDING) }.getQuery()
 
@@ -139,7 +140,7 @@ class SearchTest {
   }
 
   @Test
-  fun search_sort_descending() {
+  fun search_sort_string_descending() {
     val query =
       Search(ResourceType.Patient).apply { sort(Patient.GIVEN, Order.DESCENDING) }.getQuery()
 
@@ -155,6 +156,26 @@ class SearchTest {
         """.trimIndent()
       )
     assertThat(query.args).isEqualTo(listOf(Patient.GIVEN.paramName, ResourceType.Patient.name))
+  }
+
+  @Test
+  fun search_sort_numbers_ascending() {
+    val query =
+      Search(ResourceType.RiskAssessment)
+        .apply { sort(RiskAssessment.PROBABILITY, Order.ASCENDING) }
+        .getQuery()
+
+    assertThat(query.query)
+      .isEqualTo(
+        """
+      SELECT a.serializedResource
+      FROM ResourceEntity a
+      LEFT JOIN NumberIndexEntity b
+      ON a.resourceType = b.resourceType AND a.resourceId = b.resourceId AND b.index_name = ?
+      WHERE a.resourceType = ?
+      ORDER BY b.index_value ASC
+      """.trimIndent()
+      )
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #283  

**Description**
- Adds `sort` overload for `NumberClientParam`
- Changes DB `TypeConverter` for `BigDecimal` from `String` to `Double`
- Adds unit test in `SearchTest` to verify output SQL
- Adds integration test in `DatabaseImplTest` to verify ordering when querying the DB

**Alternative(s) considered**
See discussion on #283 for pros and cons of using `Double` instead of using 2 columns for precision + unsigned value.

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
