### PR TITLE
Convert ResourceMapper extract and populate functions to suspend funcs

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
@@ -22,10 +22,6 @@ import ca.uhn.fhir.context.support.DefaultProfileValidationSupport
 import com.google.android.fhir.datacapture.createQuestionnaireResponseItem
 import com.google.android.fhir.datacapture.targetStructureMap
 import com.google.android.fhir.datacapture.utilities.SimpleWorkerContextProvider
-import java.lang.reflect.Field
-import java.lang.reflect.Method
-import java.lang.reflect.ParameterizedType
-import java.util.Locale
 import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.BooleanType
@@ -50,6 +46,10 @@ import org.hl7.fhir.r4.model.Type
 import org.hl7.fhir.r4.model.UrlType
 import org.hl7.fhir.r4.utils.FHIRPathEngine
 import org.hl7.fhir.r4.utils.StructureMapUtilities
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
+import java.util.Locale
 
 /**
  * Maps [QuestionnaireResponse] s to FHIR resources and vice versa.
@@ -145,10 +145,10 @@ object ResourceMapper {
     return Bundle().apply {
       StructureMapUtilities(simpleWorkerContext)
         .transform(
-          /* appInfo= */ simpleWorkerContext,
-          /* source= */ questionnaireResponse,
-          /* map= */ structureMap,
-          /* target= */ this
+          simpleWorkerContext,
+          questionnaireResponse,
+          structureMap,
+          this
         )
     }
   }
@@ -164,14 +164,14 @@ object ResourceMapper {
     }
   }
 
