### PR TITLE
Added extenstions for Address and HumanName models to express them as ..

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/Util.kt
+++ b/engine/src/main/java/com/google/android/fhir/Util.kt
@@ -21,6 +21,8 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
+import org.hl7.fhir.r4.model.Address
+import org.hl7.fhir.r4.model.HumanName
 import org.hl7.fhir.r4.model.OperationOutcome
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
@@ -55,4 +57,45 @@ fun Resource.isUploadSuccess(): Boolean {
   val outcome: OperationOutcome = this as OperationOutcome
   return outcome.issue.isNotEmpty() &&
     outcome.issue.all { it.severity.equals(OperationOutcome.IssueSeverity.INFORMATION) }
+}
+
+/**
+ * Extension to expresses [HumanName]  as a separated string using [separator].
+ *  See https://www.hl7.org/fhir/patient.html#search
+ */
+fun HumanName.asString(separator: CharSequence = ", "): String {
+  return listOfNotNull(
+      prefix?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
+        it.valueNotNull
+      },
+      given?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
+        it.valueNotNull
+      },
+      family,
+      suffix?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
+        it.valueNotNull
+      },
+      text
+    )
+    .filter { it.isNotBlank() }
+    .joinToString(separator)
+}
+/**
+ * Extension to expresses [Address]  as a string using [separator].
+ * See https://www.hl7.org/fhir/patient.html#search
+ */
+fun Address.asString(separator: CharSequence = ", "): String {
+  return listOfNotNull(
+      line?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
+        it.valueNotNull
+      },
+      city,
+      district,
+      state,
+      country,
+      postalCode,
+      text
+    )
+    .filter { it.isNotBlank() }
+    .joinToString(separator)
 }

