### PR TITLE
Handle TransactionTooLargeException while dealing with a large questionnaire

### DIFF
--- a/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/MainActivity.kt
+++ b/datacapturegallery/src/main/java/com/google/android/fhir/datacapture/gallery/MainActivity.kt
@@ -27,4 +27,9 @@ class MainActivity : AppCompatActivity() {
     binding = ActivityMainBinding.inflate(layoutInflater)
     setContentView(binding.root)
   }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.clear()
+  }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #672 

**Description**
While rendering a large questionnaire, the application crashes on configuration change. My suspicion is that since we are passing the questionnaire json string as part of the arguments to the fragment, it gets stored in the outState Bundle and onSaveInstanceState we have a large bundle. Since we are storing these json in the veiwModel of datacapture , clearing this outState seems to do no harm and prevents this crash.

**Alternative(s) considered**
There maybe better ways of dealing with this within the datacapture library. I am not sure.

**Type**
Bug fix

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
