### PR TITLE
 Fix link to code coverage dashboard in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Android FHIR SDK (Early Access) [![master](https://github.com/google/android-fhir/workflows/CI/badge.svg?branch=master)](https://github.com/google/android-fhir/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/google/android-fhir/branch/master/graph/badge.svg?token=PDSC4WRDTQ)](https://codecov.io/gh/google/android-fhir)
+# Android FHIR SDK (Early Access) [![master](https://github.com/google/android-fhir/workflows/CI/badge.svg?branch=master)](https://github.com/google/android-fhir/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/google/android-fhir/branch/master/graph/badge.svg?token=PDSC4WRDTQ)](https://codecov.io/gh/google/android-fhir/branch/master)
 The Android FHIR SDK (the SDK) is an Android library for building offline-capable, mobile-first
 healthcare applications using [FHIR](https://www.hl7.org/fhir/) resources on Android. The overall
 goal is to simplify the process of incorporating support for FHIR into new or existing mobile


### PR DESCRIPTION
Fixes #734 

**Description**

Minor fixes:

* Files navigation on the codecov dashboard does not work. This is due to branch info missing from the badge. Fixed link to code coverage dashboard from coverage badge in README.md.
* Codecov has deprecated bash uploader script (that we are currently using to upload reports). Switched to codecov uploader.
* Updated testing documentation to include coverage target and added instructions to improved coverage.


**Type**
Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
