### PR TITLE
Add response item initial value to questionnaire response only if enablewhen is true.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -135,7 +135,7 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
    */
   fun getQuestionnaireResponse(): QuestionnaireResponse {
     return questionnaireResponse.copy().apply {
-      item = getEnableResponseItems(this@QuestionnaireViewModel.questionnaire.item, item)
+      item = getEnabledResponseItems(this@QuestionnaireViewModel.questionnaire.item, item)
     }
   }
 
@@ -234,7 +234,7 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
     return QuestionnaireState(items = items, pagination = pagination)
   }
 
-  private fun getEnableResponseItems(
+  private fun getEnabledResponseItems(
     questionnaireItemList: List<Questionnaire.QuestionnaireItemComponent>,
     questionnaireResponseItemList: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
   ): List<QuestionnaireResponse.QuestionnaireResponseItemComponent> {
@@ -243,24 +243,24 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
       .zip(questionnaireResponseItemList.asSequence())
       .filter { (questionnaireItem, questionnaireResponseItem) ->
         EnablementEvaluator.evaluate(questionnaireItem) { linkId ->
-          val questionnaireItemComponent = linkIdToQuestionnaireItemMap[linkId]
-          val questionnaireResponseItemComponent = linkIdToQuestionnaireResponseItemMap[linkId]
-          if (questionnaireItemComponent == null || questionnaireResponseItemComponent == null) {
+          val questionnaireItem = linkIdToQuestionnaireItemMap[linkId]
+          val questionnaireResponseItem = linkIdToQuestionnaireResponseItemMap[linkId]
+          if (questionnaireItem == null || questionnaireResponseItem == null) {
             return@evaluate QuestionnaireItemWithResponse(null, null)
           }
           QuestionnaireItemWithResponse(
-            questionnaireItem = questionnaireItemComponent,
-            questionnaireResponseItem = questionnaireResponseItemComponent
+            questionnaireItem = questionnaireItem,
+            questionnaireResponseItem = questionnaireResponseItem
           )
         }
       }
       .map { (questionnaireItem, questionnaireResponseItem) ->
         // Nested group items
         questionnaireResponseItem.item =
-          getEnableResponseItems(questionnaireItem.item, questionnaireResponseItem.item)
+          getEnabledResponseItems(questionnaireItem.item, questionnaireResponseItem.item)
         // Nested question items
         questionnaireResponseItem.answer.forEach {
-          it.item = getEnableResponseItems(questionnaireItem.item, it.item)
+          it.item = getEnabledResponseItems(questionnaireItem.item, it.item)
         }
         questionnaireResponseItem
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -341,6 +341,6 @@ internal fun QuestionnaireResponse.QuestionnaireResponseItemComponent.removeAnsw
     item.forEach { it.removeAnswers() }
   }
   if (hasAnswer()) {
-    answer = emptyList()
+    answer.removeAll { true }
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -218,7 +218,7 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
                 )
                 .items
           } else {
-            questionnaireResponseItem?.removeAnswers()
+            questionnaireResponseItem.removeAnswers()
             emptyList()
           }
         }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -44,7 +44,6 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
 
   /** The current questionnaire response as questions are being answered. */
   private val questionnaireResponse: QuestionnaireResponse
-
   init {
     val questionnaireJsonResponseString: String? =
       state[QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE_RESPONSE]
@@ -198,6 +197,9 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
               )
             }
           if (enabled) {
+            if (questionnaireItem.hasEnableWhen() && !questionnaireResponseItem.hasAnswer()) {
+              questionnaireResponseItem.updateInitialValue(questionnaireItem)
+            }
             listOf(
               QuestionnaireItemViewItem(questionnaireItem, questionnaireResponseItem) {
                 questionnaireResponseItemChangedCallback(questionnaireItem.linkId)
@@ -216,6 +218,7 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
                 )
                 .items
           } else {
+            questionnaireResponseItem?.removeAnswers()
             emptyList()
           }
         }
