### PR TITLE
Update validateQuestionnaireResponseItems function in Questionnaire view model to be aware of missing questionnaireResponse Items due to enableWhen being false

### DIFF
--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -272,7 +272,7 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
     val questionnaireResponse =
       QuestionnaireResponse().apply {
         id = "a-questionnaire-response"
@@ -287,11 +287,11 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniareResponse = printer.encodeResourceToString(questionnaireResponse)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaireResponse = printer.encodeResourceToString(questionnaireResponse)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
     state.set(
       QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE_RESPONSE,
-      serializedQuestionniareResponse
+      serializedQuestionnaireResponse
     )
 
     val errorMessage =
@@ -317,13 +317,13 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
     val questionnaireResponse = QuestionnaireResponse().apply { id = "a-questionnaire-response" }
-    val serializedQuestionniareResponse = printer.encodeResourceToString(questionnaireResponse)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaireResponse = printer.encodeResourceToString(questionnaireResponse)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
     state.set(
       QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE_RESPONSE,
-      serializedQuestionniareResponse
+      serializedQuestionnaireResponse
     )
 
     val errorMessage =
@@ -352,8 +352,8 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
     val viewModel = QuestionnaireViewModel(state)
 
     assertResourceEquals(
@@ -393,8 +393,8 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
     val viewModel = QuestionnaireViewModel(state)
 
     assertResourceEquals(
@@ -416,7 +416,7 @@ class QuestionnaireViewModelTest {
   }
 
   @Test
-  fun questionnaireHasInitialValueButQuestionnareResponseAsEmpty_shouldSetEmptyAnswer() {
+  fun questionnaireHasInitialValueButQuestionnaireResponseAsEmpty_shouldSetEmptyAnswer() {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
@@ -432,7 +432,7 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
     val questionnaireResponse =
       QuestionnaireResponse().apply {
         id = "a-questionnaire-response"
@@ -447,11 +447,11 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniareResponse = printer.encodeResourceToString(questionnaireResponse)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaireResponse = printer.encodeResourceToString(questionnaireResponse)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
     state.set(
       QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE_RESPONSE,
-      serializedQuestionniareResponse
+      serializedQuestionnaireResponse
     )
     QuestionnaireViewModel(state)
   }
@@ -475,8 +475,8 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
 
     val errorMessage =
       assertFailsWith<IllegalArgumentException> { QuestionnaireViewModel(state) }.localizedMessage
@@ -488,7 +488,7 @@ class QuestionnaireViewModelTest {
   }
 
   @Test
-  fun questionnareHasInitialValueAndGroupType_shouldThrowError() {
+  fun questionnaireHasInitialValueAndGroupType_shouldThrowError() {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
@@ -504,8 +504,8 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
 
     val errorMessage =
       assertFailsWith<IllegalArgumentException> { QuestionnaireViewModel(state) }.localizedMessage
@@ -517,7 +517,7 @@ class QuestionnaireViewModelTest {
   }
 
   @Test
-  fun questionnareHasInitialValueAndDisplayType_shouldThrowError() {
+  fun questionnaireHasInitialValueAndDisplayType_shouldThrowError() {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
@@ -533,8 +533,8 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
 
     val errorMessage =
       assertFailsWith<IllegalArgumentException> { QuestionnaireViewModel(state) }.localizedMessage
@@ -558,7 +558,7 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniare = printer.encodeResourceToString(questionnaire)
+    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
     val questionnaireResponse =
       QuestionnaireResponse().apply {
         id = "a-questionnaire-response"
@@ -583,11 +583,11 @@ class QuestionnaireViewModelTest {
           }
         )
       }
-    val serializedQuestionniareResponse = printer.encodeResourceToString(questionnaireResponse)
-    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionniare)
+    val serializedQuestionnaireResponse = printer.encodeResourceToString(questionnaireResponse)
+    state.set(QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE, serializedQuestionnaire)
     state.set(
       QuestionnaireFragment.BUNDLE_KEY_QUESTIONNAIRE_RESPONSE,
-      serializedQuestionniareResponse
+      serializedQuestionnaireResponse
     )
 
     val errorMessage =


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #836 

**Description**
Since there is a possibility of some questionnaireResponse items not being there in the QuestionnaireResponse, I am iterating over each questionnaire response and checking if the corresponding questionnaire Item is there. And also checking for cases where nested items are missing from the quesitonnaire Reponse.


**Alternative(s) considered**
No

**Type**
Bug fix

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
