### PR TITLE
Nested display item text as subtitle text.

### DIFF
--- a/catalog/src/main/assets/boolean_choice_questionnaire.json
+++ b/catalog/src/main/assets/boolean_choice_questionnaire.json
@@ -4,7 +4,14 @@
     {
       "linkId": "1",
       "text": "Have you taken a pregnancy test?",
-      "type": "boolean"
+      "type": "boolean",
+      "item": [
+        {
+          "linkId": "1-select-one",
+          "text": "Select one",
+          "type": "display"
+        }
+      ]
     }
   ]
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
@@ -153,7 +153,10 @@ fun Questionnaire.QuestionnaireItemComponent.createQuestionnaireResponseItem():
   }
 }
 
-/** Nested Display item text or null. */
+/**
+ * A nested questionnaire item of type display (if present) is used as the subtitle of the parent
+ * question.
+ */
 internal val Questionnaire.QuestionnaireItemComponent.subtitleText: Spanned?
   get() =
     item

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
@@ -153,42 +153,6 @@ fun Questionnaire.QuestionnaireItemComponent.createQuestionnaireResponseItem():
   }
 }
 
-/**
- * Disables nested display questionnaire item if current questionnaire item type is not group.
- * Display questionnaire item in group is not subtitle text.
- */
-internal fun disableNestedDisplayQuestionnaireItem(
-  questionnaireItemList: List<Questionnaire.QuestionnaireItemComponent>
-) {
-  questionnaireItemList.forEach { questionnaireItem ->
-    if (questionnaireItem.type != Questionnaire.QuestionnaireItemType.GROUP) {
-      questionnaireItem.disableNestedDisplay()
-    }
-    disableNestedDisplayQuestionnaireItem(questionnaireItem.item)
-  }
-}
-
-/**
- * Disables nested display questionnaire item. It adds
- * [Questionnaire.QuestionnaireItemEnableWhenComponent] to the nested display item where enablement
- * will be always false.
- */
-private fun Questionnaire.QuestionnaireItemComponent.disableNestedDisplay() {
-  item
-    .firstOrNull { questionnaireItem ->
-      questionnaireItem.type == Questionnaire.QuestionnaireItemType.DISPLAY
-    }
-    ?.let { nestedDisplayItem ->
-      nestedDisplayItem.enableWhen =
-        listOf(
-          Questionnaire.QuestionnaireItemEnableWhenComponent()
-            .setQuestion(nestedDisplayItem.linkId)
-            .setOperator(Questionnaire.QuestionnaireItemOperator.EQUAL)
-            .setAnswer(BooleanType(true))
-        )
-    }
-}
-
 /** Nested Display item text or null. */
 internal val Questionnaire.QuestionnaireItemComponent.subtitleText: Spanned?
   get() =

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -298,12 +298,12 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
                 // If nested display item is identified as subtitle text, then do not create
                 // questionnaire state for it.
                 questionnaireItemList =
-                  if (questionnaireItem.type != Questionnaire.QuestionnaireItemType.GROUP) {
-                    questionnaireItem.item.filterNot {
-                      it.type == Questionnaire.QuestionnaireItemType.DISPLAY
-                    }
-                  } else {
-                    questionnaireItem.item
+                  when (questionnaireItem.type) {
+                    Questionnaire.QuestionnaireItemType.GROUP -> questionnaireItem.item
+                    else ->
+                      questionnaireItem.item.filterNot {
+                        it.type == Questionnaire.QuestionnaireItemType.DISPLAY
+                      }
                   },
                 questionnaireResponseItemList =
                   if (questionnaireResponseItem.answer.isEmpty()) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -71,7 +71,6 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         else ->
           error("Neither EXTRA_QUESTIONNAIRE_URI nor EXTRA_JSON_ENCODED_QUESTIONNAIRE is supplied.")
       }
-    disableNestedDisplayQuestionnaireItem(questionnaire.item)
   }
 
   /** The current questionnaire response as questions are being answered. */