--- a/engine/src/main/java/com/google/android/fhir/Util.kt
+++ b/engine/src/main/java/com/google/android/fhir/Util.kt
@@ -60,8 +60,8 @@ fun Resource.isUploadSuccess(): Boolean {
 }
 
 /**
- * Extension to expresses [HumanName]  as a separated string using [separator].
- *  See https://www.hl7.org/fhir/patient.html#search
+ * Extension to expresses [HumanName] as a separated string using [separator]. See
+ * https://www.hl7.org/fhir/patient.html#search
  */
 fun HumanName.asString(separator: CharSequence = ", "): String {
   return listOfNotNull(
@@ -81,8 +81,8 @@ fun HumanName.asString(separator: CharSequence = ", "): String {
     .joinToString(separator)
 }
 /**
- * Extension to expresses [Address]  as a string using [separator].
- * See https://www.hl7.org/fhir/patient.html#search
+ * Extension to expresses [Address] as a string using [separator]. See
+ * https://www.hl7.org/fhir/patient.html#search
  */
 fun Address.asString(separator: CharSequence = ", "): String {
   return listOfNotNull(

--- a/engine/src/main/java/com/google/android/fhir/Util.kt
+++ b/engine/src/main/java/com/google/android/fhir/Util.kt
@@ -21,8 +21,6 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
-import org.hl7.fhir.r4.model.Address
-import org.hl7.fhir.r4.model.HumanName
 import org.hl7.fhir.r4.model.OperationOutcome
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
@@ -57,45 +55,4 @@ fun Resource.isUploadSuccess(): Boolean {
   val outcome: OperationOutcome = this as OperationOutcome
   return outcome.issue.isNotEmpty() &&
     outcome.issue.all { it.severity.equals(OperationOutcome.IssueSeverity.INFORMATION) }
-}
-
-/**
- * Extension to expresses [HumanName] as a separated string using [separator]. See
- * https://www.hl7.org/fhir/patient.html#search
- */
-fun HumanName.asString(separator: CharSequence = ", "): String {
-  return listOfNotNull(
-      prefix?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
-        it.valueNotNull
-      },
-      given?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
-        it.valueNotNull
-      },
-      family,
-      suffix?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
-        it.valueNotNull
-      },
-      text
-    )
-    .filter { it.isNotBlank() }
-    .joinToString(separator)
-}
-/**
- * Extension to expresses [Address] as a string using [separator]. See
- * https://www.hl7.org/fhir/patient.html#search
- */
-fun Address.asString(separator: CharSequence = ", "): String {
-  return listOfNotNull(
-      line?.filter { it.value.isNotBlank() }?.joinToString(separator = separator) {
-        it.valueNotNull
-      },
-      city,
-      district,
-      state,
-      country,
-      postalCode,
-      text
-    )
-    .filter { it.isNotBlank() }
-    .joinToString(separator)
 }

--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -19,6 +19,7 @@ package com.google.android.fhir.index
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.support.DefaultProfileValidationSupport
 import ca.uhn.fhir.model.api.annotation.SearchParamDefinition
+import com.google.android.fhir.asString
 import com.google.android.fhir.index.entities.DateIndex
 import com.google.android.fhir.index.entities.NumberIndex
 import com.google.android.fhir.index.entities.PositionIndex
@@ -30,11 +31,13 @@ import com.google.android.fhir.index.entities.UriIndex
 import com.google.android.fhir.logicalId
 import java.math.BigDecimal
 import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext
+import org.hl7.fhir.r4.model.Address
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.DateType
 import org.hl7.fhir.r4.model.DecimalType
+import org.hl7.fhir.r4.model.HumanName
 import org.hl7.fhir.r4.model.Identifier
 import org.hl7.fhir.r4.model.InstantType
 import org.hl7.fhir.r4.model.IntegerType
@@ -164,7 +167,11 @@ internal object ResourceIndexer {
 
   private fun stringIndex(searchParam: SearchParamDefinition, value: Base): StringIndex? =
     if (!value.isEmpty) {
-      StringIndex(searchParam.name, searchParam.path, value.toString())
+      when (value) {
+        is HumanName -> StringIndex(searchParam.name, searchParam.path, value.asString())
+        is Address -> StringIndex(searchParam.name, searchParam.path, value.asString())
+        else -> StringIndex(searchParam.name, searchParam.path, value.toString())
+      }
     } else {
       null
     }

--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -169,38 +169,29 @@ internal object ResourceIndexer {
    * https://www.hl7.org/fhir/patient.html#search
    */
   private fun HumanName.asString(separator: CharSequence = " "): String {
-    return listOfNotNull(
-        prefix
-          ?.filter { it != null && !it.value.isNullOrBlank() }
-          ?.joinToString(separator = separator),
-        given
-          ?.filter { it != null && !it.value.isNullOrBlank() }
-          ?.joinToString(separator = separator),
-        family,
-        suffix
-          ?.filter { it != null && !it.value.isNullOrBlank() }
-          ?.joinToString(separator = separator),
-        text
-      )
+    return (prefix.filterNotNull().map { it.value } +
+        given.filterNotNull().map { it.value } +
+        family +
+        suffix.filterNotNull().map { it.value } +
+        text)
+      .filterNotNull()
       .filter { it.isNotBlank() }
       .joinToString(separator)
   }
+
   /**
    * Extension to expresses [Address] as a string using [separator]. See
    * https://www.hl7.org/fhir/patient.html#search
    */
   private fun Address.asString(separator: CharSequence = ", "): String {
-    return listOfNotNull(
-        line
-          ?.filter { it != null && !it.value.isNullOrBlank() }
-          ?.joinToString(separator = separator),
-        city,
-        district,
-        state,
-        country,
-        postalCode,
-        text
-      )
+    return (line.filterNotNull().map { it.value } +
+        city +
+        district +
+        state +
+        country +
+        postalCode +
+        text)
+      .filterNotNull()
       .filter { it.isNotBlank() }
       .joinToString(separator)
   }

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -18,6 +18,7 @@ package com.google.android.fhir.index
 
 import android.os.Build
 import ca.uhn.fhir.context.FhirContext
+import com.google.android.fhir.asString
 import com.google.android.fhir.index.entities.DateIndex
 import com.google.android.fhir.index.entities.NumberIndex
 import com.google.android.fhir.index.entities.PositionIndex
@@ -832,7 +833,7 @@ class ResourceIndexerTest {
     assertThat(resourceIndices.stringIndices)
       .containsExactly(
         StringIndex("given", "Patient.name.given", testPatient.nameFirstRep.givenAsSingleString),
-        StringIndex("address", "Patient.address", testPatient.addressFirstRep.toString()),
+        StringIndex("address", "Patient.address", testPatient.addressFirstRep.asString()),
         StringIndex(
           "address-postalcode",
           "Patient.address.postalCode",
@@ -843,8 +844,8 @@ class ResourceIndexerTest {
           "Patient.address.country",
           testPatient.addressFirstRep.country
         ),
-        StringIndex("phonetic", "Patient.name", testPatient.nameFirstRep.toString()),
-        StringIndex("name", "Patient.name", testPatient.nameFirstRep.toString()),
+        StringIndex("phonetic", "Patient.name", testPatient.nameFirstRep.asString()),
+        StringIndex("name", "Patient.name", testPatient.nameFirstRep.asString()),
         StringIndex("family", "Patient.name.family", testPatient.nameFirstRep.family),
         StringIndex("address-city", "Patient.address.city", testPatient.addressFirstRep.city)
       )
@@ -888,7 +889,7 @@ class ResourceIndexerTest {
 
     assertThat(resourceIndices.stringIndices)
       .containsExactly(
-        StringIndex("address", "Location.address", testLocation.address.toString()),
+        StringIndex("address", "Location.address", testLocation.address.asString()),
         StringIndex("address-state", "Location.address.state", testLocation.address.state),
         StringIndex(
           "address-postalcode",

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -930,7 +930,7 @@ class ResourceIndexerTest {
   }
 
   @Test
-  fun index_string_humanName_null_shouldNotIndexHumanName() {
+  fun index_string_humanName_nullValues_shouldNotIndexHumanName() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -943,7 +943,7 @@ class ResourceIndexerTest {
   }
 
   @Test
-  fun index_string_humanName_empty_shouldNotIndexHumanName() {
+  fun index_string_humanName_emptyValues_shouldNotIndexHumanName() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -970,12 +970,26 @@ class ResourceIndexerTest {
         addName(
           HumanName().apply {
             prefix =
-              listOf(null, StringType(null), StringType(""), StringType(" "), StringType("Mr."))
+              listOf(
+                null,
+                StringType(null),
+                StringType(""),
+                StringType(" "),
+                StringType("Prof."),
+                StringType("Dr.")
+              )
             given =
               listOf(null, StringType(null), StringType(""), StringType(" "), StringType("Pieter"))
             family = "van de Heuvel"
             suffix =
-              listOf(null, StringType(null), StringType(""), StringType(" "), StringType("MSc"))
+              listOf(
+                null,
+                StringType(null),
+                StringType(""),
+                StringType(" "),
+                StringType("MSc"),
+                StringType("Phd")
+              )
           }
         )
       }
@@ -983,118 +997,8 @@ class ResourceIndexerTest {
     val resourceIndices = ResourceIndexer.index(patient)
     assertThat(resourceIndices.stringIndices)
       .containsAtLeast(
-        StringIndex("name", "Patient.name", "Mr. Pieter van de Heuvel MSc"),
-        StringIndex("phonetic", "Patient.name", "Mr. Pieter van de Heuvel MSc")
-      )
-  }
-
-  @Test
-  fun index_string_humanName_null_prefix() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            given = listOf(StringType("Pieter"))
-            family = "van de Heuvel"
-            suffix = listOf(StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", "Pieter van de Heuvel MSc"),
-        StringIndex("phonetic", "Patient.name", "Pieter van de Heuvel MSc")
-      )
-  }
-
-  @Test
-  fun index_string_humanName_null_given() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            prefix = listOf(StringType("Mr."))
-            family = "van de Heuvel"
-            suffix = listOf(StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", "Mr. van de Heuvel MSc"),
-        StringIndex("phonetic", "Patient.name", "Mr. van de Heuvel MSc")
-      )
-  }
-
-  fun index_string_humanName_null_family() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            prefix = listOf(StringType("Mr."))
-            given = listOf(StringType("Pieter"))
-            suffix = listOf(StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", "Mr. Pieter MSc"),
-        StringIndex("phonetic", "Patient.name", "Mr. Pieter MSc")
-      )
-  }
-
-  @Test
-  fun index_string_humanName_empty_family() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            prefix = listOf(StringType("Mr."))
-            given = listOf(StringType("Pieter"))
-            family = ""
-            suffix = listOf(StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", "Mr. Pieter MSc"),
-        StringIndex("phonetic", "Patient.name", "Mr. Pieter MSc")
-      )
-  }
-
-  @Test
-  fun index_string_humanName_null_suffix() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            prefix = listOf(StringType("Mr."))
-            given = listOf(StringType("Pieter"))
-            family = "van de Heuvel"
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", "Mr. Pieter van de Heuvel"),
-        StringIndex("phonetic", "Patient.name", "Mr. Pieter van de Heuvel")
+        StringIndex("name", "Patient.name", "Prof. Dr. Pieter van de Heuvel MSc Phd"),
+        StringIndex("phonetic", "Patient.name", "Prof. Dr. Pieter van de Heuvel MSc Phd")
       )
   }
 
@@ -1127,7 +1031,7 @@ class ResourceIndexerTest {
   }
 
   @Test
-  fun index_string_address_null_shouldNotIndexAddress() {
+  fun index_string_address_nullValues_shouldNotIndexAddress() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1139,7 +1043,7 @@ class ResourceIndexerTest {
   }
 
   @Test
-  fun index_string_address_empty_shouldNotIndexAddress() {
+  fun index_string_address_emptyValues_shouldNotIndexAddress() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1157,250 +1061,6 @@ class ResourceIndexerTest {
 
     val resourceIndices = ResourceIndexer.index(patient)
     assertThat(resourceIndices.stringIndices.any { it.name == "address" }).isFalse()
-  }
-
-  @Test
-  fun index_string_address_null_line() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType(null))
-              district = "Amsterdam"
-              city = "Amsterdam"
-              postalCode = "1024 RJ"
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", "Amsterdam, Amsterdam, NLD, 1024 RJ"))
-  }
-
-  @Test
-  fun index_string_address_null_city() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = "Amsterdam"
-              city = null
-              postalCode = "1024 RJ"
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
-      )
-  }
-
-  @Test
-  fun index_string_address_null_district() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = null
-              city = "Amsterdam"
-              postalCode = "1024 RJ"
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
-      )
-  }
-
-  @Test
-  fun index_string_address_null_country() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = "Amsterdam"
-              city = "Amsterdam"
-              postalCode = "1024 RJ"
-              country = null
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex(
-          "address",
-          "Patient.address",
-          "Van Egmondkade 23, Amsterdam, Amsterdam, 1024 RJ"
-        )
-      )
-  }
-
-  @Test
-  fun index_string_address_null_postalCode() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = "Amsterdam"
-              city = "Amsterdam"
-              postalCode = null
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, Amsterdam, NLD")
-      )
-  }
-
-  @Test
-  fun index_string_address_empty_line() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType(""))
-              district = "Amsterdam"
-              city = "Amsterdam"
-              postalCode = "1024 RJ"
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", "Amsterdam, Amsterdam, NLD, 1024 RJ"))
-  }
-
-  @Test
-  fun index_string_address_empty_city() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = "Amsterdam"
-              city = ""
-              postalCode = "1024 RJ"
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
-      )
-  }
-
-  @Test
-  fun index_string_address_empty_district() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = ""
-              city = "Amsterdam"
-              postalCode = "1024 RJ"
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
-      )
-  }
-
-  @Test
-  fun index_string_address_empty_country() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = "Amsterdam"
-              city = "Amsterdam"
-              postalCode = "1024 RJ"
-              country = ""
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex(
-          "address",
-          "Patient.address",
-          "Van Egmondkade 23, Amsterdam, Amsterdam, 1024 RJ"
-        )
-      )
-  }
-
-  @Test
-  fun index_string_address_empty_postalCode() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        address =
-          listOf(
-            Address().apply {
-              line = listOf(StringType("Van Egmondkade 23"))
-              district = "Amsterdam"
-              city = "Amsterdam"
-              postalCode = ""
-              country = "NLD"
-            }
-          )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    assertThat(resourceIndices.stringIndices)
-      .contains(
-        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, Amsterdam, NLD")
-      )
   }
 
   private companion object {

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -907,7 +907,7 @@ class ResourceIndexerTest {
   }
 
   @Test
-  fun index_string_humanname() {
+  fun index_string_humanName() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -922,33 +922,28 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter van de Heuvel MSc"
     assertThat(resourceIndices.stringIndices)
       .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
+        StringIndex("name", "Patient.name", "Mr. Pieter van de Heuvel MSc"),
+        StringIndex("phonetic", "Patient.name", "Mr. Pieter van de Heuvel MSc")
       )
   }
 
   @Test
