### PR TITLE
Use a non-empty message to generate the database encryption key

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseEncryptionKeyProvider.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseEncryptionKeyProvider.kt
@@ -74,7 +74,7 @@ internal object DatabaseEncryptionKeyProvider {
             keyGenerator.generateKey()
           }
       hmac.init(signingKey)
-      val key = hmac.doFinal("".toByteArray(StandardCharsets.UTF_8))
+      val key = hmac.doFinal(MESSAGE_TO_BE_SIGNED.toByteArray(StandardCharsets.UTF_8))
       keyMap[keyName] = key
       return key
     } catch (exception: KeyStoreException) {
@@ -94,4 +94,5 @@ internal object DatabaseEncryptionKeyProvider {
    * encryption secret.
    */
   @VisibleForTesting const val ANDROID_KEYSTORE_NAME = "AndroidKeyStore"
+  private const val MESSAGE_TO_BE_SIGNED = "Android FHIR SDK rocks!"
 }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseEncryptionKeyProvider.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseEncryptionKeyProvider.kt
@@ -94,5 +94,11 @@ internal object DatabaseEncryptionKeyProvider {
    * encryption secret.
    */
   @VisibleForTesting const val ANDROID_KEYSTORE_NAME = "AndroidKeyStore"
+  /**
+   * A message used to derive the database encryption key.
+   *
+   * The content of the message doesn't matter. However, once it is selected, we must not change it
+   * unless we introduce a mechanism to change the database encryption key.
+   */
   private const val MESSAGE_TO_BE_SIGNED = "Android FHIR SDK rocks!"
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1120

**Description**
Use a non-empty string for generating the database encryption key. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
Two topics we discussed within the team
1. The database keys are not stored anywhere but rather it is derived by signing a message using a key from Android keystore. Changing the message to be signed means we will not get back the database key which has already been used in apps that have already leverage our database encryption.

    We decided not to handle this because our library is still in alpha

2. Allow app developers to specify the message to be signed.

    We decided not to expose this capability to keep the API interface neat. Besides, exposing such API means we will also need to store any previously pass message to avoid app developers accidentally change the message.


**Type**
Bug fix 

**Screenshots (if applicable)**
N/A

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
