### PR TITLE
Handle Indexing of canonical types and uri types in referenced resources

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -38,6 +38,7 @@ import java.math.BigDecimal
 import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext
 import org.hl7.fhir.r4.model.Address
 import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.CanonicalType
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.DateType
@@ -255,8 +256,12 @@ internal object ResourceIndexer {
     }
 
   private fun referenceIndex(searchParam: SearchParamDefinition, value: Base): ReferenceIndex? {
-    val reference = (value as Reference).reference
-    return reference?.let { ReferenceIndex(searchParam.name, searchParam.path, it) }
+    return when (value) {
+        is Reference -> value.reference
+        is CanonicalType -> value.value
+        is UriType -> value.value
+        else -> throw UnsupportedOperationException("Value $value is not readable by SDK")
+      }?.let { ReferenceIndex(searchParam.name, searchParam.path, it) }
   }
 
   private fun quantityIndex(searchParam: SearchParamDefinition, value: Base): QuantityIndex? =

--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -257,11 +257,11 @@ internal object ResourceIndexer {
 
   private fun referenceIndex(searchParam: SearchParamDefinition, value: Base): ReferenceIndex? {
     return when (value) {
-        is Reference -> value.reference
-        is CanonicalType -> value.value
-        is UriType -> value.value
-        else -> throw UnsupportedOperationException("Value $value is not readable by SDK")
-      }?.let { ReferenceIndex(searchParam.name, searchParam.path, it) }
+      is Reference -> value.reference
+      is CanonicalType -> value.value
+      is UriType -> value.value
+      else -> throw UnsupportedOperationException("Value $value is not readable by SDK")
+    }?.let { ReferenceIndex(searchParam.name, searchParam.path, it) }
   }
 
   private fun quantityIndex(searchParam: SearchParamDefinition, value: Base): QuantityIndex? =

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -498,6 +498,57 @@ class ResourceIndexerTest {
   }
 
   @Test
+  fun index_reference_canonical_type() {
+    val relatedArtifact =
+      RelatedArtifact().apply {
+        this.id = "someRelatedArtifact"
+        this.resource = "Questionnaire/someQuestionnaire"
+        this.type = RelatedArtifact.RelatedArtifactType.DEPENDSON
+      }
+
+    val activityDefinition =
+      ActivityDefinition().apply {
+        this.id = "someActivityDefinition"
+        this.addLibrary("Library/someLibrary")
+
+        this.addRelatedArtifact(relatedArtifact)
+      }
+
+    val resourceIndices = ResourceIndexer.index(activityDefinition)
+
+    val indexPath =
+      "ActivityDefinition.relatedArtifact.where(type='depends-on').resource | ActivityDefinition.library"
+    val indexName = ActivityDefinition.SP_DEPENDS_ON
+
+    assertThat(resourceIndices.referenceIndices)
+      .containsExactly(
+        ReferenceIndex(indexName, indexPath, "Library/someLibrary"),
+        ReferenceIndex(indexName, indexPath, "Questionnaire/someQuestionnaire")
+      )
+  }
+
+  @Test
+  fun index_reference_uri_type() {
+    val planDefinition =
+      PlanDefinition().apply {
+        this.id = "somePlanDefinition"
+        this.addAction().definition = UriType("http://action1.com")
+        this.addAction().definition = UriType("http://action2.com")
+      }
+
+    val resourceIndices = ResourceIndexer.index(planDefinition)
+
+    val indexPath = "PlanDefinition.action.definition"
+    val indexName = PlanDefinition.SP_DEFINITION
+
+    assertThat(resourceIndices.referenceIndices)
+      .containsExactly(
+        ReferenceIndex(indexName, indexPath, "http://action1.com"),
+        ReferenceIndex(indexName, indexPath, "http://action2.com"),
+      )
+  }
+
+  @Test
   fun index_reference_null() {
     val patient =
       Patient().apply {
@@ -544,61 +595,6 @@ class ResourceIndexerTest {
         }
       )
       .isFalse()
-  }
-
-  @Test
-  fun index_reference_canonical_type() {
-    val libraries = mutableListOf("Library/someLibrary1", "Library/someLibrary2")
-
-    val relatedArtifact =
-      RelatedArtifact().apply {
-        this.id = "someRelatedArtifact"
-        this.resource = "Questionnaire/someQuestionnaire"
-        this.type = RelatedArtifact.RelatedArtifactType.DEPENDSON
-      }
-
-    val activityDefinition =
-      ActivityDefinition().apply {
-        this.id = "someActivityDefinition"
-        this.addLibrary(libraries[0])
-        this.addLibrary(libraries[1])
-
-        this.addRelatedArtifact(relatedArtifact)
-      }
-
-    val resourceIndices = ResourceIndexer.index(activityDefinition)
-
-    val indexPath =
-      "ActivityDefinition.relatedArtifact.where(type='depends-on').resource | ActivityDefinition.library"
-    val indexName = ActivityDefinition.SP_DEPENDS_ON
-
-    assertThat(resourceIndices.referenceIndices)
-      .containsExactly(
-        ReferenceIndex(indexName, indexPath, "Library/someLibrary1"),
-        ReferenceIndex(indexName, indexPath, "Library/someLibrary2"),
-        ReferenceIndex(indexName, indexPath, "Questionnaire/someQuestionnaire")
-      )
-  }
-
-  @Test
-  fun index_reference_uri_type() {
-    val planDefinition =
-      PlanDefinition().apply {
-        this.id = "somePlanDefinition"
-        this.addAction().definition = UriType("http://action1.com")
-        this.addAction().definition = UriType("http://action2.com")
-      }
-
-    val resourceIndices = ResourceIndexer.index(planDefinition)
-
-    val indexPath = "PlanDefinition.action.definition"
-    val indexName = PlanDefinition.SP_DEFINITION
-
-    assertThat(resourceIndices.referenceIndices)
-      .containsExactly(
-        ReferenceIndex(indexName, indexPath, "http://action1.com"),
-        ReferenceIndex(indexName, indexPath, "http://action2.com"),
-      )
   }
 
   @Test


### PR DESCRIPTION
Fixes #694 

**Description**
Resource properties which are in SearchParam reference but are of type Canonical/Uri are now handled and do not throw ClassCastException

**Alternative(s) considered**
No alternates. Ideally the resolved type and the SearchParam definition should have been of different type, but Reference, Canonical and Uri and closely related and handled in same way by hapi-fhir library. So we need to handle the resolved type properly

**Type**
Bug fix

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
