### PR TITLE
Nested display questionnaire item text as subtitle text for parent question item.

### DIFF
--- a/catalog/src/main/assets/boolean_choice_questionnaire.json
+++ b/catalog/src/main/assets/boolean_choice_questionnaire.json
@@ -4,7 +4,14 @@
     {
       "linkId": "1",
       "text": "Have you taken a pregnancy test?",
-      "type": "boolean"
+      "type": "boolean",
+      "item": [
+        {
+          "linkId": "1-select-one",
+          "text": "Select one",
+          "type": "display"
+        }
+      ]
     }
   ]
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -71,6 +71,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         else ->
           error("Neither EXTRA_QUESTIONNAIRE_URI nor EXTRA_JSON_ENCODED_QUESTIONNAIRE is supplied.")
       }
+    disableNestedDisplayQuestionnaireItem(questionnaire.item)
   }
 
   /** The current questionnaire response as questions are being answered. */

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
@@ -23,6 +23,7 @@ import android.widget.TextView
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
+import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import org.hl7.fhir.r4.model.BooleanType
@@ -34,6 +35,7 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
     object : QuestionnaireItemViewHolderDelegate {
       private lateinit var prefixTextView: TextView
       private lateinit var questionTextView: TextView
+      private lateinit var questionSubTextView: TextView
       private lateinit var radioGroup: RadioGroup
       private lateinit var yesRadioButton: RadioButton
       private lateinit var noRadioButton: RadioButton
@@ -44,6 +46,7 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
       override fun init(itemView: View) {
         prefixTextView = itemView.findViewById(R.id.prefix_text_view)
         questionTextView = itemView.findViewById(R.id.question_text_view)
+        questionSubTextView = itemView.findViewById(R.id.subtitle_text_view)
         radioGroup = itemView.findViewById(R.id.radio_group)
         yesRadioButton = itemView.findViewById(R.id.yes_radio_button)
         noRadioButton = itemView.findViewById(R.id.no_radio_button)
@@ -54,6 +57,7 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
         this.questionnaireItemViewItem = questionnaireItemViewItem
         val (questionnaireItem, questionnaireResponseItem) = questionnaireItemViewItem
         questionTextView.text = questionnaireItem.localizedTextSpanned
+        questionSubTextView.text = questionnaireItem.subtitleText
 
         if (!questionnaireItem.prefix.isNullOrEmpty()) {
           prefixTextView.visibility = View.VISIBLE

--- a/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
@@ -44,8 +44,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
         />
-
     </LinearLayout>
+    <TextView
+        style="?attr/subtitleTextAppearanceQuestionnaire"
+        android:id="@+id/subtitle_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+    />
 
     <RadioGroup
         android:id="@+id/radio_group"

--- a/datacapture/src/main/res/values/attrs.xml
+++ b/datacapture/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
 <resources>
     <attr name="groupHeaderTextAppearanceQuestionnaire" format="reference" />
     <attr name="headerTextAppearanceQuestionnaire" format="reference" />
+    <attr name="subtitleTextAppearanceQuestionnaire" format="reference" />
     <attr name="checkBoxStyleQuestionnaire" format="reference" />
     <attr name="radioButtonStyleQuestionnaire" format="reference" />
     <attr name="dropDownTextAppearanceQuestionnaire" format="reference" />

--- a/datacapture/src/main/res/values/styles.xml
+++ b/datacapture/src/main/res/values/styles.xml
@@ -45,6 +45,9 @@
             name="headerTextAppearanceQuestionnaire"
         >@style/TextAppearance.MaterialComponents.Body2</item>
         <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/TextAppearance.MaterialComponents.Body2</item>
+        <item
             name="checkBoxStyleQuestionnaire"
         >@style/Questionnaire.Widget.MaterialComponents.CompoundButton.CheckBox
         </item>


### PR DESCRIPTION
…

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1113 

**Description**

-  Nested display item text as subtitle text for parent questionnaire item.
-  If parent questionnaire item is group, then nested display questionnaire item is actually independent questionnaire item and not subtitle text.
- Nested display questionnaire item should not be considered as questionnaire view item, therefore disable it by adding enable when clause which will be always false.
- Use boolean choice view for end to end use case.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
