### PR TITLE
Add tests for API 30, cache AVD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradlejars-
     - name: Gradle build cache
-    - uses: actions/cache@v1
+      uses: actions/cache@v1
       with:
         path: ~/.gradle/caches/build-cache-1
         key: ${{ runner.os }}-gradlebuildcache-${{ hashFiles('checksum.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       with:
         api-level: ${{ matrix.api-level }}
         arch: x86_64
+        emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: ./gradlew connectedCheck --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
-        arch: x86_64
+        arch: x86
         emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,8 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
-        arch: x86
+        arch: x86_64
+        target: default
         emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
     
     strategy:
       matrix:
-        api-level: [24, 27, 29]
+        api-level: [24, 27, 29, 30]
+        include:
+          - api-level: 30
+          - full-build: true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Cancel previous
@@ -86,18 +89,42 @@ jobs:
           ${{ runner.os }}-gradlebuildcache-
 
     - name: Spotless check
-      if: matrix.api-level == 29  # don't spotless on older APIs
+      if: matrix.full-build == true
       run: ./gradlew spotlessCheck
 
     - name: Build with Gradle
-      if: matrix.api-level == 29 # don't run full build on older APIs
+      if: matrix.full-build == true
       run: ./gradlew build
+
+    - name: AVD cache
+      uses: actions/cache@v2
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.api-level }}
+
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
+
     - name: Run Integration Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
         arch: x86_64
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
         script: ./gradlew connectedCheck --stacktrace
+
     - name: Release artifacts to local repo
       run: ./gradlew publishReleasePublicationToCIRepository
     - name: Upload maven repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
         access_token: ${{ github.token }}
     
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      
     
     - name: set up JDK 1.8
       uses: actions/setup-java@v1
@@ -69,18 +71,22 @@ jobs:
     - name: Copy CI gradle.properties
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-    - uses: actions/cache@v1
+    - name: Gradle module cache
+      uses: actions/cache@v1
       with:
         path: ~/.gradle/caches/modules-2
         key: ${{ runner.os }}-gradlemodules-${{ hashFiles('checksum.txt') }}
         restore-keys: |
           ${{ runner.os }}-gradlemodules-
-    - uses: actions/cache@v1
+    
+    - name: Gradle jars cache
+      uses: actions/cache@v1
       with:
         path: ~/.gradle/caches/jars-3
         key: ${{ runner.os }}-gradlejars-${{ hashFiles('checksum.txt') }}
         restore-keys: |
           ${{ runner.os }}-gradlejars-
+    - name: Gradle build cache
     - uses: actions/cache@v1
       with:
         path: ~/.gradle/caches/build-cache-1
@@ -96,31 +102,11 @@ jobs:
       if: ${{ matrix.full-build == true }}
       run: ./gradlew build
 
-    - name: AVD cache
-      uses: actions/cache@v2
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-${{ matrix.api-level }}
-
-    - name: create AVD and generate snapshot for caching
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: ${{ matrix.api-level }}
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: false
-        script: echo "Generated AVD snapshot for caching."
-
     - name: Run Integration Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
         arch: x86_64
-        force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: ./gradlew connectedCheck --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,11 @@ jobs:
           ${{ runner.os }}-gradlebuildcache-
 
     - name: Spotless check
-      if: matrix.full-build == true
+      if: ${{ matrix.full-build == true }}
       run: ./gradlew spotlessCheck
 
     - name: Build with Gradle
-      if: matrix.full-build == true
+      if: ${{ matrix.full-build == true }}
       run: ./gradlew build
 
     - name: AVD cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         api-level: [24, 27, 29, 30]
         include:
           - api-level: 30
-          - full-build: true
+            full-build: true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Cancel previous


### PR DESCRIPTION
This PR adds testing for API 30 devices.

* Cleaned up the CI build a bit to explicitly have a matrix parameter for full build.
* Added cache for AVD

Fixes #617
Test: CI
