### PR TITLE
Use cached fhir context

### DIFF
--- a/catalog/src/main/java/com/google/android/fhir/catalog/QuestionnaireContainerFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/QuestionnaireContainerFragment.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.navArgs
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.catalog.databinding.FragmentQuestionnaireContainerBinding
 import com.google.android.fhir.datacapture.QuestionnaireFragment
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_JSON_STRING
@@ -113,7 +114,9 @@ class QuestionnaireContainerFragment : Fragment() {
   // Display Questionnaire response as a dialog
   private fun displayQuestionnaireResponse(questionnaireResponse: QuestionnaireResponse) {
     val questionnaireResponseJson =
-      FhirContext.forR4().newJsonParser().encodeResourceToString(questionnaireResponse)
+      FhirContext.forCached(FhirVersionEnum.R4)
+        .newJsonParser()
+        .encodeResourceToString(questionnaireResponse)
     val dialogFragment = QuestionnaireResponseDialogFragment()
     dialogFragment.arguments =
       bundleOf(QuestionnaireResponseDialogFragment.BUNDLE_KEY_CONTENTS to questionnaireResponseJson)

--- a/codegen/src/main/java/com/google/android/fhir/codegen/SearchParameterRepositoryGenerator.kt
+++ b/codegen/src/main/java/com/google/android/fhir/codegen/SearchParameterRepositoryGenerator.kt
@@ -17,6 +17,7 @@
 package com.google.android.fhir.codegen
 
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -169,7 +170,7 @@ private const val testOutputPath = "engine/src/test/java"
 fun main(args: Array<String>) {
   val searchParamDef = File(args.getOrElse(0) { inputFilePath })
   val bundle =
-    FhirContext.forR4()
+    FhirContext.forCached(FhirVersionEnum.R4)
       .newJsonParser()
       .parseResource(Bundle::class.java, searchParamDef.inputStream())
   SearchParameterRepositoryGenerator.generate(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.datacapture.enablement.EnablementEvaluator
 import com.google.android.fhir.datacapture.validation.QuestionnaireResponseValidator.checkQuestionnaireResponse
 import com.google.android.fhir.datacapture.views.QuestionnaireItemViewItem
@@ -54,7 +55,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
             )
           }
           val uri: Uri = state[QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_URI]!!
-          FhirContext.forR4()
+          FhirContext.forCached(FhirVersionEnum.R4)
             .newJsonParser()
             .parseResource(application.contentResolver.openInputStream(uri)) as
             Questionnaire
@@ -62,7 +63,10 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         state.contains(QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING) -> {
           val questionnaireJson: String =
             state[QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING]!!
-          FhirContext.forR4().newJsonParser().parseResource(questionnaireJson) as Questionnaire
+          FhirContext.forCached(FhirVersionEnum.R4)
+            .newJsonParser()
+            .parseResource(questionnaireJson) as
+            Questionnaire
         }
         else ->
           error("Neither EXTRA_QUESTIONNAIRE_URI nor EXTRA_JSON_ENCODED_QUESTIONNAIRE is supplied.")
@@ -77,7 +81,9 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
       state[QuestionnaireFragment.EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING]
     if (questionnaireJsonResponseString != null) {
       questionnaireResponse =
-        FhirContext.forR4().newJsonParser().parseResource(questionnaireJsonResponseString) as
+        FhirContext.forCached(FhirVersionEnum.R4)
+          .newJsonParser()
+          .parseResource(questionnaireJsonResponseString) as
           QuestionnaireResponse
       checkQuestionnaireResponse(questionnaire, questionnaireResponse)
     } else {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
@@ -18,6 +18,7 @@ package com.google.android.fhir.datacapture.mapping
 
 import android.content.Context
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import ca.uhn.fhir.context.support.DefaultProfileValidationSupport
 import com.google.android.fhir.datacapture.DataCapture
 import com.google.android.fhir.datacapture.createQuestionnaireResponseItem
@@ -71,7 +72,7 @@ import org.hl7.fhir.r4.utils.StructureMapUtilities
 object ResourceMapper {
 
   private val fhirPathEngine: FHIRPathEngine =
-    with(FhirContext.forR4()) {
+    with(FhirContext.forCached(FhirVersionEnum.R4)) {
       FHIRPathEngine(HapiWorkerContext(this, DefaultProfileValidationSupport(this)))
     }
 

--- a/demo/src/main/java/com/google/android/fhir/demo/AddPatientViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/AddPatientViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.mapping.ResourceMapper
 import java.util.UUID
@@ -39,7 +40,9 @@ class AddPatientViewModel(application: Application, private val state: SavedStat
   val isPatientSaved = MutableLiveData<Boolean>()
 
   private val questionnaireResource: Questionnaire
-    get() = FhirContext.forR4().newJsonParser().parseResource(questionnaire) as Questionnaire
+    get() =
+      FhirContext.forCached(FhirVersionEnum.R4).newJsonParser().parseResource(questionnaire) as
+        Questionnaire
   private var fhirEngine: FhirEngine = FhirApplication.fhirEngine(application.applicationContext)
   private var questionnaireJson: String? = null
 

--- a/demo/src/main/java/com/google/android/fhir/demo/EditPatientViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/EditPatientViewModel.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.mapping.ResourceMapper
 import kotlinx.coroutines.launch
@@ -44,7 +45,7 @@ class EditPatientViewModel(application: Application, private val state: SavedSta
   private suspend fun prepareEditPatient(): Pair<String, String> {
     val patient = fhirEngine.load(Patient::class.java, patientId)
     val question = readFileFromAssets("new-patient-registration-paginated.json").trimIndent()
-    val parser = FhirContext.forR4().newJsonParser()
+    val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
     val questionnaire =
       parser.parseResource(org.hl7.fhir.r4.model.Questionnaire::class.java, question) as
         Questionnaire
@@ -60,7 +61,9 @@ class EditPatientViewModel(application: Application, private val state: SavedSta
   val isPatientSaved = MutableLiveData<Boolean>()
 
   private val questionnaireResource: Questionnaire
-    get() = FhirContext.forR4().newJsonParser().parseResource(questionnaire) as Questionnaire
+    get() =
+      FhirContext.forCached(FhirVersionEnum.R4).newJsonParser().parseResource(questionnaire) as
+        Questionnaire
 
   private var questionnaireJson: String? = null
 

--- a/demo/src/main/java/com/google/android/fhir/demo/ScreenerViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/ScreenerViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.mapping.ResourceMapper
 import java.math.BigDecimal
@@ -49,7 +50,9 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
   val isResourcesSaved = MutableLiveData<Boolean>()
 
   private val questionnaireResource: Questionnaire
-    get() = FhirContext.forR4().newJsonParser().parseResource(questionnaire) as Questionnaire
+    get() =
+      FhirContext.forCached(FhirVersionEnum.R4).newJsonParser().parseResource(questionnaire) as
+        Questionnaire
   private var questionnaireJson: String? = null
   private var fhirEngine: FhirEngine = FhirApplication.fhirEngine(application.applicationContext)
 

--- a/demo/src/main/java/com/google/android/fhir/demo/data/FhirPeriodicSyncWorker.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/data/FhirPeriodicSyncWorker.kt
@@ -19,6 +19,7 @@ package com.google.android.fhir.demo.data
 import android.content.Context
 import androidx.work.WorkerParameters
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.demo.FhirApplication
 import com.google.android.fhir.demo.api.HapiFhirService
 import com.google.android.fhir.sync.FhirSyncWorker
@@ -30,7 +31,9 @@ class FhirPeriodicSyncWorker(appContext: Context, workerParams: WorkerParameters
   override fun getSyncData() = mapOf(ResourceType.Patient to mapOf("address-city" to "NAIROBI"))
 
   override fun getDataSource() =
-    HapiFhirResourceDataSource(HapiFhirService.create(FhirContext.forR4().newJsonParser()))
+    HapiFhirResourceDataSource(
+      HapiFhirService.create(FhirContext.forCached(FhirVersionEnum.R4).newJsonParser())
+    )
 
   override fun getFhirEngine() = FhirApplication.fhirEngine(applicationContext)
 }

--- a/engine/src/main/java/com/google/android/fhir/FhirServices.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirServices.kt
@@ -18,6 +18,7 @@ package com.google.android.fhir
 
 import android.content.Context
 import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import ca.uhn.fhir.parser.IParser
 import com.google.android.fhir.db.Database
 import com.google.android.fhir.db.impl.DatabaseConfig
@@ -51,7 +52,7 @@ internal data class FhirServices(
     }
 
     fun build(): FhirServices {
-      val parser = FhirContext.forR4().newJsonParser()
+      val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
       val db =
         DatabaseImpl(
           context = context,


### PR DESCRIPTION
**Fixes** 
#1111 

**Description**
FhirContext.forR4 initializes FhirContext everytime. It is recommended to use Cached version to prevent heavy opertaion everytime 

**Type**
Choose one: ( Code health)

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
