### PR TITLE
Landing page component overlapping issue.

### DIFF
--- a/catalog/src/main/res/layout/component_list_fragment.xml
+++ b/catalog/src/main/res/layout/component_list_fragment.xml
@@ -11,7 +11,7 @@
         android:id="@+id/componentsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="4dp"
+        android:layout_marginHorizontal="@dimen/component_horizontal_margin"
         android:layout_marginBottom="56dp"
     />
 </FrameLayout>

--- a/catalog/src/main/res/layout/component_list_fragment.xml
+++ b/catalog/src/main/res/layout/component_list_fragment.xml
@@ -11,7 +11,7 @@
         android:id="@+id/componentsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/cardView_margin"
+        android:layout_marginHorizontal="4dp"
         android:layout_marginBottom="56dp"
     />
 </FrameLayout>

--- a/catalog/src/main/res/layout/landing_page_item.xml
+++ b/catalog/src/main/res/layout/landing_page_item.xml
@@ -3,10 +3,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="@dimen/component_item_width"
+    android:layout_width="match_parent"
     android:layout_height="@dimen/component_item_height"
-    android:layout_marginTop="@dimen/cardView_margin"
-    android:layout_marginEnd="@dimen/cardView_margin"
+    android:layout_marginHorizontal="4dp"
+    android:layout_marginVertical="4dp"
     android:orientation="vertical"
 >
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/catalog/src/main/res/layout/landing_page_item.xml
+++ b/catalog/src/main/res/layout/landing_page_item.xml
@@ -5,8 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/component_item_height"
-    android:layout_marginHorizontal="4dp"
-    android:layout_marginVertical="4dp"
+    android:layout_marginHorizontal="@dimen/component_horizontal_margin"
+    android:layout_marginVertical="@dimen/component_vertical_margin"
     android:orientation="vertical"
 >
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/catalog/src/main/res/values/dimens.xml
+++ b/catalog/src/main/res/values/dimens.xml
@@ -6,4 +6,6 @@
   <dimen name="cardView_margin">8dp</dimen>
   <dimen name="fragment_container_margin">64dp</dimen>
   <dimen name="bottom_navigation_view_height">56dp</dimen>
+  <dimen name="component_horizontal_margin">4dp</dimen>
+  <dimen name="component_vertical_margin">4dp</dimen>
 </resources>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1112 

**Description**
Devices with small resolution and dpi/ppi, component grids were overlapping on each other.
Instead of giving hard coded value as per figma, match parent value is provided as width.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix 

**Screenshots (if applicable)**

<img width="505" alt="Screen Shot 2022-02-21 at 5 57 37 PM" src="https://user-images.githubusercontent.com/86107848/154955327-ed406f75-1518-452f-9ee0-e4b06de6a03f.png">


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate )
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
