### PR TITLE
update flag so that keyboards starts with an upper case letter

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextStringViewHolderDelegate.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextStringViewHolderDelegate.kt
@@ -29,7 +29,7 @@ import org.hl7.fhir.r4.model.StringType
  */
 internal class QuestionnaireItemEditTextStringViewHolderDelegate(isSingleLine: Boolean) :
   QuestionnaireItemEditTextViewHolderDelegate(
-    InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
+    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
     isSingleLine
   ) {
   override fun getValue(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextStringViewHolderDelegate.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextStringViewHolderDelegate.kt
@@ -28,7 +28,10 @@ import org.hl7.fhir.r4.model.StringType
  * Any `ViewHolder` containing a `EditText` view that collects text data should use this class.
  */
 internal class QuestionnaireItemEditTextStringViewHolderDelegate(isSingleLine: Boolean) :
-  QuestionnaireItemEditTextViewHolderDelegate(InputType.TYPE_CLASS_TEXT, isSingleLine) {
+  QuestionnaireItemEditTextViewHolderDelegate(
+    InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
+    isSingleLine
+  ) {
   override fun getValue(
     text: String
   ): QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent? {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1176

**Description**
Clear and concise code change description. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
The other options are we CAP_WORDS and CAP_CHARACTERS.

I think we can have CAP_WORDS for singleline and CAP_SENTENCES for Multiline : /.

**Type**
Choose one: Feature 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
