### PR TITLE
Demo App: Add missing 'Gender' label to Add Patient screen

### DIFF
--- a/demo/src/main/assets/new-patient-registration-paginated.json
+++ b/demo/src/main/assets/new-patient-registration-paginated.json
@@ -164,6 +164,7 @@
           "linkId": "patient-0-gender",
           "definition": "http://hl7.org/fhir/StructureDefinition/Patient#Patient.gender",
           "type": "choice",
+          "text": "Gender",
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",


### PR DESCRIPTION
Fixes #834

**Description**
Adds missing 'Gender' label to new-patient-registration-paginated.json

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**
![Screenshot_1642189421](https://user-images.githubusercontent.com/23126325/149575937-e55c7467-423f-4e74-82d7-8b284027061d.png)


**Checklist**
- [X] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [X] I have read [How to Contribute](https://github.com/google/android-fhir/blob/master/docs/contributing.md)
- [X] I have read the [Developer's guide](https://github.com/google/android-fhir/wiki/Developer's-Guide)
- [X] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach (Didn't do this as it's literally a 1-line fix).
- [X] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [X] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [X] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
