### PR TITLE
Add missing nested answers to the questionnaire response item map

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -76,11 +76,14 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
   /** Tracks modifications in order to update the UI. */
   private val modificationCount = MutableStateFlow(0)
 
-  /** Callback function to update the UI. */
+  /**
+   * Callback function to update the UI which takes the linkId of the question whose answer(s) has
+   * been changed.
+   */
   private val questionnaireResponseItemChangedCallback: (String) -> Unit = { linkId ->
-    linkIdToQuestionnaireItemMap[linkId]?.let {
-      if (it.hasNestedItemsWithinAnswers) {
-        linkIdToQuestionnaireResponseItemMap[linkId]?.addNestedItemsToAnswer(it)
+    linkIdToQuestionnaireItemMap[linkId]?.let { questionnaireItem ->
+      if (questionnaireItem.hasNestedItemsWithinAnswers) {
+        linkIdToQuestionnaireResponseItemMap[linkId]?.addNestedItemsToAnswer(questionnaireItem)
         linkIdToQuestionnaireResponseItemMap[linkId]?.answer?.singleOrNull()?.item?.forEach {
           linkIdToQuestionnaireResponseItemMap[it.linkId] = it
         }
@@ -89,8 +92,7 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
     modificationCount.value += 1
   }
 
-  private val pageFlow =
-    MutableStateFlow<QuestionnairePagination?>(questionnaire.getInitialPagination())
+  private val pageFlow = MutableStateFlow(questionnaire.getInitialPagination())
 
   internal fun goToPreviousPage() {
     pageFlow.value = pageFlow.value!!.previousPage()
@@ -133,9 +135,7 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
       linkIdToQuestionnaireResponseItemMap.putAll(
         createLinkIdToQuestionnaireResponseItemMap(item.item)
       )
-      item.answer.forEach {
-        createLinkIdToQuestionnaireResponseItemMap(it.item)
-      }
+      item.answer.forEach { createLinkIdToQuestionnaireResponseItemMap(it.item) }
     }
     return linkIdToQuestionnaireResponseItemMap
   }
@@ -218,7 +218,7 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
 
 /**
  * Traverse (DFS) through the list of questionnaire items and the list of questionnaire response
- * items and check if the linkid of the matching pairs of questionnaire item and questionnaire
+ * items and check if the linkId of the matching pairs of questionnaire item and questionnaire
  * response item are equal. The traverse is carried out in the two lists in tandem. The two lists
  * should be structurally identical.
  */

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -80,7 +80,10 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
   private val questionnaireResponseItemChangedCallback: (String) -> Unit = { linkId ->
     linkIdToQuestionnaireItemMap[linkId]?.let {
       if (it.hasNestedItemsWithinAnswers) {
-        linkIdToQuestionnaireResponseItemMap[linkId]!!.addNestedItemsToAnswer(it)
+        linkIdToQuestionnaireResponseItemMap[linkId]?.addNestedItemsToAnswer(it)
+        linkIdToQuestionnaireResponseItemMap[linkId]?.answer?.singleOrNull()?.item?.forEach {
+          linkIdToQuestionnaireResponseItemMap[it.linkId] = it
+        }
       }
     }
     modificationCount.value += 1
@@ -123,13 +126,16 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
 
   private fun createLinkIdToQuestionnaireResponseItemMap(
     questionnaireResponseItemList: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>
-  ): Map<String, QuestionnaireResponse.QuestionnaireResponseItemComponent> {
+  ): MutableMap<String, QuestionnaireResponse.QuestionnaireResponseItemComponent> {
     val linkIdToQuestionnaireResponseItemMap =
       questionnaireResponseItemList.map { it.linkId to it }.toMap().toMutableMap()
     for (item in questionnaireResponseItemList) {
       linkIdToQuestionnaireResponseItemMap.putAll(
         createLinkIdToQuestionnaireResponseItemMap(item.item)
       )
+      item.answer.forEach {
+        createLinkIdToQuestionnaireResponseItemMap(it.item)
+      }
     }
     return linkIdToQuestionnaireResponseItemMap
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -137,7 +137,11 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
       linkIdToQuestionnaireResponseItemMap.putAll(
         createLinkIdToQuestionnaireResponseItemMap(item.item)
       )
-      item.answer.forEach { createLinkIdToQuestionnaireResponseItemMap(it.item) }
+      item.answer.forEach {
+        linkIdToQuestionnaireResponseItemMap.putAll(
+          createLinkIdToQuestionnaireResponseItemMap(it.item)
+        )
+      }
     }
     return linkIdToQuestionnaireResponseItemMap
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -85,7 +85,9 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
       if (questionnaireItem.hasNestedItemsWithinAnswers) {
         linkIdToQuestionnaireResponseItemMap[linkId]?.addNestedItemsToAnswer(questionnaireItem)
         linkIdToQuestionnaireResponseItemMap[linkId]?.answer?.singleOrNull()?.item?.forEach {
-          linkIdToQuestionnaireResponseItemMap[it.linkId] = it
+          questionnaireResponseItem ->
+          linkIdToQuestionnaireResponseItemMap[questionnaireResponseItem.linkId] =
+            questionnaireResponseItem
         }
       }
     }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -83,11 +83,13 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
   private val questionnaireResponseItemChangedCallback: (String) -> Unit = { linkId ->
     linkIdToQuestionnaireItemMap[linkId]?.let { questionnaireItem ->
       if (questionnaireItem.hasNestedItemsWithinAnswers) {
-        linkIdToQuestionnaireResponseItemMap[linkId]?.addNestedItemsToAnswer(questionnaireItem)
-        linkIdToQuestionnaireResponseItemMap[linkId]?.answer?.singleOrNull()?.item?.forEach {
-          questionnaireResponseItem ->
-          linkIdToQuestionnaireResponseItemMap[questionnaireResponseItem.linkId] =
-            questionnaireResponseItem
+        linkIdToQuestionnaireResponseItemMap[linkId]?.let { questionnaireResponseItem ->
+          questionnaireResponseItem.addNestedItemsToAnswer(questionnaireItem)
+          questionnaireResponseItem.answer.singleOrNull()?.item?.forEach {
+            nestedQuestionnaireResponseItem ->
+            linkIdToQuestionnaireResponseItemMap[nestedQuestionnaireResponseItem.linkId] =
+              nestedQuestionnaireResponseItem
+          }
         }
       }
     }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #652 

**Description**

- In the questionnaire response item map, we were missing answers to questions nested under other non-group questions. This causes issues for enable when evaluation because no answer can be retrieved to evaluate if another question should be enabled or not
- The assumption that the response item map is immutable needs to be removed. This is because as the user answers questions, more nested items might be created (questions nested under other questions are nested in the response under the answers).

**Alternative(s) considered**
NA

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