@@ -294,7 +293,18 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
             ) { questionnaireResponseItemChangedCallback(questionnaireItem.linkId) }
           ) +
             getQuestionnaireState(
-                questionnaireItemList = questionnaireItem.item,
+                // Nested display item is subtitle text for parent questionnaire item if data type
+                // is not group.
+                // If nested display item is identified as subtitle text, then do not create
+                // questionnaire state for it.
+                questionnaireItemList =
+                  if (questionnaireItem.type != Questionnaire.QuestionnaireItemType.GROUP) {
+                    questionnaireItem.item.filterNot {
+                      it.type == Questionnaire.QuestionnaireItemType.DISPLAY
+                    }
+                  } else {
+                    questionnaireItem.item
+                  },
                 questionnaireResponseItemList =
                   if (questionnaireResponseItem.answer.isEmpty()) {
                     questionnaireResponseItem.item

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -71,6 +71,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         else ->
           error("Neither EXTRA_QUESTIONNAIRE_URI nor EXTRA_JSON_ENCODED_QUESTIONNAIRE is supplied.")
       }
+    disableNestedDisplayQuestionnaireItem(questionnaire.item)
   }
 
   /** The current questionnaire response as questions are being answered. */

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
@@ -23,6 +23,7 @@ import android.widget.TextView
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
+import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import org.hl7.fhir.r4.model.BooleanType
@@ -34,6 +35,7 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
     object : QuestionnaireItemViewHolderDelegate {
       private lateinit var prefixTextView: TextView
       private lateinit var questionTextView: TextView
+      private lateinit var questionSubTextView: TextView
       private lateinit var radioGroup: RadioGroup
       private lateinit var yesRadioButton: RadioButton
       private lateinit var noRadioButton: RadioButton
@@ -44,6 +46,7 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
       override fun init(itemView: View) {
         prefixTextView = itemView.findViewById(R.id.prefix_text_view)
         questionTextView = itemView.findViewById(R.id.question_text_view)
+        questionSubTextView = itemView.findViewById(R.id.subtitle_text_view)
         radioGroup = itemView.findViewById(R.id.radio_group)
         yesRadioButton = itemView.findViewById(R.id.yes_radio_button)
         noRadioButton = itemView.findViewById(R.id.no_radio_button)
@@ -54,6 +57,7 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
         this.questionnaireItemViewItem = questionnaireItemViewItem
         val (questionnaireItem, questionnaireResponseItem) = questionnaireItemViewItem
         questionTextView.text = questionnaireItem.localizedTextSpanned
+        questionSubTextView.text = questionnaireItem.subtitleText
 
         if (!questionnaireItem.prefix.isNullOrEmpty()) {
           prefixTextView.visibility = View.VISIBLE

--- a/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
@@ -44,8 +44,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
         />
-
     </LinearLayout>
+    <TextView
+        style="?attr/subtitleTextAppearanceQuestionnaire"
+        android:id="@+id/subtitle_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+    />
 
     <RadioGroup
         android:id="@+id/radio_group"

--- a/datacapture/src/main/res/values/attrs.xml
+++ b/datacapture/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
 <resources>
     <attr name="groupHeaderTextAppearanceQuestionnaire" format="reference" />
     <attr name="headerTextAppearanceQuestionnaire" format="reference" />
+    <attr name="subtitleTextAppearanceQuestionnaire" format="reference" />
     <attr name="checkBoxStyleQuestionnaire" format="reference" />
     <attr name="radioButtonStyleQuestionnaire" format="reference" />
     <attr name="dropDownTextAppearanceQuestionnaire" format="reference" />

--- a/datacapture/src/main/res/values/styles.xml
+++ b/datacapture/src/main/res/values/styles.xml
@@ -45,6 +45,9 @@
             name="headerTextAppearanceQuestionnaire"
         >@style/TextAppearance.MaterialComponents.Body2</item>
         <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/TextAppearance.MaterialComponents.Body2</item>
+        <item
             name="checkBoxStyleQuestionnaire"
         >@style/Questionnaire.Widget.MaterialComponents.CompoundButton.CheckBox
         </item>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
@@ -17,7 +17,6 @@
 package com.google.android.fhir.datacapture
 
 import android.os.Build
-import com.google.android.fhir.datacapture.enablement.EnablementEvaluator
 import com.google.common.truth.Truth.assertThat
 import java.util.Locale
 import org.hl7.fhir.r4.model.BooleanType
@@ -27,7 +26,6 @@ import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Enumeration
 import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Questionnaire
-import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 import org.hl7.fhir.r4.utils.ToolingExtensions
 import org.junit.Test
@@ -428,69 +426,6 @@ class MoreQuestionnaireItemComponentsTest {
         (questionResponse.item[0].answer[0].item[0].answer[0].value as BooleanType).booleanValue()
       )
       .isEqualTo(true)
-  }
-
-  @Test
-  fun disableNestedDisplayQuestionnaireItem_nestedDisplayItemPresent_disablesNestedDisplayItem() {
-    val questionItemList =
-      listOf(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          linkId = "parent-question"
-          text = "parent question text"
-          type = Questionnaire.QuestionnaireItemType.BOOLEAN
-          item =
-            listOf(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "nested-display-question"
-                text = "subtitle text"
-                type = Questionnaire.QuestionnaireItemType.DISPLAY
-              }
-            )
-        }
-      )
-
-    disableNestedDisplayQuestionnaireItem(questionItemList)
-
-    assertThat(
-        EnablementEvaluator.evaluate(questionItemList.first().item.first()) { _ ->
-          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-            addAnswer(
-              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
-                .setValue(BooleanType(false))
-            )
-          }
-        }
-      )
-      .isFalse()
-  }
-
-  @Test
-  fun disableNestedDisplayQuestionnaireItem_nestedDisplayItemPresent_parentQuestionItemIsGroup_doesNotDisableNestedDisplayItem() {
-    val questionItemList =
-      listOf(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          linkId = "parent-question"
-          text = "parent question text"
-          type = Questionnaire.QuestionnaireItemType.GROUP
-          item =
-            listOf(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "nested-display-question"
-                text = "subtitle text"
-                type = Questionnaire.QuestionnaireItemType.DISPLAY
-              }
-            )
-        }
-      )
-
-    disableNestedDisplayQuestionnaireItem(questionItemList)
-
-    assertThat(
-        EnablementEvaluator.evaluate(questionItemList.first().item.first()) { _ ->
-          QuestionnaireResponse.QuestionnaireResponseItemComponent()
-        }
-      )
-      .isTrue()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -1363,6 +1363,65 @@ class QuestionnaireViewModelTest(private val questionnaireSource: QuestionnaireS
     )
   }
 
