### PR TITLE
Update deprecated jacoco block to testCoverage in build files

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -151,6 +151,8 @@ object Dependencies {
     const val sqlcipher = "4.5.0"
     const val truth = "1.0.1"
 
+    // Test dependencies
+
     object AndroidxTest {
       const val core = "1.2.0"
       const val archCore = "2.1.0"
@@ -160,6 +162,7 @@ object Dependencies {
     }
 
     const val espresso = "3.3.0"
+    const val jacoco = "0.8.7"
     const val junit = "4.13"
     const val mockitoKotlin = "3.2.0"
     const val robolectric = "4.5.1"

--- a/buildSrc/src/main/kotlin/JacocoConfig.kt
+++ b/buildSrc/src/main/kotlin/JacocoConfig.kt
@@ -52,9 +52,9 @@ fun Project.createJacocoTestReportTask() {
       )
     )
     reports {
-      xml.isEnabled = true
-      csv.isEnabled = false
-      html.isEnabled = true
+      xml.required.set(true)
+      csv.required.set(true)
+      html.required.set(true)
     }
     sourceDirectories.setFrom("$projectDir/src/main/java")
     classDirectories.setFrom(fileTree("$buildDir/tmp/kotlin-classes/debug"))
@@ -92,5 +92,5 @@ fun LibraryExtension.configureJacocoTestOptions() {
     unitTests.isIncludeAndroidResources = true
     unitTests.isReturnDefaultValues = true
   }
-  jacoco { version = "0.8.7" }
+  testCoverage { jacocoVersion = Dependencies.Versions.jacoco }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Update deprecated jacoco block to testCoverage in build files

**Alternative(s) considered**
NA

**Type**
Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
