### PR TITLE
Cleaned up the questionnaire json to have either definition or itemExtractionContext for an item.

### DIFF
--- a/demo/src/main/assets/new-patient-registration-paginated.json
+++ b/demo/src/main/assets/new-patient-registration-paginated.json
@@ -44,16 +44,6 @@
           "linkId": "PR-name",
           "type": "group",
           "definition": "http://hl7.org/fhir/StructureDefinition/Patient#Patient.name",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-              "valueExpression": {
-                "language": "application/x-fhir-query",
-                "expression": "HumanName",
-                "name": "humanName"
-              }
-            }
-          ],
           "item": [
             {
               "extension": [
@@ -175,14 +165,6 @@
               }
             },
             {
-              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-              "valueExpression": {
-                "language": "application/x-fhir-query",
-                "expression": "Enumerations$AdministrativeGender",
-                "name": "administrativeGender"
-              }
-            },
-            {
               "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
               "valueCodeableConcept": {
                 "coding": [
@@ -239,29 +221,11 @@
           "linkId": "PR-telecom",
           "type": "group",
           "definition": "http://hl7.org/fhir/StructureDefinition/Patient#Patient.telecom",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-              "valueExpression": {
-                "language": "application/x-fhir-query",
-                "expression": "ContactPoint",
-                "name": "contactPoint"
-              }
-            }
-          ],
           "item": [
             {
               "linkId": "PR-telecom-system",
               "definition": "http://hl7.org/fhir/StructureDefinition/Patient#Patient.telecom.system",
               "extension": [
-                {
-                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-                  "valueExpression": {
-                    "language": "application/x-fhir-query",
-                    "expression": "ContactPoint$ContactPointSystem",
-                    "name": "contactPointSystem"
-                  }
-                },
                 {
                   "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
                   "valueBoolean": true
@@ -315,16 +279,6 @@
           "linkId": "PR-address",
           "type": "group",
           "definition": "http://hl7.org/fhir/StructureDefinition/Patient#Patient.address",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-              "valueExpression": {
-                "language": "application/x-fhir-query",
-                "expression": "Address",
-                "name": "address"
-              }
-            }
-          ],
           "item": [
             {
               "extension": [

--- a/demo/src/main/assets/screener-questionnaire.json
+++ b/demo/src/main/assets/screener-questionnaire.json
@@ -92,7 +92,6 @@
         {
           "linkId": "1.2.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -140,7 +139,6 @@
         {
           "linkId": "1.3.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -186,7 +184,6 @@
         {
           "linkId": "1.4.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -232,7 +229,6 @@
         {
           "linkId": "1.5.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -297,7 +293,6 @@
           "linkId": "2.1.0",
           "type": "group",
           "required": true,
-          "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -360,7 +355,6 @@
           "linkId": "2.2.0",
           "type": "group",
           "required": true,
-          "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -414,7 +408,6 @@
           "linkId": "2.3.0",
           "type": "group",
           "required": true,
-          "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -562,7 +555,6 @@
         {
           "linkId": "3.2.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Condition",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -608,7 +600,6 @@
         {
           "linkId": "3.3.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Condition",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -654,7 +645,6 @@
         {
           "linkId": "3.4.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Condition",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -700,7 +690,6 @@
         {
           "linkId": "3.5.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Condition",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -746,7 +735,6 @@
         {
           "linkId": "3.6.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Condition",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -792,7 +780,6 @@
         {
           "linkId": "3.7.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Condition",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -838,7 +825,6 @@
         {
           "linkId": "3.8.0",
           "type": "group",
-          "definition": "http://hl7.org/fhir/StructureDefinition/Condition",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -887,7 +873,6 @@
       "text": "COVID Vaccination",
       "type": "group",
       "linkId": "4.0.0",
-      "definition": "http://hl7.org/fhir/StructureDefinition/Immunization",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -1050,7 +1035,6 @@
       "text": "Temperature",
       "type": "group",
       "linkId": "5.0.0",
-      "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -1084,16 +1068,6 @@
           "linkId": "5.2.0",
           "type": "group",
           "definition": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.valueQuantity",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-              "valueExpression": {
-                "language": "application/x-fhir-query",
-                "expression": "Quantity",
-                "name": "quantity"
-              }
-            }
-          ],
           "item": [
             {
               "definition": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.valueQuantity.value",
@@ -1191,7 +1165,6 @@
       "text": "Pulse Oximetry",
       "linkId": "6.0.0",
       "type": "group",
-      "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -1225,16 +1198,6 @@
           "linkId": "6.2.0",
           "type": "group",
           "definition": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.valueQuantity",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-              "valueExpression": {
-                "language": "application/x-fhir-query",
-                "expression": "Quantity",
-                "name": "quantity"
-              }
-            }
-          ],
           "item": [
             {
               "text": "Pulse oximetry reading",
@@ -1312,7 +1275,6 @@
       "text": "Pulse (heart rate)",
       "type": "group",
       "linkId": "7.0.0",
-      "definition": "http://hl7.org/fhir/StructureDefinition/Observation",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -1346,16 +1308,6 @@
           "linkId": "7.2.0",
           "type": "group",
           "definition": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.valueQuantity",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
-              "valueExpression": {
-                "language": "application/x-fhir-query",
-                "expression": "Quantity",
-                "name": "quantity"
-              }
-            }
-          ],
           "item": [
             {
               "text": "Pulse (heart rate) reading",


### PR DESCRIPTION
…

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1029 and #1032 

**Description**
Based on [Hl7's Definition based extraction guide](http://hl7.org/fhir/uv/sdc/2019May/extraction.html#definition-based-extraction), the itemExtractionContext should be used for creation of resources and definition should be used to fill up the resources with appropriate values.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [x] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