+  @Test
+  fun nestedDisplayItem_parentQuestionItemIsGroup_createQuestionnaireStateItem() = runBlocking {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "parent-question"
+            text = "parent question text"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            item =
+              listOf(
+                Questionnaire.QuestionnaireItemComponent().apply {
+                  linkId = "nested-display-question"
+                  text = "subtitle text"
+                  type = Questionnaire.QuestionnaireItemType.DISPLAY
+                }
+              )
+          }
+        )
+      }
+    state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, printer.encodeResourceToString(questionnaire))
+
+    val viewModel = QuestionnaireViewModel(context, state)
+
+    assertThat(viewModel.getQuestionnaireItemViewItemList().last().questionnaireResponseItem.linkId)
+      .isEqualTo("nested-display-question")
+  }
+
+  @Test
+  fun nestedDisplayItem_parentQuestionItemIsNotGroup_doesNotcreateQuestionnaireStateItem() =
+      runBlocking {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "parent-question"
+            text = "parent question text"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            item =
+              listOf(
+                Questionnaire.QuestionnaireItemComponent().apply {
+                  linkId = "nested-display-question"
+                  text = "subtitle text"
+                  type = Questionnaire.QuestionnaireItemType.DISPLAY
+                }
+              )
+          }
+        )
+      }
+    state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, printer.encodeResourceToString(questionnaire))
+
+    val viewModel = QuestionnaireViewModel(context, state)
+
+    assertThat(viewModel.getQuestionnaireItemViewItemList().last().questionnaireResponseItem.linkId)
+      .isEqualTo("parent-question")
+  }
+
   private fun createQuestionnaireViewModel(
     questionnaire: Questionnaire,
     response: QuestionnaireResponse? = null


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1113

**Description**
Clear and concise code change description. 
Nested display item is subtitle text for parent questionnaire item if data type is not group.
If nested display item is identified as subtitle text, then do not create questionnaire state for it.
Use boolean choice view for end to end use case.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature

**Screenshots (if applicable)**


<img width="435" alt="Screen Shot 2022-03-09 at 1 28 07 PM" src="https://user-images.githubusercontent.com/86107848/157427644-cd982654-0d7d-448d-99df-d8fd76e2b82f.png">

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
