### PR TITLE
Use hidden extension to hide the element.

### DIFF
--- a/reference/src/main/assets/new-patient-registration-paginated.json
+++ b/reference/src/main/assets/new-patient-registration-paginated.json
@@ -261,6 +261,10 @@
                     "expression": "ContactPoint$ContactPointSystem",
                     "name": "contactPointSystem"
                   }
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
+                  "valueBoolean": true
                 }
               ],
               "type": "string",
@@ -268,13 +272,6 @@
               "initial": [
                 {
                   "valueString": "phone"
-                }
-              ],
-              "enableWhen": [
-                {
-                  "question": "patient-0-gender",
-                  "operator": "=",
-                  "answerString": "ok"
                 }
               ]
             },


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #795 

**Description**
Earlier sdc library was not supporting hidden extension. Therefore to hide the element enablewhen element was used.
Currently, if element is not enabled then respective questionnaire response item get removed from questionnaire response at the time of request. 

Now, to hide the element hidden extension is used so that response item and initial value will be present in response.


**Alternative(s) considered**
No.

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
