### PR TITLE
Enable kotlin.setJvmTargetFromAndroidCompileOptions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,7 @@ org.gradle.jvmargs=-Xmx4096m
 # org.gradle.parallel=true
 
 android.useAndroidX=true
+
+# Avoids needing to manually set Kotlin's JVM target.
+# https://stackoverflow.com/a/59798799/3204764
+kotlin.setJvmTargetFromAndroidCompileOptions = true


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Ensures that all modules have JVM target 1.8 (eg, you don't get a lint error when using `.forEach` anymore), without having to set the JVM options per-module.

**Type**
Choose one: Code health

**Screenshots (if applicable)**

**Checklist**
- [X] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [X] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [X] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [X] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [X] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [X] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [X] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
