### PR TITLE
Forward compileSdk and targetSdk from 30 to 31

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -206,7 +206,7 @@ object Dependencies {
     const val junit = "4.12"
     const val mockitoKotlin = "3.2.0"
     const val mockitoInline = "4.0.0"
-    const val robolectric = "4.5.1"
+    const val robolectric = "4.7.3"
 
     object Mlkit {
       const val barcodeScanning = "16.1.1"

--- a/buildSrc/src/main/kotlin/Sdk.kt
+++ b/buildSrc/src/main/kotlin/Sdk.kt
@@ -15,7 +15,7 @@
  */
 
 object Sdk {
-  const val compileSdk = 30
+  const val compileSdk = 31
   const val minSdk = 21
-  const val targetSdk = 30
+  const val targetSdk = 31
 }


### PR DESCRIPTION
This is the preperation work for forwad room to 2.4 or higher version.
Since we want to use room 2.4 for supporting UUID type.

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1179 Forward compileSdk and targetSdk from 30 to 31 for room 2.4 support

**Description**
Clear and concise code change description. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Code health
 
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