-  fun index_string_humanname_all_null() {
+  fun index_string_humanName_null_shouldNotIndexHumanName() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
-        addName(HumanName().apply {})
+        addName(HumanName())
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter van de Heuvel MSc"
-    assertThat(resourceIndices.stringIndices)
-      .containsNoneOf(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
-      )
+    assertThat(resourceIndices.stringIndices.any { it.name == "name" }).isFalse()
+    assertThat(resourceIndices.stringIndices.any { it.name == "phonetic" }).isFalse()
   }
 
   @Test
-  fun index_string_humanname_all_empty() {
+  fun index_string_humanName_empty_shouldNotIndexHumanName() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -963,39 +958,12 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter van de Heuvel MSc"
-    assertThat(resourceIndices.stringIndices)
-      .containsNoneOf(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
-      )
+    assertThat(resourceIndices.stringIndices.any { it.path == "name" }).isFalse()
+    assertThat(resourceIndices.stringIndices.any { it.name == "phonetic" }).isFalse()
   }
 
   @Test
-  fun index_string_humanname_null_prefix() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            given = listOf(StringType("Pieter"))
-            family = "van de Heuvel"
-            suffix = listOf(StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Pieter van de Heuvel MSc"
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
-      )
-  }
-
-  @Test
-  fun index_string_humanname_multiple_prefix() {
+  fun index_string_humanName_multipleListValues() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1003,71 +971,68 @@ class ResourceIndexerTest {
           HumanName().apply {
             prefix =
               listOf(null, StringType(null), StringType(""), StringType(" "), StringType("Mr."))
-            given = listOf(StringType("Pieter"))
-            family = "van de Heuvel"
-            suffix = listOf(StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter van de Heuvel MSc"
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
-      )
-  }
-
-  @Test
-  fun index_string_humanname_null_given() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            prefix = listOf(StringType("Mr."))
-            family = "van de Heuvel"
-            suffix = listOf(StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. van de Heuvel MSc"
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
-      )
-  }
-
-  @Test
-  fun index_string_humanname_multiple_given() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            prefix = listOf(StringType("Mr."))
             given =
               listOf(null, StringType(null), StringType(""), StringType(" "), StringType("Pieter"))
             family = "van de Heuvel"
+            suffix =
+              listOf(null, StringType(null), StringType(""), StringType(" "), StringType("MSc"))
+          }
+        )
+      }
+
+    val resourceIndices = ResourceIndexer.index(patient)
+    assertThat(resourceIndices.stringIndices)
+      .containsAtLeast(
+        StringIndex("name", "Patient.name", "Mr. Pieter van de Heuvel MSc"),
+        StringIndex("phonetic", "Patient.name", "Mr. Pieter van de Heuvel MSc")
+      )
+  }
+
+  @Test
+  fun index_string_humanName_null_prefix() {
+    val patient =
+      Patient().apply {
+        id = "non-null-ID"
+        addName(
+          HumanName().apply {
+            given = listOf(StringType("Pieter"))
+            family = "van de Heuvel"
             suffix = listOf(StringType("MSc"))
           }
         )
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter van de Heuvel MSc"
     assertThat(resourceIndices.stringIndices)
       .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
+        StringIndex("name", "Patient.name", "Pieter van de Heuvel MSc"),
+        StringIndex("phonetic", "Patient.name", "Pieter van de Heuvel MSc")
       )
   }
 
