### PR TITLE
temporarily use mac-os version 11.0 to avoid emulator timeout.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
    # Build will compile APK, test APK and run tests, lint, etc.
    build:
 
-    runs-on: macos-latest # use mac build for emulator hardware accelerator
+    runs-on: macos-11.0 # use mac build for emulator hardware accelerator
     
     strategy:
       matrix:


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes # trivial

**Description**
Clear and concise code change description. 

use mac-os version 11.0 to avoid emulator timeout.

see 
current version
https://github.com/google/android-fhir/runs/2888614202 

after using mac-os version 11.0
https://github.com/google/android-fhir/runs/2891412388


**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

see https://github.com/ReactiveCircus/android-emulator-runner/issues/160

**Type**
Choose one:  Other

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
