### PR TITLE
Fix null pointer exception for max length validator

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/PrimitiveTypeAnswerMaxLengthValidator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/PrimitiveTypeAnswerMaxLengthValidator.kt
@@ -35,10 +35,13 @@ internal object PrimitiveTypeAnswerMaxLengthValidator : ConstraintValidator {
     context: Context
   ): ConstraintValidationResult {
     // TODO(https://github.com/google/android-fhir/issues/487): Validate all answers.
-    val answer = questionnaireResponseItem.answer[0].value
+    val answer =
+      questionnaireResponseItem.answer.singleOrNull()
+        ?: return ConstraintValidationResult(true, null)
+
     if (questionnaireItem.hasMaxLength() &&
-        answer.isPrimitive &&
-        answer.asStringValue().length > questionnaireItem.maxLength
+        answer.value.isPrimitive &&
+        answer.value.asStringValue().length > questionnaireItem.maxLength
     ) {
       return ConstraintValidationResult(
         false,

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/validation/PrimitiveTypeAnswerMaxLengthValidatorTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/validation/PrimitiveTypeAnswerMaxLengthValidatorTest.kt
@@ -52,6 +52,31 @@ class PrimitiveTypeAnswerMaxLengthValidatorTest {
   }
 
   @Test
+  fun noAnswer_shouldReturnValidResult() {
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().apply { this.maxLength = maxLength }
+    val questionnaireResponseItem =
+      QuestionnaireResponseItemComponent().apply {
+        addAnswer(
+          QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+            this.value = value
+          }
+        )
+      }
+    QuestionnaireTestItem(questionnaireItem, questionnaireResponseItem)
+
+    val validationResult =
+      PrimitiveTypeAnswerMaxLengthValidator.validate(
+        questionnaireItem,
+        questionnaireResponseItem,
+        Companion.context
+      )
+
+    assertThat(validationResult.isValid).isTrue()
+    assertThat(validationResult.message.isNullOrBlank()).isTrue()
+  }
+
+  @Test
   fun boolean_answerOverMaxLength_shouldReturnInvalidResult() {
     checkAnswerOverMaxLength(maxLength = 4, value = BooleanType(false))
   }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/validation/PrimitiveTypeAnswerMaxLengthValidatorTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/validation/PrimitiveTypeAnswerMaxLengthValidatorTest.kt
@@ -53,22 +53,10 @@ class PrimitiveTypeAnswerMaxLengthValidatorTest {
 
   @Test
   fun noAnswer_shouldReturnValidResult() {
-    val questionnaireItem =
-      Questionnaire.QuestionnaireItemComponent().apply { this.maxLength = maxLength }
-    val questionnaireResponseItem =
-      QuestionnaireResponseItemComponent().apply {
-        addAnswer(
-          QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-            this.value = value
-          }
-        )
-      }
-    QuestionnaireTestItem(questionnaireItem, questionnaireResponseItem)
-
     val validationResult =
       PrimitiveTypeAnswerMaxLengthValidator.validate(
-        questionnaireItem,
-        questionnaireResponseItem,
+        Questionnaire.QuestionnaireItemComponent().apply { this.maxLength = maxLength },
+        QuestionnaireResponseItemComponent(),
         Companion.context
       )
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #616 

**Description**
Fix NPE

**Alternative(s) considered**
NA

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