-  fun index_string_humanname_null_family() {
+  @Test
+  fun index_string_humanName_null_given() {
+    val patient =
+      Patient().apply {
+        id = "non-null-ID"
+        addName(
+          HumanName().apply {
+            prefix = listOf(StringType("Mr."))
+            family = "van de Heuvel"
+            suffix = listOf(StringType("MSc"))
+          }
+        )
+      }
+
+    val resourceIndices = ResourceIndexer.index(patient)
+    assertThat(resourceIndices.stringIndices)
+      .containsAtLeast(
+        StringIndex("name", "Patient.name", "Mr. van de Heuvel MSc"),
+        StringIndex("phonetic", "Patient.name", "Mr. van de Heuvel MSc")
+      )
+  }
+
+  fun index_string_humanName_null_family() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1081,16 +1046,15 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter MSc"
     assertThat(resourceIndices.stringIndices)
       .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
+        StringIndex("name", "Patient.name", "Mr. Pieter MSc"),
+        StringIndex("phonetic", "Patient.name", "Mr. Pieter MSc")
       )
   }
 
   @Test
-  fun index_string_humanname_empty_family() {
+  fun index_string_humanName_empty_family() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1105,16 +1069,15 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter MSc"
     assertThat(resourceIndices.stringIndices)
       .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
+        StringIndex("name", "Patient.name", "Mr. Pieter MSc"),
+        StringIndex("phonetic", "Patient.name", "Mr. Pieter MSc")
       )
   }
 
   @Test
