### PR TITLE
Reformat LocalChangeUtils.kt to avoid spotless divergence

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeUtils.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeUtils.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeUtils.kt
@@ -90,10 +90,12 @@ internal object LocalChangeUtils {
   /** Calculates the JSON patch between two [Resource] s. */
   internal fun diff(parser: IParser, source: Resource, target: Resource): JSONArray {
     val objectMapper = ObjectMapper()
-    return getFilteredJSONArray(JsonDiff.asJson(
+    return getFilteredJSONArray(
+      JsonDiff.asJson(
         objectMapper.readValue(parser.encodeResourceToString(source), JsonNode::class.java),
         objectMapper.readValue(parser.encodeResourceToString(target), JsonNode::class.java)
-      ))
+      )
+    )
   }
 
   /**
@@ -109,17 +111,22 @@ internal object LocalChangeUtils {
   }
 
   /**
-   * This function returns the json diff as a json array of operation objects. We remove the "/meta" and
-   * "/text" paths as they cause path not found issue when we update the resource. They are usually
-   * present in the downloaded resource object but are missing in the edited object as these aren't
-   * supposed to be edited. Thus, the Json diff creates a DELETE- OP for "/meta" and "/text" and
-   * causes the issue with server update.
+   * This function returns the json diff as a json array of operation objects. We remove the "/meta"
+   * and "/text" paths as they cause path not found issue when we update the resource. They are
+   * usually present in the downloaded resource object but are missing in the edited object as these
+   * aren't supposed to be edited. Thus, the Json diff creates a DELETE- OP for "/meta" and "/text"
+   * and causes the issue with server update.
    *
-   * An unfiltered JSON Array for family name update looks like ```[{"op":"remove","path":"/meta"},
-   * {"op":"remove","path":"/text"}, {"op":"replace","path":"/name/0/family","value":"Nucleus"}]```
+   * An unfiltered JSON Array for family name update looks like
+   * ```
+   * [{"op":"remove","path":"/meta"}, {"op":"remove","path":"/text"},
+   * {"op":"replace","path":"/name/0/family","value":"Nucleus"}]
+   * ```
    *
    * A filtered JSON Array for family name update looks like
-   * ```[{"op":"replace","path":"/name/0/family","value":"Nucleus"}]```
+   * ```
+   * [{"op":"replace","path":"/name/0/family","value":"Nucleus"}]
+   * ```
    */
   private fun getFilteredJSONArray(jsonDiff: JsonNode) =
     with(JSONArray(jsonDiff.toString())) {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #823

**Description**
Update and reformat the comment on line 113-130 so the spotlessCheck can converge

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

The alternative way for fixing this can be: Change the way how spotless handles the comment format. But Spotless is out of our control and the android-fhir project scope.

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)
Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
