### PR TITLE
[1083] DatePicker Does not open after cancel date picker dialog on sam…

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/DatePickerDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/DatePickerDialogFragment.kt
@@ -19,6 +19,7 @@ package com.google.android.fhir.datacapture.views
 import android.annotation.SuppressLint
 import android.app.DatePickerDialog
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.widget.DatePicker
 import androidx.core.os.bundleOf
@@ -50,6 +51,19 @@ internal class DatePickerFragment : DialogFragment(), DatePickerDialog.OnDateSet
         RESULT_BUNDLE_KEY_YEAR to year,
         RESULT_BUNDLE_KEY_MONTH to month,
         RESULT_BUNDLE_KEY_DAY_OF_MONTH to dayOfMonth
+      )
+    )
+    dismiss()
+  }
+
+  override fun onCancel(dialog: DialogInterface) {
+    super.onCancel(dialog)
+    setFragmentResult(
+      RESULT_REQUEST_KEY,
+      bundleOf(
+        RESULT_BUNDLE_KEY_YEAR to 0,
+        RESULT_BUNDLE_KEY_MONTH to 0,
+        RESULT_BUNDLE_KEY_DAY_OF_MONTH to 0
       )
     )
     dismiss()

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -73,17 +73,21 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
               val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
               // Month values are 1-12 in java.time but 0-11 in
               // DatePickerDialog.
-              val localDate = LocalDate.of(year, month + 1, dayOfMonth)
-              textInputEditText.setText(localDate?.localizedString)
+              if(year !=0 &&month !=0&&dayOfMonth!=0){
+                val localDate = LocalDate.of(year, month + 1, dayOfMonth)
+                textInputEditText.setText(localDate?.localizedString)
 
-              val date = DateType(year, month, dayOfMonth)
-              questionnaireItemViewItem.singleAnswerOrNull =
-                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                  value = date
-                }
+                val date = DateType(year, month, dayOfMonth)
+                questionnaireItemViewItem.singleAnswerOrNull =
+                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                    value = date
+                  }
+                onAnswerChanged(textInputEditText.context)
+              }
+
               // Clear focus so that the user can refocus to open the dialog
               textInputEditText.clearFocus()
-              onAnswerChanged(textInputEditText.context)
+
             }
           )
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -65,30 +65,29 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
           val context = itemView.context.tryUnwrapContext()!!
           context.supportFragmentManager.setFragmentResultListener(
             DatePickerFragment.RESULT_REQUEST_KEY,
-            context,
-            { _, result ->
-              // java.time APIs can be used with desugaring
-              val year = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_YEAR)
-              val month = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_MONTH)
-              val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
-              // Month values are 1-12 in java.time but 0-11 in
-              // DatePickerDialog.
-              if (year != 0 && month != 0 && dayOfMonth != 0) {
-                val localDate = LocalDate.of(year, month + 1, dayOfMonth)
-                textInputEditText.setText(localDate?.localizedString)
+            context
+          ) { _, result ->
+            // java.time APIs can be used with desugaring
+            val year = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_YEAR)
+            val month = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_MONTH)
+            val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
+            // Month values are 1-12 in java.time but 0-11 in
+            // DatePickerDialog.
+            if (year != 0 && month != 0 && dayOfMonth != 0) {
+              val localDate = LocalDate.of(year, month + 1, dayOfMonth)
+              textInputEditText.setText(localDate?.localizedString)
 
-                val date = DateType(year, month, dayOfMonth)
-                questionnaireItemViewItem.singleAnswerOrNull =
-                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    value = date
-                  }
-                onAnswerChanged(textInputEditText.context)
-              }
-
-              // Clear focus so that the user can refocus to open the dialog
-              textInputEditText.clearFocus()
+              val date = DateType(year, month, dayOfMonth)
+              questionnaireItemViewItem.singleAnswerOrNull =
+                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                  value = date
+                }
+              onAnswerChanged(textInputEditText.context)
             }
-          )
+
+            // Clear focus so that the user can refocus to open the dialog
+            textInputEditText.clearFocus()
+          }
 
           val selectedDate = questionnaireItemViewItem.singleAnswerOrNull?.valueDateType?.localDate
           DatePickerFragment()

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -73,7 +73,7 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
               val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
               // Month values are 1-12 in java.time but 0-11 in
               // DatePickerDialog.
-              if(year !=0 &&month !=0&&dayOfMonth!=0){
+              if (year != 0 && month != 0 && dayOfMonth != 0) {
                 val localDate = LocalDate.of(year, month + 1, dayOfMonth)
                 textInputEditText.setText(localDate?.localizedString)
 
@@ -87,7 +87,6 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
 
               // Clear focus so that the user can refocus to open the dialog
               textInputEditText.clearFocus()
-
             }
           )
 


### PR DESCRIPTION
…e field -Bug Fixd

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[1083]

**Description**
overridden onCancel() method of DatePickerDialog and setFragmentResult() with default values i.e. 0


**Type**
Choose one: Bug fix 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
