### PR TITLE
Fixed crash caused by configuration changes

### DIFF
--- a/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireContainerFragment.kt
+++ b/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireContainerFragment.kt
@@ -54,11 +54,9 @@ class QuestionnaireContainerFragment : Fragment() {
   ): View? {
     super.onCreate(savedInstanceState)
     _binding = FragmentQuestionnaireContainerBinding.inflate(inflater, container, false)
-    arguments?.putString(QUESTIONNAIRE_FILE_PATH_KEY, args.questionnaireFilePathKey)
-    arguments?.putString(
-      QUESTIONNAIRE_RESPONSE_FILE_PATH_KEY,
-      args.questionnaireResponseFilePathKey
-    )
+    requireArguments().putString(QUESTIONNAIRE_FILE_PATH_KEY, args.questionnaireFilePathKey)
+    requireArguments()
+      .putString(QUESTIONNAIRE_RESPONSE_FILE_PATH_KEY, args.questionnaireResponseFilePathKey)
 
     (requireActivity() as AppCompatActivity).supportActionBar?.apply {
       title = args.questionnaireTitleKey

--- a/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireContainerFragment.kt
+++ b/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/QuestionnaireContainerFragment.kt
@@ -54,11 +54,12 @@ class QuestionnaireContainerFragment : Fragment() {
   ): View? {
     super.onCreate(savedInstanceState)
     _binding = FragmentQuestionnaireContainerBinding.inflate(inflater, container, false)
-    arguments =
-      bundleOf(
-        QUESTIONNAIRE_FILE_PATH_KEY to args.questionnaireFilePathKey,
-        QUESTIONNAIRE_RESPONSE_FILE_PATH_KEY to args.questionnaireResponseFilePathKey
-      )
+    arguments?.putString(QUESTIONNAIRE_FILE_PATH_KEY, args.questionnaireFilePathKey)
+    arguments?.putString(
+      QUESTIONNAIRE_RESPONSE_FILE_PATH_KEY,
+      args.questionnaireResponseFilePathKey
+    )
+
     (requireActivity() as AppCompatActivity).supportActionBar?.apply {
       title = args.questionnaireTitleKey
       setDisplayHomeAsUpEnabled(true)


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #477

**Description**
Data Capture Gallery App crashes when device configuration changes (eg: language is changed and user comes back to the app or Orientation is changed) while user is on Questionnaire Fragment.

**Alternative(s) considered**
The code was replacing the QuestionnaireContainerFragment#arguments with a new Bundle. This caused issue after QuestionnaireContainerFragment#arguments was recreated because of orientation / language change as the navagrs now couldn't get the same data from Bundle as the keys were not there anymore.
Fixing this issue by adding data QuestionnaireContainerFragment#arguments Bundle instead of replacing it with a new one.

**Type**
Choose one: Bug fix 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
