### PR TITLE
Update datastore version from 1.0.0-rc02 to 1.0.0 

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -115,7 +115,7 @@ object Dependencies {
       const val activity = "1.2.1"
       const val appCompat = "1.1.0"
       const val constraintLayout = "1.1.3"
-      const val datastorePref = "1.0.0-rc02"
+      const val datastorePref = "1.0.0"
       const val fragmentKtx = "1.3.1"
       const val lifecycle = "2.2.0"
       const val navigation = "2.3.4"


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #947

**Description**
Update datastore version from 1.0.0-rc02 to 1.0.0

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
N/A

**Type**
Choose one: Code health

**Screenshots (if applicable)**
N/A

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
