### PR TITLE
Enable coverage on debug builds and upload to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,19 +89,22 @@ jobs:
       if: matrix.api-level == 29  # don't spotless on older APIs
       run: ./gradlew spotlessCheck
 
-    - name: Build with Gradle
-      if: matrix.api-level == 29 # don't run full build on older APIs
+    - name: Build and Run Integrations tests
+      if: matrix.api-level == 29 # On Api 29 - build and run in a single step
       uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86_64
-          script: ./gradlew build --info
+      with:
+        api-level: ${{ matrix.api-level }}
+        arch: x86_64
+        script: ./gradlew build connectedCheck --info
+
     - name: Run Integration Tests
+      if: matrix.api-level != 29 # don't run tests again on API 29
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
         arch: x86_64
         script: ./gradlew connectedCheck --info
+
     - name: Code coverage (via codecov.io)
       run: bash <(curl -s https://codecov.io/bash) -f engine/build/reports/coverage/debug/report.xml
     - name: Release artifacts to local repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
         api-level: ${{ matrix.api-level }}
         arch: x86_64
         script: ./gradlew connectedCheck --stacktrace
+    - name: Code coverage (via codecov.io)
+      run: bash <(curl -s https://codecov.io/bash) -f engine/build/reports/coverage/debug/report.xml
     - name: Release artifacts to local repo
       run: ./gradlew publishReleasePublicationToCIRepository
     - name: Upload maven repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,17 @@ jobs:
 
     - name: Build with Gradle
       if: matrix.api-level == 29 # don't run full build on older APIs
-      run: ./gradlew build
+      uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          script: ./gradlew build --info
     - name: Run Integration Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
         arch: x86_64
-        script: ./gradlew connectedCheck --stacktrace
+        script: ./gradlew connectedCheck --info
     - name: Code coverage (via codecov.io)
       run: bash <(curl -s https://codecov.io/bash) -f engine/build/reports/coverage/debug/report.xml
     - name: Release artifacts to local repo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Android FHIR SDK (Early Access) [![master](https://github.com/google/android-fhir/workflows/CI/badge.svg?branch=master)](https://github.com/google/android-fhir/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/google/android-fhir/branch/db/coverage/graph/badge.svg?token=PDSC4WRDTQ)](https://codecov.io/gh/google/android-fhir)
+# Android FHIR SDK (Early Access) [![master](https://github.com/google/android-fhir/workflows/CI/badge.svg?branch=master)](https://github.com/google/android-fhir/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/google/android-fhir/branch/master/graph/badge.svg?token=PDSC4WRDTQ)](https://codecov.io/gh/google/android-fhir)
 The Android FHIR SDK (the SDK) is an Android library for building offline-capable, mobile-first
 healthcare applications using [FHIR](https://www.hl7.org/fhir/) resources on Android. The overall
 goal is to simplify the process of incorporating support for FHIR into new or existing mobile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Android FHIR SDK (Early Access) [![master](https://github.com/google/android-fhir/workflows/CI/badge.svg?branch=master)](https://github.com/google/android-fhir/actions?query=workflow%3ACI)
+# Android FHIR SDK (Early Access) [![master](https://github.com/google/android-fhir/workflows/CI/badge.svg?branch=master)](https://github.com/google/android-fhir/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/google/android-fhir/branch/db/coverage/graph/badge.svg?token=PDSC4WRDTQ)](https://codecov.io/gh/google/android-fhir)
 The Android FHIR SDK (the SDK) is an Android library for building offline-capable, mobile-first
 healthcare applications using [FHIR](https://www.hl7.org/fhir/) resources on Android. The overall
 goal is to simplify the process of incorporating support for FHIR into new or existing mobile

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ buildscript {
   }
 }
 
+plugins { id(Plugins.coveragePlugin) version Dependencies.Versions.coverage }
+
 allprojects {
   repositories {
     google()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -149,5 +149,6 @@ object Dependencies {
     const val junit = "4.13"
     const val mockitoKotlin = "3.2.0"
     const val robolectric = "4.5.1"
+    const val coverage = "0.16.0"
   }
 }

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -32,6 +32,7 @@ object Plugins {
     "org.jetbrains.kotlin:kotlin-gradle-plugin:${Dependencies.Versions.Kotlin.stdlib}"
   const val navSafeArgsGradlePlugin =
     "androidx.navigation:navigation-safe-args-gradle-plugin:${Dependencies.Versions.Androidx.navigation}"
+  const val coveragePlugin = "com.vanniktech.android.junit.jacoco"
 
   object Versions {
     const val androidGradlePlugin = "4.2.2"

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -64,9 +64,7 @@ android {
       isMinifyEnabled = false
       proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
     }
-    getByName("debug") {
-      isTestCoverageEnabled = true
-    }
+    getByName("debug") { isTestCoverageEnabled = true }
   }
 
   compileOptions {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -64,6 +64,9 @@ android {
       isMinifyEnabled = false
       proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
     }
+    getByName("debug") {
+      isTestCoverageEnabled = true
+    }
   }
 
   compileOptions {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #671 

**Description**
* Generate coverage reports using built-in jacoco plugin
* Upload report to codecov.io

**Alternative(s) considered**
Coveralls is another coverage report provider but we need add a plugin to upload reports which might impact build times. However this a weak criteria and it should be re-considered.

**Type**
Choose one: Testing

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