-  fun index_string_humanname_null_suffix() {
+  fun index_string_humanName_null_suffix() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1128,36 +1091,10 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter van de Heuvel"
     assertThat(resourceIndices.stringIndices)
       .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
-      )
-  }
-
-  @Test
-  fun index_string_humanname_multiple_suffix() {
-    val patient =
-      Patient().apply {
-        id = "non-null-ID"
-        addName(
-          HumanName().apply {
-            prefix = listOf(StringType("Mr."))
-            given = listOf(StringType("Pieter"))
-            family = "van de Heuvel"
-            suffix =
-              listOf(null, StringType(null), StringType(""), StringType(" "), StringType("MSc"))
-          }
-        )
-      }
-
-    val resourceIndices = ResourceIndexer.index(patient)
-    val patientName = "Mr. Pieter van de Heuvel MSc"
-    assertThat(resourceIndices.stringIndices)
-      .containsAtLeast(
-        StringIndex("name", "Patient.name", patientName),
-        StringIndex("phonetic", "Patient.name", patientName)
+        StringIndex("name", "Patient.name", "Mr. Pieter van de Heuvel"),
+        StringIndex("phonetic", "Patient.name", "Mr. Pieter van de Heuvel")
       )
   }
 
@@ -1179,13 +1116,18 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, Amsterdam, NLD, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex(
+          "address",
+          "Patient.address",
+          "Van Egmondkade 23, Amsterdam, Amsterdam, NLD, 1024 RJ"
+        )
+      )
   }
 
   @Test
