### PR TITLE
Reference App crashed on search.

### DIFF
--- a/reference/src/main/java/com/google/android/fhir/reference/PatientDetailsViewModel.kt
+++ b/reference/src/main/java/com/google/android/fhir/reference/PatientDetailsViewModel.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.db.ResourceNotFoundException
 import com.google.android.fhir.logicalId
 import com.google.android.fhir.search.search
 import java.time.LocalDate
@@ -51,7 +52,13 @@ class PatientDetailsViewModel(
 
   /** Emits list of [PatientDetailData]. */
   fun getPatientDetailData() {
-    viewModelScope.launch { livePatientData.value = getPatientDetailDataModel() }
+    viewModelScope.launch {
+      try {
+        livePatientData.value = getPatientDetailDataModel()
+      } catch (exception: ResourceNotFoundException) {
+        exception.printStackTrace()
+      }
+    }
   }
 
   private suspend fun getPatient(): PatientListViewModel.PatientItem {

--- a/reference/src/main/java/com/google/android/fhir/reference/PatientListViewModel.kt
+++ b/reference/src/main/java/com/google/android/fhir/reference/PatientListViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import ca.uhn.fhir.parser.DataFormatException
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.search.Order
 import com.google.android.fhir.search.Search
@@ -60,7 +61,11 @@ class PatientListViewModel(application: Application, private val fhirEngine: Fhi
     count: suspend () -> Long
   ) {
     viewModelScope.launch {
-      liveSearchedPatients.value = search()
+      try {
+        liveSearchedPatients.value = search()
+      } catch (exception: DataFormatException) {
+        exception.printStackTrace()
+      }
       patientCount.value = count()
     }
   }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #877 

**Description**
There are two fatal exceptions.
1. As per the attached log, exception is dataformat exception which was caused at the time of json parsing. Just remove the separator which is used to separate the object entity in resource  entity under the serialised resource section. Now, this exception is caught in reference application so that it will not crash the app
2. Another exception is ResourceNotFoundException which get thrown by engine module. To reproduce it just update the patient id which is not present in resource entity table in serialized resource column. When user click on origin patient item on patient list, it throws ResourceNotFoundException. Now exception is caught at application side, so that it will not crash the app.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
