### PR TITLE
Fixed failing tests of AutoCompleteTextView for lower android versions.

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest.kt
@@ -45,6 +45,7 @@ class QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest {
   private lateinit var viewHolder: QuestionnaireItemViewHolder
 
   @Before
+  @UiThreadTest
   fun setUp() {
     context =
       ContextThemeWrapper(

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryInstrumentedTest.kt
@@ -44,6 +44,7 @@ class QuestionnaireItemDropDownViewHolderFactoryInstrumentedTest {
   private lateinit var viewHolder: QuestionnaireItemViewHolder
 
   @Before
+  @UiThreadTest
   fun setUp() {
     context =
       ContextThemeWrapper(


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #970 

**Description**
After analyzing the trace, Added `@UiThreadTest` to the setup for tests where the Layout was getting inflated.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
