### PR TITLE
Bump up the version of fhir engine to alpha06

### DIFF
--- a/buildSrc/src/main/kotlin/Releases.kt
+++ b/buildSrc/src/main/kotlin/Releases.kt
@@ -29,7 +29,7 @@ object Releases {
 
   object Engine {
     const val artifactId = "engine"
-    const val version = "0.1.0-alpha05"
+    const val version = "0.1.0-alpha06"
     const val name = "Android FHIR Engine Library"
   }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1005 

**Description**
Bump up the version of fhir engine for a new release to resolve #1005.

This issue is partially resolved for data capture library clients who do not depend on earlier versions of fhir engine. However, if developers use an earlier version of fhir engine, a duplicated class exception will be thrown due to the common lib code being part of fhir engine.

The dependency change has already been included in #1017 for the engine library.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Releases

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
