### PR TITLE
Added missing call to questionnaireItemViewItem.questionnaireResponseItemChangedCallback

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactory.kt
@@ -186,6 +186,7 @@ internal object QuestionnaireItemAutoCompleteViewHolderFactory :
           replaceChip(answer)
           questionnaireItemViewItem.singleAnswerOrNull = answer
         }
+        questionnaireItemViewItem.questionnaireResponseItemChangedCallback()
       }
 
       /**
@@ -248,6 +249,7 @@ internal object QuestionnaireItemAutoCompleteViewHolderFactory :
         } else {
           questionnaireItemViewItem.singleAnswerOrNull = null
         }
+        questionnaireItemViewItem.questionnaireResponseItemChangedCallback()
       }
 
       private fun updateContainerBorder(hasFocus: Boolean) {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #651 

**Description**
Added the missing call to questionnaireItemViewItem.questionnaireResponseItemChangedCallback when questionnaireItemViewItem.singleAnswerOrNull changes. This callback has to be called to run enableWhen and modify the linkIdMaps

**Alternative(s) considered**
Nope

**Type**
Bug fix 

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