@@ -323,4 +326,21 @@ internal fun QuestionnairePagination.previousPage(): QuestionnairePagination {
 internal fun QuestionnairePagination.nextPage(): QuestionnairePagination {
   check(hasNextPage) { "Can't call nextPage() if hasNextPage is false ($this)" }
   return copy(currentPageIndex = currentPageIndex + 1)
+}
+
+internal fun QuestionnaireResponse.QuestionnaireResponseItemComponent.updateInitialValue(
+  questionnaireItem: Questionnaire.QuestionnaireItemComponent
+) {
+  val responseItemWithInitialValue = questionnaireItem.createQuestionnaireResponseItem()
+  item = responseItemWithInitialValue.item
+  answer = responseItemWithInitialValue.answer
+}
+
+internal fun QuestionnaireResponse.QuestionnaireResponseItemComponent.removeAnswers() {
+  if (hasItem()) {
+    item.forEach { it.removeAnswers() }
+  }
+  if (hasAnswer()) {
+    answer = emptyList()
+  }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -196,7 +196,11 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
                     ?: return@evaluate QuestionnaireItemWithResponse(null, null))
               )
             }
-          if (enabled) {
+
+          if (!enabled) {
+            questionnaireResponseItem.removeAllNestedAnswers()
+            emptyList()
+          } else {
             if (questionnaireItem.hasEnableWhen() && !questionnaireResponseItem.hasAnswer()) {
               questionnaireResponseItem.updateInitialValue(questionnaireItem)
             }
@@ -217,9 +221,6 @@ internal class QuestionnaireViewModel(state: SavedStateHandle) : ViewModel() {
                   pagination = null,
                 )
                 .items
-          } else {
-            questionnaireResponseItem.removeAnswers()
-            emptyList()
           }
         }
         .toList()
@@ -336,11 +337,8 @@ internal fun QuestionnaireResponse.QuestionnaireResponseItemComponent.updateInit
   answer = responseItemWithInitialValue.answer
 }
 
-internal fun QuestionnaireResponse.QuestionnaireResponseItemComponent.removeAnswers() {
-  if (hasItem()) {
-    item.forEach { it.removeAnswers() }
-  }
-  if (hasAnswer()) {
-    answer.removeAll { true }
-  }
+/** Removes all nested answers of current questionnaire response item. */
+internal fun QuestionnaireResponse.QuestionnaireResponseItemComponent.removeAllNestedAnswers() {
+  answer.removeAll { true }
+  item.forEach { it.removeAllNestedAnswers() }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -896,36 +896,39 @@ class QuestionnaireViewModelTest {
         )
       }
     val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
-    val questionnaireResponse =
-      QuestionnaireResponse().apply {
-        this.questionnaire = "Questionnaire/a-questionnaire"
-        addItem(
-          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-            linkId = "a-group-item"
-            addItem(
-              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-                linkId = "question-1"
-                addAnswer(
-                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    this.value = valueBooleanType.setValue(false)
-                  }
-                )
+    val questionnaireResponseJsonString =
+      """
+  {
+    "resourceType": "QuestionnaireResponse",
+    "questionnaire": "Questionnaire/a-questionnaire",
+    "item": [
+      {
+        "linkId": "a-group-item",
+        "item": [
+          {
+            "linkId": "question-1",
+            "answer": [
+              {
+                "valueBoolean": false
               }
-            )
-            addItem(
-              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-                linkId = "question-2"
-                addAnswer()
-              }
-            )
+            ]
+          },
+          {
+            "linkId": "question-2"
           }
-        )
+        ]
       }
+    ]
+  }
+      """.trimIndent()
     state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
 
     val viewModel = QuestionnaireViewModel(state)
 
-    assertResourceEquals(viewModel.getQuestionnaireResponse(), questionnaireResponse)
+    assertResourceEquals(
+      viewModel.getQuestionnaireResponse(),
+      printer.parseResource(questionnaireResponseJsonString)
+    )
   }
 
   @Test
@@ -963,40 +966,44 @@ class QuestionnaireViewModelTest {
         )
       }
     val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
-    val questionnaireResponse =
-      QuestionnaireResponse().apply {
-        this.questionnaire = "Questionnaire/a-questionnaire"
-        addItem(
-          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-            linkId = "a-group-item"
-            addItem(
-              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-                linkId = "question-1"
-                addAnswer(
-                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    this.value = valueBooleanType.setValue(true)
-                  }
-                )
-              }
-            )
-            addItem(
-              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-                linkId = "question-2"
-                addAnswer(
-                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    this.value = valueBooleanType.setValue(true)
-                  }
-                )
-              }
-            )
-          }
-        )
-      }
+    val questionnaireResponseJsonString =
+      """
+        {
+          "resourceType": "QuestionnaireResponse",
+          "questionnaire": "Questionnaire/a-questionnaire",
+          "item": [
+            {
+              "linkId": "a-group-item",
+              "item": [
+                {
+                  "linkId": "question-1",
+                  "answer": [
+                    {
+                      "valueBoolean": true
+                    }
+                  ]
+                },
+                {
+                  "linkId": "question-2",
+                  "answer": [
+                    {
+                      "valueBoolean": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      """.trimIndent()
     state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
 
     val viewModel = QuestionnaireViewModel(state)
 
