### PR TITLE
Fixed crash caused by java.lang.UnsupportedOperationException when evaluating Observation.component.valueQuantity

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -16,8 +16,6 @@
 
 package com.google.android.fhir.index
 
-import ca.uhn.fhir.context.FhirContext
-import ca.uhn.fhir.context.support.DefaultProfileValidationSupport
 import ca.uhn.fhir.model.api.annotation.SearchParamDefinition
 import com.google.android.fhir.ConverterException
 import com.google.android.fhir.UcumValue
@@ -35,7 +33,7 @@ import com.google.android.fhir.index.entities.UriIndex
 import com.google.android.fhir.logicalId
 import com.google.android.fhir.ucumUrl
 import java.math.BigDecimal
-import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext
+import org.hl7.fhir.r4.context.SimpleWorkerContext
 import org.hl7.fhir.r4.model.Address
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.CanonicalType
@@ -64,9 +62,9 @@ import org.hl7.fhir.r4.utils.FHIRPathEngine
  * [search parameters](https://www.hl7.org/fhir/searchparameter-registry.html).
  */
 internal object ResourceIndexer {
-  private val context = FhirContext.forR4()
-  private val fhirPathEngine =
-    FHIRPathEngine(HapiWorkerContext(context, DefaultProfileValidationSupport(context)))
+  // Switched HapiWorkerContext to SimpleWorkerContext as a fix for
+  // https://github.com/google/android-fhir/issues/768
+  private val fhirPathEngine = FHIRPathEngine(SimpleWorkerContext())
 
   fun <R : Resource> index(resource: R) = extractIndexValues(resource)
 

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -1394,6 +1394,86 @@ class ResourceIndexerTest {
       .hasSize(1)
   }
 
+  @Test
+  fun index_quantity_observation_valueQuantity() {
+    val observation =
+      Observation().apply {
+        addComponent().apply {
+          this.valueQuantity.apply {
+            value = BigDecimal.valueOf(70)
+            system = "http://unitsofmeasure.org"
+          }
+        }
+        addComponent().apply {
+          this.valueQuantity.apply {
+            value = BigDecimal.valueOf(110)
+            system = "http://unitsofmeasure.org"
+          }
+        }
+      }
+    // The indexer creates 2 QuantityIndex per valueQuantity in this particular example because each
+    // Observation.component.value can be indexed for both [Observation.SP_COMPONENT_VALUE_QUANTITY]
+    // and [Observation.SP_COMBO_VALUE_QUANTITY]
+    val resourceIndices = ResourceIndexer.index(observation)
+
+    assertThat(resourceIndices.quantityIndices)
+      .containsExactly(
+        QuantityIndex(
+          name = Observation.SP_COMPONENT_VALUE_QUANTITY,
+          path =
+            "(Observation.component.value as Quantity) " +
+              "| (Observation.component.value as SampledData)",
+          system = "http://unitsofmeasure.org",
+          unit = "",
+          code = "",
+          value = BigDecimal.valueOf(70),
+          canonicalCode = "",
+          canonicalValue = BigDecimal.ZERO
+        ),
+        QuantityIndex(
+          name = Observation.SP_COMPONENT_VALUE_QUANTITY,
+          path =
+            "(Observation.component.value as Quantity) " +
+              "| (Observation.component.value as SampledData)",
+          system = "http://unitsofmeasure.org",
+          unit = "",
+          code = "",
+          value = BigDecimal.valueOf(110),
+          canonicalCode = "",
+          canonicalValue = BigDecimal.ZERO
+        ),
+        QuantityIndex(
+          name = Observation.SP_COMBO_VALUE_QUANTITY,
+          path =
+            "(Observation.value as Quantity) " +
+              "| (Observation.value as SampledData) " +
+              "| (Observation.component.value as Quantity) " +
+              "| (Observation.component.value as SampledData)",
+          system = "http://unitsofmeasure.org",
+          unit = "",
+          code = "",
+          value = BigDecimal.valueOf(70),
+          canonicalCode = "",
+          canonicalValue = BigDecimal.ZERO
+        ),
+        QuantityIndex(
+          name = Observation.SP_COMBO_VALUE_QUANTITY,
+          path =
+            "(Observation.value as Quantity) " +
+              "| (Observation.value as SampledData) " +
+              "| (Observation.component.value as Quantity) " +
+              "| (Observation.component.value as SampledData)",
+          system = "http://unitsofmeasure.org",
+          unit = "",
+          code = "",
+          value = BigDecimal.valueOf(110),
+          canonicalCode = "",
+          canonicalValue = BigDecimal.ZERO
+        )
+      )
+      .inOrder()
+  }
+
   private companion object {
     // See: https://www.hl7.org/fhir/valueset-currencies.html
     const val FHIR_CURRENCY_SYSTEM = "urn:iso:std:iso:4217"


### PR DESCRIPTION

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #768 

**Description**
Switched HapiWorkerContext with SimpleWorkerContext in the ResourceIndexer. Added necessary unit test.
Additionally, locally tested against large file from [Synthea]( https://synthea.mitre.org/downloads) to make sure indexing works fine.

**Alternative(s) considered**
No

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
