### PR TITLE
Always canonicalize quantity values

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/QuantityIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/QuantityIndexEntity.kt
@@ -27,16 +27,7 @@ import org.hl7.fhir.r4.model.ResourceType
 @Entity(
   indices =
     [
-      Index(
-        value =
-          [
-            "resourceType",
-            "index_name",
-            "index_value",
-            "index_code",
-            "index_canonicalValue",
-            "index_canonicalCode"]
-      ),
+      Index(value = ["resourceType", "index_name", "index_value", "index_code"]),
       Index(
         // keep this index for faster foreign lookup
         value = ["resourceId", "resourceType"]

--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -79,7 +79,7 @@ internal object ResourceIndexer {
             numberIndex(searchParam, value)?.also { indexBuilder.addNumberIndex(it) }
           SearchParamType.DATE ->
             if (value.fhirType() == "date") {
-              dateIndex(searchParam, value)?.also { indexBuilder.addDateIndex(it) }
+              dateIndex(searchParam, value).also { indexBuilder.addDateIndex(it) }
             } else {
               dateTimeIndex(searchParam, value)?.also { indexBuilder.addDateTimeIndex(it) }
             }
@@ -290,9 +290,7 @@ internal object ResourceIndexer {
             searchParam.path,
             FHIR_CURRENCY_CODE_SYSTEM,
             money.currency,
-            money.value,
-            "",
-            BigDecimal.ZERO
+            money.value
           )
         )
       }
@@ -303,21 +301,13 @@ internal object ResourceIndexer {
         // Add quantity indexing record for the human readable unit
         if (quantity.unit != null) {
           quantityIndices.add(
-            QuantityIndex(
-              searchParam.name,
-              searchParam.path,
-              "",
-              quantity.unit,
-              quantity.value,
-              "",
-              BigDecimal.ZERO
-            )
+            QuantityIndex(searchParam.name, searchParam.path, "", quantity.unit, quantity.value)
           )
         }
 
         // Add quantity indexing record for the coded unit
-        var canonicalCode = ""
-        var canonicalValue = BigDecimal.ZERO
+        var canonicalCode = quantity.code
+        var canonicalValue = quantity.value
         if (quantity.system == ucumUrl && quantity.code != null) {
           try {
             val ucumUnit = UnitConverter.getCanonicalForm(UcumValue(quantity.code, quantity.value))
@@ -332,9 +322,7 @@ internal object ResourceIndexer {
             searchParam.name,
             searchParam.path,
             quantity.system ?: "",
-            quantity.code ?: "",
-            quantity.value,
-            canonicalCode,
+            canonicalCode ?: "",
             canonicalValue
           )
         )

--- a/engine/src/main/java/com/google/android/fhir/index/entities/QuantityIndex.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/entities/QuantityIndex.kt
@@ -28,7 +28,5 @@ internal data class QuantityIndex(
   val path: String,
   val system: String,
   val code: String,
-  val value: BigDecimal,
-  val canonicalCode: String,
-  val canonicalValue: BigDecimal
+  val value: BigDecimal
 )

--- a/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
@@ -361,48 +361,42 @@ internal fun getConditionParamPair(
   system: String?,
   unit: String?
 ): ConditionParam<Any> {
-  // value cannot be null -> the value condition will always be present
-  val valueConditionParam = getConditionParamPair(prefix, value)
-  val argList = mutableListOf<Any>()
+  var canonicalizedUnit = unit
+  var canonicalizedValue = value
 
-  val condition = StringBuilder()
-  val canonicalCondition = StringBuilder()
-  val nonCanonicalCondition = StringBuilder()
-
-  if (system != null) {
-    argList.add(system)
-    condition.append("index_system = ? AND ")
-  }
-
-  if (unit != null) {
-    argList.add(unit)
-    nonCanonicalCondition.append("index_code = ? AND ")
-  }
-
-  nonCanonicalCondition.append(valueConditionParam.condition)
-  argList.addAll(valueConditionParam.params)
-
+  // Canonicalize the unit if possible. For example, 1000 g will be canonilized to 1 kg
   if (system == ucumUrl && unit != null) {
     try {
-      val ucumUnit = UnitConverter.getCanonicalForm(UcumValue(unit, value))
-      val canonicalConditionParam = getConditionParamPair(prefix, ucumUnit.value)
-      argList.add(ucumUnit.code)
-      argList.addAll(canonicalConditionParam.params)
-      canonicalCondition
-        .append("index_canonicalCode = ? AND ")
-        .append(canonicalConditionParam.condition.replace("index_value", "index_canonicalValue"))
+      val ucumValue = UnitConverter.getCanonicalForm(UcumValue(unit, value))
+      canonicalizedUnit = ucumValue.code
+      canonicalizedValue = ucumValue.value
     } catch (exception: ConverterException) {
       exception.printStackTrace()
     }
   }
 
-  // Add OR only when canonical match is possible
-  if (canonicalCondition.isNotEmpty()) {
-    condition.append("($nonCanonicalCondition OR $canonicalCondition)")
-  } else {
-    condition.append(nonCanonicalCondition)
+  val queryBuilder = StringBuilder()
+  val argList = mutableListOf<Any>()
+
+  // system condition will be preceded by a value condition so if exists append an AND here
+  if (system != null) {
+    queryBuilder.append("index_system = ? AND ")
+    argList.add(system)
   }
-  return ConditionParam(condition.toString(), argList)
+
+  // if the unit condition will be preceded by a value condition so if exists append an AND here
+  if (canonicalizedUnit != null) {
+    queryBuilder.append("index_code = ? AND ")
+    argList.add(canonicalizedUnit)
+  }
+
+  // add value condition
+  // value cannot be null -> the value condition will always be present
+  val valueConditionParam = getConditionParamPair(prefix, canonicalizedValue)
+  queryBuilder.append(valueConditionParam.condition)
+  argList.addAll(valueConditionParam.params)
+
+  return ConditionParam(queryBuilder.toString(), argList)
 }
 
 /**

--- a/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
@@ -364,7 +364,7 @@ internal fun getConditionParamPair(
   var canonicalizedUnit = unit
   var canonicalizedValue = value
 
-  // Canonicalize the unit if possible. For example, 1000 g will be canonilized to 1 kg
+  // Canonicalize the unit if possible. For example, 1 kg will be canonicalized to 1000 g
   if (system == ucumUrl && unit != null) {
     try {
       val ucumValue = UnitConverter.getCanonicalForm(UcumValue(unit, value))

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -692,15 +692,7 @@ class ResourceIndexerTest {
 
     assertThat(resourceIndices.quantityIndices)
       .contains(
-        QuantityIndex(
-          "totalnet",
-          "Invoice.totalNet",
-          FHIR_CURRENCY_SYSTEM,
-          currency,
-          value,
-          "",
-          BigDecimal.ZERO
-        )
+        QuantityIndex("totalnet", "Invoice.totalNet", FHIR_CURRENCY_SYSTEM, currency, value)
       )
   }
 
@@ -717,15 +709,7 @@ class ResourceIndexerTest {
 
     assertThat(resourceIndices.quantityIndices)
       .contains(
-        QuantityIndex(
-          "quantity",
-          "Substance.instance.quantity",
-          "",
-          "",
-          BigDecimal.valueOf(value),
-          "",
-          BigDecimal.ZERO
-        )
+        QuantityIndex("quantity", "Substance.instance.quantity", "", "", BigDecimal.valueOf(value))
       )
   }
 
@@ -750,9 +734,7 @@ class ResourceIndexerTest {
           "Substance.instance.quantity",
           "",
           "kg",
-          BigDecimal.valueOf(value),
-          "",
-          BigDecimal.ZERO
+          BigDecimal.valueOf(value)
         )
       )
   }
@@ -777,8 +759,6 @@ class ResourceIndexerTest {
           "quantity",
           "Substance.instance.quantity",
           "http://unitsofmeasure.org",
-          "mg",
-          BigDecimal.valueOf(value),
           "g",
           BigDecimal("0.100")
         )
@@ -808,9 +788,7 @@ class ResourceIndexerTest {
           "Substance.instance.quantity",
           "http://unitsofmeasure.org",
           "randomUnit",
-          BigDecimal.valueOf(value),
-          "",
-          BigDecimal.ZERO
+          BigDecimal.valueOf(value)
         )
       )
   }
@@ -926,18 +904,14 @@ class ResourceIndexerTest {
           "Invoice.totalGross",
           FHIR_CURRENCY_SYSTEM,
           testInvoice.totalGross.currency,
-          testInvoice.totalGross.value,
-          "",
-          BigDecimal.ZERO
+          testInvoice.totalGross.value
         ),
         QuantityIndex(
           "totalnet",
           "Invoice.totalNet",
           FHIR_CURRENCY_SYSTEM,
           testInvoice.totalNet.currency,
-          testInvoice.totalNet.value,
-          "",
-          BigDecimal.ZERO
+          testInvoice.totalNet.value
         )
       )
 
@@ -1528,9 +1502,7 @@ class ResourceIndexerTest {
               "| (Observation.component.value as SampledData)",
           system = "http://unitsofmeasure.org",
           code = "",
-          value = BigDecimal.valueOf(70),
-          canonicalCode = "",
-          canonicalValue = BigDecimal.ZERO
+          value = BigDecimal.valueOf(70)
         ),
         QuantityIndex(
           name = Observation.SP_COMPONENT_VALUE_QUANTITY,
@@ -1539,9 +1511,7 @@ class ResourceIndexerTest {
               "| (Observation.component.value as SampledData)",
           system = "http://unitsofmeasure.org",
           code = "",
-          value = BigDecimal.valueOf(110),
-          canonicalCode = "",
-          canonicalValue = BigDecimal.ZERO
+          value = BigDecimal.valueOf(110)
         ),
         QuantityIndex(
           name = Observation.SP_COMBO_VALUE_QUANTITY,
@@ -1552,9 +1522,7 @@ class ResourceIndexerTest {
               "| (Observation.component.value as SampledData)",
           system = "http://unitsofmeasure.org",
           code = "",
-          value = BigDecimal.valueOf(70),
-          canonicalCode = "",
-          canonicalValue = BigDecimal.ZERO
+          value = BigDecimal.valueOf(70)
         ),
         QuantityIndex(
           name = Observation.SP_COMBO_VALUE_QUANTITY,
@@ -1565,9 +1533,7 @@ class ResourceIndexerTest {
               "| (Observation.component.value as SampledData)",
           system = "http://unitsofmeasure.org",
           code = "",
-          value = BigDecimal.valueOf(110),
-          canonicalCode = "",
-          canonicalValue = BigDecimal.ZERO
+          value = BigDecimal.valueOf(110)
         )
       )
   }

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -740,6 +740,28 @@ class ResourceIndexerTest {
   }
 
   @Test
+  fun index_quantity_null() {
+    val substance =
+      Substance().apply {
+        id = "non-null-ID"
+        instance.add(Substance.SubstanceInstanceComponent().setQuantity(null))
+      }
+
+    val resourceIndices = ResourceIndexer.index(substance)
+
+    assertThat(
+        resourceIndices.quantityIndices.any { quantityIndex -> quantityIndex.name == "quantity" }
+      )
+      .isFalse()
+    assertThat(
+        resourceIndices.quantityIndices.any { quantityIndex ->
+          quantityIndex.path == "Substance.instance.quantity"
+        }
+      )
+      .isFalse()
+  }
+
+  @Test
   fun index_quantity_quantity_code_canonicalized() {
     val value = (100).toLong()
     val substance =
@@ -791,28 +813,6 @@ class ResourceIndexerTest {
           BigDecimal.valueOf(value)
         )
       )
-  }
-
-  @Test
-  fun index_quantity_null() {
-    val substance =
-      Substance().apply {
-        id = "non-null-ID"
-        instance.add(Substance.SubstanceInstanceComponent().setQuantity(null))
-      }
-
-    val resourceIndices = ResourceIndexer.index(substance)
-
-    assertThat(
-        resourceIndices.quantityIndices.any { quantityIndex -> quantityIndex.name == "quantity" }
-      )
-      .isFalse()
-    assertThat(
-        resourceIndices.quantityIndices.any { quantityIndex ->
-          quantityIndex.path == "Substance.instance.quantity"
-        }
-      )
-      .isFalse()
   }
 
   @Test

--- a/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/ResourceIndexerTest.kt
@@ -680,48 +680,49 @@ class ResourceIndexerTest {
 
   @Test
   fun index_quantity_money() {
-    val currency = "EU"
-    val value = BigDecimal.valueOf(300)
     val testInvoice =
       Invoice().apply {
         id = "non_NULL_ID"
-        totalNet = Money().setCurrency(currency).setValue(value)
+        totalNet = Money().setCurrency("EU").setValue(BigDecimal.valueOf(300))
       }
 
     val resourceIndices = ResourceIndexer.index(testInvoice)
 
     assertThat(resourceIndices.quantityIndices)
       .contains(
-        QuantityIndex("totalnet", "Invoice.totalNet", FHIR_CURRENCY_SYSTEM, currency, value)
+        QuantityIndex(
+          "totalnet",
+          "Invoice.totalNet",
+          FHIR_CURRENCY_SYSTEM,
+          "EU",
+          BigDecimal.valueOf(300)
+        )
       )
   }
 
   @Test
   fun index_quantity_quantity_noUnitOrCode() {
-    val value = (100).toLong()
     val substance =
       Substance().apply {
         id = "non-null-ID"
-        instance.add(Substance.SubstanceInstanceComponent().setQuantity(Quantity(value)))
+        instance.add(Substance.SubstanceInstanceComponent().setQuantity(Quantity(100L)))
       }
 
     val resourceIndices = ResourceIndexer.index(substance)
 
     assertThat(resourceIndices.quantityIndices)
       .contains(
-        QuantityIndex("quantity", "Substance.instance.quantity", "", "", BigDecimal.valueOf(value))
+        QuantityIndex("quantity", "Substance.instance.quantity", "", "", BigDecimal.valueOf(100L))
       )
   }
 
   @Test
   fun index_quantity_quantity_unit() {
-    val value = (100).toLong()
     val substance =
       Substance().apply {
         id = "non-null-ID"
         instance.add(
-          Substance.SubstanceInstanceComponent()
-            .setQuantity(Quantity(null, value, null, null, "kg"))
+          Substance.SubstanceInstanceComponent().setQuantity(Quantity(null, 100L, null, null, "kg"))
         )
       }
 
@@ -729,13 +730,7 @@ class ResourceIndexerTest {
 
     assertThat(resourceIndices.quantityIndices)
       .contains(
-        QuantityIndex(
-          "quantity",
-          "Substance.instance.quantity",
-          "",
-          "kg",
-          BigDecimal.valueOf(value)
-        )
+        QuantityIndex("quantity", "Substance.instance.quantity", "", "kg", BigDecimal.valueOf(100L))
       )
   }
 
@@ -763,13 +758,12 @@ class ResourceIndexerTest {
 
   @Test
   fun index_quantity_quantity_code_canonicalized() {
-    val value = (100).toLong()
     val substance =
       Substance().apply {
         id = "non-null-ID"
         instance.add(
           Substance.SubstanceInstanceComponent()
-            .setQuantity(Quantity(value).setSystem("http://unitsofmeasure.org").setCode("mg"))
+            .setQuantity(Quantity(100L).setSystem("http://unitsofmeasure.org").setCode("mg"))
         )
       }
 
@@ -789,14 +783,13 @@ class ResourceIndexerTest {
 
   @Test
   fun index_quantity_quantity_code_notCanonicalized() {
-    val value = (100).toLong()
     val substance =
       Substance().apply {
         id = "non-null-ID"
         instance.add(
           Substance.SubstanceInstanceComponent()
             .setQuantity(
-              Quantity(value).setSystem("http://unitsofmeasure.org").setCode("randomUnit")
+              Quantity(100L).setSystem("http://unitsofmeasure.org").setCode("randomUnit")
             )
         )
       }
@@ -810,23 +803,23 @@ class ResourceIndexerTest {
           "Substance.instance.quantity",
           "http://unitsofmeasure.org",
           "randomUnit",
-          BigDecimal.valueOf(value)
+          BigDecimal.valueOf(100L)
         )
       )
   }
 
   @Test
   fun index_uri() {
-    val urlString = "www.someDomainName.someDomain"
     val device =
       Device().apply {
         id = "non-null-ID"
-        url = urlString
+        url = "www.someDomainName.someDomain"
       }
 
     val resourceIndices = ResourceIndexer.index(device)
 
-    assertThat(resourceIndices.uriIndices).contains(UriIndex("url", "Device.url", urlString))
+    assertThat(resourceIndices.uriIndices)
+      .contains(UriIndex("url", "Device.url", "www.someDomainName.someDomain"))
   }
 
   @Test

--- a/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
@@ -2151,7 +2151,7 @@ class SearchTest {
         AND a.resourceId IN (
         SELECT resourceId FROM QuantityIndexEntity
         WHERE resourceType= ? AND index_name = ?
-        AND index_system = ? AND (index_code = ? AND index_value >= ? AND index_value < ? OR index_canonicalCode = ? AND index_canonicalValue >= ? AND index_canonicalValue < ?)
+        AND index_system = ? AND index_code = ? AND index_value >= ? AND index_value < ?
         )
         """.trimIndent()
       )
@@ -2162,9 +2162,6 @@ class SearchTest {
           ResourceType.Observation.name,
           Observation.VALUE_QUANTITY.paramName,
           "http://unitsofmeasure.org",
-          "mg",
-          BigDecimal("5402.5").toDouble(),
-          BigDecimal("5403.5").toDouble(),
           "g",
           BigDecimal("5.4025").toDouble(),
           BigDecimal("5.4035").toDouble()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #733 

**Description**
Always canonicalize quantity values in the quantity index table.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