-    assertResourceEquals(viewModel.getQuestionnaireResponse(), questionnaireResponse)
+    assertResourceEquals(
+      viewModel.getQuestionnaireResponse(),
+      printer.parseResource(questionnaireResponseJsonString)
+    )
   }
 
   private fun createQuestionnaireViewModel(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -814,54 +814,6 @@ class QuestionnaireViewModelTest {
   }
 
   @Test
-  fun removeAnswers_questionnaireResponseItemHasAnswers_removeAnswers() {
-    val questionnaireResponse =
-      QuestionnaireResponse().apply {
-        this.questionnaire = "Questionnaire/a-questionnaire"
-        addItem(
-          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-            linkId = "a-item"
-            addItem(
-              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-                linkId = "a-coding-item"
-                addAnswer(
-                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    this.value =
-                      valueCoding.apply {
-                        code = "a-code-1"
-                        display = "a-display-1"
-                        system = "http://snomed.info/sct"
-                      }
-                  }
-                )
-              }
-            )
-            addItem(
-              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-                linkId = "a-coding-item"
-                addAnswer(
-                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    this.value =
-                      valueCoding.apply {
-                        code = "a-code-2"
-                        display = "a-display-2"
-                        system = "http://snomed.info/sct"
-                      }
-                  }
-                )
-              }
-            )
-          }
-        )
-      }
-
-    questionnaireResponse.item[0].item[0].removeAllNestedAnswers()
-
-    assertThat(questionnaireResponse.item[0].item[0].answer).isEmpty()
-    assertThat(questionnaireResponse.item[0].item[1].answer).hasSize(1)
-  }
-
-  @Test
   fun questionnaireItemWithInitialValue_enableWhenFalse_removeItemFromResponse() = runBlocking {
     val questionnaire =
       Questionnaire().apply {
@@ -912,9 +864,6 @@ class QuestionnaireViewModelTest {
                 "valueBoolean": false
               }
             ]
-          },
-          {
-            "linkId": "question-2"
           }
         ]
       }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -855,7 +855,7 @@ class QuestionnaireViewModelTest {
         )
       }
 
-    questionnaireResponse.item[0].item[0].removeAnswers()
+    questionnaireResponse.item[0].item[0].removeAllNestedAnswers()
 
     assertThat(questionnaireResponse.item[0].item[0].answer).isEmpty()
     assertThat(questionnaireResponse.item[0].item[1].answer).hasSize(1)


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #755 

**Description**
Add response item initial value to questionnaire response only if enablewhen is true.
Remove response item initial value from questionnaire response if enablewhen is false.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
