### PR TITLE
Update Spotless + ktlint to latest versions

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,5 +9,5 @@ repositories {
 }
 
 dependencies {
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:5.11.0")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:5.12.5")
 }

--- a/buildSrc/src/main/kotlin/SpotlessConfig.kt
+++ b/buildSrc/src/main/kotlin/SpotlessConfig.kt
@@ -19,12 +19,14 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 
 fun Project.configureSpotless() {
+  val ktlintVersion = "0.41.0"
+  val ktlintOptions = mapOf("indent_size" to "2", "continuation_indent_size" to "2")
   apply(plugin = Plugins.BuildPlugins.spotless)
   configure<com.diffplug.gradle.spotless.SpotlessExtension> {
     kotlin {
       target("**/*.kt")
       targetExclude("**/build/")
-      ktlint().userData(mapOf("indent_size" to "2", "continuation_indent_size" to "2"))
+      ktlint(ktlintVersion).userData(ktlintOptions)
       ktfmt().googleStyle()
       licenseHeaderFile(
         "${project.rootProject.projectDir}/license-header.txt",
@@ -35,7 +37,7 @@ fun Project.configureSpotless() {
     }
     kotlinGradle {
       target("*.gradle.kts")
-      ktlint().userData(mapOf("indent_size" to "2", "continuation_indent_size" to "2"))
+      ktlint(ktlintVersion).userData(ktlintOptions)
       ktfmt().googleStyle()
     }
     format("xml") {

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/mapping/ResourceMapperTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/mapping/ResourceMapperTest.kt
@@ -295,7 +295,7 @@ class ResourceMapperTest {
             }
           ]
         }
-        """.trimIndent()
+      """.trimIndent()
 
     val questionnaireResponseJson =
       """
@@ -419,7 +419,7 @@ class ResourceMapperTest {
             }
           ]
         }
-        """.trimIndent()
+      """.trimIndent()
 
     val iParser: IParser = FhirContext.forR4().newJsonParser()
 
@@ -673,7 +673,7 @@ class ResourceMapperTest {
             }
           ]
         }
-        """.trimIndent()
+      """.trimIndent()
 
     val iParser: IParser = FhirContext.forR4().newJsonParser()
 

--- a/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
@@ -44,7 +44,7 @@ fun Search.getQuery(): SearchQuery {
       """.trimIndent()
     sortOrderStatement = """
       ORDER BY b.index_value ${order.sqlString}
-      """.trimIndent()
+    """.trimIndent()
     sortArgs += sort.paramName
   }
 

--- a/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
@@ -260,7 +260,7 @@ class SearchTest {
       ON a.resourceType = b.resourceType AND a.resourceId = b.resourceId AND b.index_name = ?
       WHERE a.resourceType = ?
       ORDER BY b.index_value ASC
-      """.trimIndent()
+        """.trimIndent()
       )
   }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Updates Spotless and ktlint, and re-runs ktlint.

ktlint had a [bug](https://github.com/pinterest/ktlint/issues/729) that results in a cryptic error when attempting to use trailing commas (a valid Kotlin 1.4 feature). Updated ktlint to the latest version. Updated Spotless as well, and ran `spotlessApply` to apply the updated ktlint rules.

**Type**
Choose one: Code health

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
