### PR TITLE
Radio group bug fix

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
@@ -48,10 +48,11 @@ internal object QuestionnaireItemRadioGroupViewHolderFactory :
         } else {
           prefixTextView.visibility = View.GONE
         }
-        val (questionnaireItem, questionnaireResponseItem) = questionnaireItemViewItem
+        val (questionnaireItem, questionnaireResponseItem) = this.questionnaireItemViewItem
         val answer = questionnaireResponseItem.answer.singleOrNull()?.valueCoding
         radioHeader.text = questionnaireItem.text
         radioGroup.removeAllViews()
+        radioGroup.setOnCheckedChangeListener(null)
         var index = 0
         questionnaireItem.answerOption.forEach {
           radioGroup.addView(
@@ -67,12 +68,13 @@ internal object QuestionnaireItemRadioGroupViewHolderFactory :
             }
           )
         }
-        radioGroup.setOnCheckedChangeListener { _, checkedId ->
+
+        radioGroup.setOnCheckedChangeListener { group, checkedId ->
           // if-else block to prevent over-writing of "items" nested within "answer"
+
           if (questionnaireResponseItem.answer.size > 0) {
-            val tmpItems = questionnaireResponseItem.answer.first().item
-            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              value = questionnaireItem.answerOption[checkedId].value
+            questionnaireResponseItem.answer.apply {
+              this[0].value = questionnaireItem.answerOption[checkedId].value
             }
           } else {
             questionnaireResponseItem.answer.apply {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
@@ -48,7 +48,7 @@ internal object QuestionnaireItemRadioGroupViewHolderFactory :
         } else {
           prefixTextView.visibility = View.GONE
         }
-        val (questionnaireItem, questionnaireResponseItem) = this.questionnaireItemViewItem
+        val (questionnaireItem, questionnaireResponseItem) = questionnaireItemViewItem
         val answer = questionnaireResponseItem.answer.singleOrNull()?.valueCoding
         radioHeader.text = questionnaireItem.text
         radioGroup.removeAllViews()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #455

**Description**
In the `QuestionnaireItemRadioGroupViewHolderFactory` there were two bugs:

1. After the initial selection of the answer, if the user selects a different answer, the change was reflected in the UI but was not reflected in the questionnaireResponseItem. Fixed bug by setting the current answer to the new selected answer
2. When there are more than 1 radio groups in the questionnaire the OnCheckedChangeListener was not being set to null with `radioGroup.removeAllViews()` . This caused the listener to receive a stale value of the questionnaireResponseItem. You can reproduce this by following the instructions in #455 

**Alternative(s) considered**
I selected this method, not sure if there are other ways to remove the stale listener from the radio group. 

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)
Bug Fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
