### PR TITLE
Edit Patient Save logic fix

### DIFF
--- a/reference/src/main/java/com/google/android/fhir/reference/EditPatientViewModel.kt
+++ b/reference/src/main/java/com/google/android/fhir/reference/EditPatientViewModel.kt
@@ -71,7 +71,9 @@ class EditPatientViewModel(application: Application, private val state: SavedSta
    */
   fun updatePatient(questionnaireResponse: QuestionnaireResponse) {
     viewModelScope.launch {
-      val patient = ResourceMapper.extract(questionnaireResource, questionnaireResponse) as Patient
+      val entry = ResourceMapper.extract(questionnaireResource, questionnaireResponse).entryFirstRep
+      if (entry.resource !is Patient) return@launch
+      val patient = entry.resource as Patient
       if (patient.hasName() &&
           patient.name[0].hasGiven() &&
           patient.name[0].hasFamily() &&


### PR DESCRIPTION
The EditPatientViewModel was still expecting ResourceMapper.extract to return a resource while the api had changed to return a bundle.


**Fixes** : No issue created

**Type**
 Bug fix


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