-  private fun populateInitialValues(
+  private suspend fun populateInitialValues(
     questionnaireItems: List<Questionnaire.QuestionnaireItemComponent>,
     resource: Resource
   ) {
     questionnaireItems.forEach { populateInitialValue(it, resource) }
   }
 
-  private fun populateInitialValue(
+  private suspend fun populateInitialValue(
     question: Questionnaire.QuestionnaireItemComponent,
     resource: Resource
   ) {
@@ -200,7 +200,7 @@ object ResourceMapper {
    * Extracts answer values from [questionnaireResponseItemList] and updates the fields defined in
    * the corresponding questions in [questionnaireItemList]. This method handles nested fields.
    */
-  private fun Base.extractFields(
+  private suspend fun Base.extractFields(
     bundle: Bundle,
     questionnaireItemList: List<Questionnaire.QuestionnaireItemComponent>,
     questionnaireResponseItemList: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>
@@ -221,7 +221,7 @@ object ResourceMapper {
    * Extracts the answer value from [questionnaireResponseItem] and updates the field defined in
    * [questionnaireItem]. This method handles nested fields.
    */
-  private fun Base.extractField(
+  private suspend fun Base.extractField(
     bundle: Bundle,
     questionnaireItem: Questionnaire.QuestionnaireItemComponent,
     questionnaireResponseItem: QuestionnaireResponse.QuestionnaireResponseItemComponent

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
@@ -22,6 +22,10 @@ import ca.uhn.fhir.context.support.DefaultProfileValidationSupport
 import com.google.android.fhir.datacapture.createQuestionnaireResponseItem
 import com.google.android.fhir.datacapture.targetStructureMap
 import com.google.android.fhir.datacapture.utilities.SimpleWorkerContextProvider
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
+import java.util.Locale
 import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.BooleanType
@@ -46,10 +50,6 @@ import org.hl7.fhir.r4.model.Type
 import org.hl7.fhir.r4.model.UrlType
 import org.hl7.fhir.r4.utils.FHIRPathEngine
 import org.hl7.fhir.r4.utils.StructureMapUtilities
-import java.lang.reflect.Field
-import java.lang.reflect.Method
-import java.lang.reflect.ParameterizedType
-import java.util.Locale
 
 /**
  * Maps [QuestionnaireResponse] s to FHIR resources and vice versa.

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/NpmPackageProvider.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/NpmPackageProvider.kt
@@ -20,12 +20,12 @@ import android.content.Context
 import android.os.Environment
 import android.util.Log
 import com.google.android.fhir.datacapture.mapping.NpmPackageInitializationError
+import org.apache.commons.compress.utils.IOUtils
+import org.hl7.fhir.utilities.npm.NpmPackage
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
-import org.apache.commons.compress.utils.IOUtils
-import org.hl7.fhir.utilities.npm.NpmPackage
 
 /**
  * Manages extracting the fhir core package into app storage and loading it into memory. Extracting
@@ -76,7 +76,7 @@ object NpmPackageProvider {
    *
    * @Throws NpmPackageInitializationError
    */
-  private fun setupNpmPackage(context: Context) {
+  private suspend fun setupNpmPackage(context: Context) {
     val outDir = getLocalFhirCorePackageDirectory(context)
 
     if (File(outDir + "/package/package.json").exists()) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/NpmPackageProvider.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/NpmPackageProvider.kt
@@ -59,7 +59,7 @@ object NpmPackageProvider {
    *
    * The whole process can take 1-2 minutes on a clean installation.
    */
-  fun loadNpmPackage(context: Context): NpmPackage {
+  suspend fun loadNpmPackage(context: Context): NpmPackage {
     setupNpmPackage(context)
 
     if (!this::npmPackage.isInitialized) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/SimpleWorkerContextProvider.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/SimpleWorkerContextProvider.kt
@@ -37,7 +37,7 @@ object SimpleWorkerContextProvider {
    * The whole process can take 1-3 minutes on a clean installation, otherwise, it should take 20
    * seconds to 1 minute .
    */
-  fun loadSimpleWorkerContext(context: Context): SimpleWorkerContext {
+  suspend fun loadSimpleWorkerContext(context: Context): SimpleWorkerContext {
     if (!this::simpleWorkerContext.isInitialized) {
       simpleWorkerContext =
         SimpleWorkerContext.fromPackage(NpmPackageProvider.loadNpmPackage(context))

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/mapping/ShadowNpmPackageProvider.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/mapping/ShadowNpmPackageProvider.kt
@@ -33,7 +33,7 @@ import org.robolectric.util.ReflectionHelpers
 class ShadowNpmPackageProvider {
 
   @Implementation
-  fun loadNpmPackage(context: Context): NpmPackage {
+  suspend fun loadNpmPackage(context: Context): NpmPackage {
     // Package name manually checked from
     // https://simplifier.net/packages/hl7.fhir.r4.core/4.0.1
     val npmPackage =

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/SimpleWorkerContextProviderTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/SimpleWorkerContextProviderTest.kt
@@ -20,6 +20,8 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.fhir.datacapture.mapping.ShadowNpmPackageProvider
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.hl7.fhir.r4.context.SimpleWorkerContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,16 +40,24 @@ class SimpleWorkerContextProviderTest {
 
   @Test
   fun `loadSimpleWorkerContext() should cache SimpleWorkerContext`() {
-    val generatedSimpleWorkerContext =
-      SimpleWorkerContextProvider.loadSimpleWorkerContext(
-        ApplicationProvider.getApplicationContext()
-      )
+    val expectedSimpleWorkerContext: SimpleWorkerContext
 
-    assertThat(generatedSimpleWorkerContext)
-      .isEqualTo(
+    runBlocking {
+      expectedSimpleWorkerContext =
         SimpleWorkerContextProvider.loadSimpleWorkerContext(
           ApplicationProvider.getApplicationContext()
         )
-      )
+    }
+
+    val actualSimpleWorkerContext: SimpleWorkerContext
+
+    runBlocking {
+      actualSimpleWorkerContext =
+        SimpleWorkerContextProvider.loadSimpleWorkerContext(
+          ApplicationProvider.getApplicationContext()
+        )
+    }
+
+    assertThat(expectedSimpleWorkerContext).isEqualTo(actualSimpleWorkerContext)
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #666 

**Description**
Convert ResourceMapper, SimpleWorkerContextProvider and NpmPackageProvider functions to suspend functions

**Alternative(s) considered**
None

**Type**
Feature

**Screenshots (if applicable)**
None

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
