### PR TITLE
Update the cql evaluator version to 1.4.2 (and downgrade junit to 4.12)

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -203,7 +203,7 @@ object Dependencies {
 
     const val espresso = "3.3.0"
     const val jacoco = "0.8.7"
-    const val junit = "4.13"
+    const val junit = "4.12"
     const val mockitoKotlin = "3.2.0"
     const val mockitoInline = "4.0.0"
     const val robolectric = "4.5.1"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -155,8 +155,7 @@ object Dependencies {
     }
 
     object Cql {
-      const val cqlEngine = "1.3.14-SNAPSHOT"
-      const val evaluator = "1.3.1-SNAPSHOT"
+      const val evaluator = "1.4.2"
     }
 
     object JavaJsonTools {

--- a/buildSrc/src/main/kotlin/LicenseeConfig.kt
+++ b/buildSrc/src/main/kotlin/LicenseeConfig.kt
@@ -64,11 +64,6 @@ fun Project.configureLicensee() {
       because("Custom license, essentially BSD-3. https://www.zetetic.net/sqlcipher/license/")
     }
 
-    // JAXB https://github.com/eclipse-ee4j/jaxb-ri
-    allowDependency("jakarta.xml.bind", "jakarta.xml.bind-api", "2.3.3") {
-      because("BSD 3-clause.")
-    }
-
     // Javax Annotation API
     allowDependency("javax.annotation", "javax.annotation-api", "1.3.2") {
       because("Dual-licensed under CDDL 1.1 and GPL v2 with classpath exception.")

--- a/buildSrc/src/main/kotlin/LicenseeConfig.kt
+++ b/buildSrc/src/main/kotlin/LicenseeConfig.kt
@@ -64,6 +64,11 @@ fun Project.configureLicensee() {
       because("Custom license, essentially BSD-3. https://www.zetetic.net/sqlcipher/license/")
     }
 
+    // JAXB https://github.com/eclipse-ee4j/jaxb-ri
+    allowDependency("jakarta.xml.bind", "jakarta.xml.bind-api", "2.3.3") {
+      because("BSD 3-clause.")
+    }
+
     // Javax Annotation API
     allowDependency("javax.annotation", "javax.annotation-api", "1.3.2") {
       because("Dual-licensed under CDDL 1.1 and GPL v2 with classpath exception.")

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -92,13 +92,9 @@ configurations {
     exclude(module = "xpp3")
     exclude(group = "net.sf.saxon", module = "Saxon-HE")
     exclude(module = "hamcrest-all")
-    exclude(module = "jaxb-impl")
-    exclude(module = "jaxb-core")
     exclude(module = "jakarta.activation-api")
     exclude(module = "javax.activation")
     exclude(module = "jakarta.xml.bind-api")
-    // TODO =  the following line can be removed from the next CQL engine release.
-    exclude(module = "hapi-fhir-jpaserver-base")
   }
 }
 

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -85,8 +85,6 @@ android {
         "META-INF/NOTICE.md",
         "META-INF/notice.txt",
         "META-INF/LGPL-3.0.txt",
-        "META-INF/sun-jaxb.episode",
-        "META-INF/sun-jaxb.episode",
         "META-INF/*.kotlin_module",
         "readme.html",
       )
@@ -114,7 +112,6 @@ configurations {
     exclude(group = "org.eclipse.persistence")
     exclude(group = "com.google.code.javaparser")
     exclude(group = "jakarta.activation")
-    // exclude(group = "jakarta.xml.bind")
   }
 }
 

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -85,6 +85,7 @@ android {
         "META-INF/NOTICE.md",
         "META-INF/notice.txt",
         "META-INF/LGPL-3.0.txt",
+        "META-INF/sun-jaxb.episode",
         "META-INF/*.kotlin_module",
         "readme.html",
       )


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Update the cql evaluator version to 1.4.2 and remove redundant module exclusions.

**NOTE:** junit is downgraded to 4.12 in this PR due to a dependency issue:

```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':workflow:lintAnalyzeDebug'.
> Could not resolve all files for configuration ':workflow:debugAndroidTestRuntimeClasspath'.
   > Could not resolve junit:junit:4.13.
     Required by:
         project :workflow
      > Cannot find a version of 'junit:junit' that satisfies the version constraints:
           Dependency path 'android-fhir:workflow:unspecified' --> 'junit:junit:4.13'
           Constraint path 'android-fhir:workflow:unspecified' --> 'junit:junit:{strictly 4.12}' because of the following reason: debugRuntimeClasspath uses version 4.12
           Dependency path 'android-fhir:workflow:unspecified' --> 'androidx.test.ext:junit:1.1.3' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'androidx.test:runner:1.4.0' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'com.google.truth:truth:1.0.1' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'android-fhir:workflow:unspecified' (debugRuntimeElements) --> 'android-fhir:engine:unspecified' (debugRuntimeElements) --> 'com.google.android.fhir:common:0.1.0-alpha02' (releaseRuntimePublication) --> 'org.jetbrains.kotlin:kotlin-test-junit:1.5.31' (junitRuntime) --> 'junit:junit:4.12'
   > Could not resolve junit:junit:{strictly 4.12}.
     Required by:
         project :workflow
      > Cannot find a version of 'junit:junit' that satisfies the version constraints:
           Dependency path 'android-fhir:workflow:unspecified' --> 'junit:junit:4.13'
           Constraint path 'android-fhir:workflow:unspecified' --> 'junit:junit:{strictly 4.12}' because of the following reason: debugRuntimeClasspath uses version 4.12
           Dependency path 'android-fhir:workflow:unspecified' --> 'androidx.test.ext:junit:1.1.3' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'androidx.test:runner:1.4.0' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'com.google.truth:truth:1.0.1' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'android-fhir:workflow:unspecified' (debugRuntimeElements) --> 'android-fhir:engine:unspecified' (debugRuntimeElements) --> 'com.google.android.fhir:common:0.1.0-alpha02' (releaseRuntimePublication) --> 'org.jetbrains.kotlin:kotlin-test-junit:1.5.31' (junitRuntime) --> 'junit:junit:4.12'
   > Could not resolve junit:junit:4.12.
     Required by:
         project :workflow > androidx.test.ext:junit:1.1.3
         project :workflow > androidx.test:runner:1.4.0
         project :workflow > com.google.truth:truth:1.0.1
         project :workflow > org.jetbrains.kotlin:kotlin-test-junit:1.5.31
      > Cannot find a version of 'junit:junit' that satisfies the version constraints:
           Dependency path 'android-fhir:workflow:unspecified' --> 'junit:junit:4.13'
           Constraint path 'android-fhir:workflow:unspecified' --> 'junit:junit:{strictly 4.12}' because of the following reason: debugRuntimeClasspath uses version 4.12
           Dependency path 'android-fhir:workflow:unspecified' --> 'androidx.test.ext:junit:1.1.3' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'androidx.test:runner:1.4.0' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'com.google.truth:truth:1.0.1' (runtime) --> 'junit:junit:4.12'
           Dependency path 'android-fhir:workflow:unspecified' --> 'android-fhir:workflow:unspecified' (debugRuntimeElements) --> 'android-fhir:engine:unspecified' (debugRuntimeElements) --> 'com.google.android.fhir:common:0.1.0-alpha02' (releaseRuntimePublication) --> 'org.jetbrains.kotlin:kotlin-test-junit:1.5.31' (junitRuntime) --> 'junit:junit:4.12'
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 52s
```

**Alternative(s) considered**
NA

**Type**
Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