-  fun index_string_null_address() {
+  fun index_string_address_null_shouldNotIndexAddress() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1197,7 +1139,7 @@ class ResourceIndexerTest {
   }
 
   @Test
-  fun index_string_empty_address() {
+  fun index_string_address_empty_shouldNotIndexAddress() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1235,9 +1177,8 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Amsterdam, Amsterdam, NLD, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(StringIndex("address", "Patient.address", "Amsterdam, Amsterdam, NLD, 1024 RJ"))
   }
 
   @Test
@@ -1258,9 +1199,10 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
+      )
   }
 
   @Test
@@ -1281,9 +1223,10 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
+      )
   }
 
   @Test
@@ -1304,13 +1247,18 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, Amsterdam, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex(
+          "address",
+          "Patient.address",
+          "Van Egmondkade 23, Amsterdam, Amsterdam, 1024 RJ"
+        )
+      )
   }
 
   @Test
-  fun index_string_address_null_postalcode() {
+  fun index_string_address_null_postalCode() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1327,9 +1275,10 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, Amsterdam, NLD"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, Amsterdam, NLD")
+      )
   }
 
   @Test
@@ -1350,9 +1299,8 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Amsterdam, Amsterdam, NLD, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(StringIndex("address", "Patient.address", "Amsterdam, Amsterdam, NLD, 1024 RJ"))
   }
 
   @Test
@@ -1373,9 +1321,10 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
+      )
   }
 
   @Test
@@ -1396,9 +1345,10 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, NLD, 1024 RJ")
+      )
   }
 
   @Test
@@ -1419,13 +1369,18 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, Amsterdam, 1024 RJ"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex(
+          "address",
+          "Patient.address",
+          "Van Egmondkade 23, Amsterdam, Amsterdam, 1024 RJ"
+        )
+      )
   }
 
   @Test
-  fun index_string_address_empty_postalcode() {
+  fun index_string_address_empty_postalCode() {
     val patient =
       Patient().apply {
         id = "non-null-ID"
@@ -1442,9 +1397,10 @@ class ResourceIndexerTest {
       }
 
     val resourceIndices = ResourceIndexer.index(patient)
-    val patientAddress = "Van Egmondkade 23, Amsterdam, Amsterdam, NLD"
     assertThat(resourceIndices.stringIndices)
-      .contains(StringIndex("address", "Patient.address", patientAddress))
+      .contains(
+        StringIndex("address", "Patient.address", "Van Egmondkade 23, Amsterdam, Amsterdam, NLD")
+      )
   }
 
   private companion object {


### PR DESCRIPTION
… a string value #450

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #450

**Description**
The issue was related to the default toString() implementation of Address and HumanName model classes in hl7.fhir library.
The approach I have used is to provide asString() extension function for the classes and generate a default comma-separated  string as output.

**Alternative(s) considered**
N.A

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
