### PR TITLE
Added configurable page size for each searchset

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/Configuration.kt
+++ b/engine/src/main/java/com/google/android/fhir/Configuration.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir
+
+/** Used to configure [FhirEngine] module. */
+data class Configuration(
+  /** Set the desired number of resources to be returned in each search-set bundle. */
+  val pageSize: Int = 500
+) {
+  /**
+   * Clients may implement [Provider] interface to provide [Configuration] for the [FhirEngine]
+   * module.
+   */
+  interface Provider {
+    fun getFhirEngineConfiguration(): Configuration
+  }
+}

--- a/engine/src/main/java/com/google/android/fhir/FhirEngineProvider.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngineProvider.kt
@@ -21,6 +21,7 @@ import android.content.Context
 /** The builder for [FhirEngine] instance */
 object FhirEngineProvider {
   lateinit var fhirEngine: FhirEngine
+  internal lateinit var configuration: Configuration
 
   /**
    * Returns the cached [FhirEngine] instance. Creates a new instance from the supplied [Context] if
@@ -30,7 +31,26 @@ object FhirEngineProvider {
   fun getInstance(context: Context): FhirEngine {
     if (!::fhirEngine.isInitialized) {
       fhirEngine = FhirServices.builder(context.applicationContext).build().fhirEngine
+
+      if (!::configuration.isInitialized) {
+        val appContext = context.applicationContext
+        configuration =
+          if (appContext is Configuration.Provider) {
+            appContext.getFhirEngineConfiguration()
+          } else {
+            Configuration()
+          }
+      }
     }
     return fhirEngine
+  }
+
+  /**
+   * The client may set the [Configuration] for the [FhirEngine] module using this api.
+   * [Configuration] should only be set once, calling this api again may cause exception.
+   */
+  fun initialize(configuration: Configuration) {
+    check(!FhirEngineProvider::configuration.isInitialized) { "FhirEngine is already initialized" }
+    this.configuration = configuration
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #860

**Description**
Added Configuration for the FhirEngine module and clients can set pageSize using this configuration. The page size then decides the count of items that library would fetch in individual get calls. If the page size is greater than supported by the Fhir server, server just return the max items.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
