### PR TITLE
Reference app get crashed when it get launched.

### DIFF
--- a/reference/src/main/java/com/google/android/fhir/reference/FhirApplication.kt
+++ b/reference/src/main/java/com/google/android/fhir/reference/FhirApplication.kt
@@ -29,7 +29,11 @@ import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.ResourceType
 
 class FhirApplication : Application() {
-  init {
+  // Only initiate the FhirEngine when used for the first time, not when the app is created.
+  private val fhirEngine: FhirEngine by lazy { constructFhirEngine() }
+
+  override fun onCreate() {
+    super.onCreate()
     GlobalScope.launch {
       Sync.oneTimeSync(
         fhirEngine,
@@ -38,9 +42,6 @@ class FhirApplication : Application() {
       )
     }
   }
-
-  // only initiate the FhirEngine when used for the first time, not when the app is created
-  private val fhirEngine: FhirEngine by lazy { constructFhirEngine() }
 
   private fun constructFhirEngine(): FhirEngine {
     return FhirEngineBuilder(this).build()


### PR DESCRIPTION
Fix reference app crash.

Testing
Tested on Moto G5 Plus, Android 8.1

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #565 

**Description**
Reference app was getting crashed when context was null in ContextWrapper.
Moved init block to onCreate callback method in FhirApplication. 

**Alternative(s) considered**
No

**Type**
Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
