### PR TITLE
Use reified generics for delete and read operations in FhirEngine

### DIFF
--- a/demo/src/main/java/com/google/android/fhir/demo/EditPatientViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/EditPatientViewModel.kt
@@ -26,6 +26,7 @@ import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.mapping.ResourceMapper
+import com.google.android.fhir.get
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.Questionnaire
@@ -43,7 +44,7 @@ class EditPatientViewModel(application: Application, private val state: SavedSta
   val livePatientData = liveData { emit(prepareEditPatient()) }
 
   private suspend fun prepareEditPatient(): Pair<String, String> {
-    val patient = fhirEngine.load(Patient::class.java, patientId)
+    val patient = fhirEngine.get<Patient>(patientId)
     val question = readFileFromAssets("new-patient-registration-paginated.json").trimIndent()
     val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
     val questionnaire =

--- a/demo/src/main/java/com/google/android/fhir/demo/PatientDetailsViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/PatientDetailsViewModel.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.get
 import com.google.android.fhir.logicalId
 import com.google.android.fhir.search.search
 import java.text.SimpleDateFormat
@@ -60,7 +61,7 @@ class PatientDetailsViewModel(
   }
 
   private suspend fun getPatient(): PatientListViewModel.PatientItem {
-    val patient = fhirEngine.load(Patient::class.java, patientId)
+    val patient = fhirEngine.get<Patient>(patientId)
     return patient.toPatientItem(0)
   }
 

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -79,7 +79,6 @@ interface FhirEngine {
    */
   @Deprecated("Deprecated", ReplaceWith("this.get<R>(id)"))
   suspend fun <R : Resource> load(clazz: Class<R>, id: String): R
-  
 
   /**
    * Removes a FHIR resource given the class and the logical ID.

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -73,21 +73,19 @@ interface FhirEngine {
   suspend fun getLastSyncTimeStamp(): OffsetDateTime?
 
   /**
-   * DO NOT USE. Internal and test only function to load a FHIR resource given the class and the
-   * logical ID.
+   * Loads a FHIR resource given the class and the logical ID.
    *
-   * The `@Deprecated` annotation suggests replacement if this function is called.
+   * DEPRECATED. Use `get<R>(id)` instead.
    */
-  @Deprecated("Internal and test only function", ReplaceWith("this.get<R>(id)"))
+  @Deprecated("Deprecated", ReplaceWith("this.get<R>(id)"))
   suspend fun <R : Resource> load(clazz: Class<R>, id: String): R
 
   /**
-   * DO NOT USE. Internal and test only function to delete a FHIR resource given the class and the
-   * logical ID.
+   * Removes a FHIR resource given the class and the logical ID.
    *
-   * The `@Deprecated` annotation suggests replacement if this function is called.
+   * DEPRECATED. Use `delete<R>(id)` instead.
    */
-  @Deprecated("Internal and test only function", ReplaceWith("this.delete<R>(id)"))
+  @Deprecated("Deprecated", ReplaceWith("this.delete<R>(id)"))
   suspend fun <R : Resource> remove(clazz: Class<R>, id: String)
 }
 

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -43,22 +43,6 @@ interface FhirEngine {
   suspend fun <R : Resource> update(resource: R)
 
   /**
-   * Returns a FHIR resource of type [clazz] with [id] from the local storage.
-   *
-   * @param <R> The resource type which should be a subtype of [Resource].
-   * @throws ResourceNotFoundException if the resource is not found
-   */
-  @Throws(ResourceNotFoundException::class)
-  suspend fun <R : Resource> load(clazz: Class<R>, id: String): R
-
-  /**
-   * Removes a FHIR resource of type [clazz] with [id] from the local storage.
-   *
-   * @param <R> The resource type which should be a subtype of [Resource].
-   */
-  suspend fun <R : Resource> remove(clazz: Class<R>, id: String)
-
-  /**
    * Searches the database and returns a list resources according to the [search] specifications.
    */
   suspend fun <R : Resource> search(search: Search): List<R>
@@ -87,6 +71,43 @@ interface FhirEngine {
 
   /** Returns the timestamp when data was last synchronized. */
   suspend fun getLastSyncTimeStamp(): OffsetDateTime?
+
+  /**
+   * DO NOT USE. Internal only function to read a FHIR resource given the class and the logical ID.
+   *
+   * The `@Deprecated` annotation suggests replacement if this function is called.
+   */
+  @Deprecated("Internal only function", ReplaceWith("this.get<R>(id)"))
+  suspend fun <R : Resource> getInternal(clazz: Class<R>, id: String): R
+
+  /**
+   * DO NOT USE. Internal only function to delete a FHIR resource given the class and the logical
+   * ID.
+   *
+   * The `@Deprecated` annotation suggests replacement if this function is called.
+   */
+  @Deprecated("Internal only function", ReplaceWith("this.delete<R>(id)"))
+  suspend fun <R : Resource> deleteInternal(clazz: Class<R>, id: String)
+}
+
+/**
+ * Deletes a FHIR resource of type [R] with [id] from the local storage.
+ *
+ * @param <R> The resource type which should be a subtype of [Resource].
+ */
+suspend inline fun <reified R : Resource> FhirEngine.delete(id: String) {
+  deleteInternal(R::class.java, id)
+}
+
+/**
+ * Returns a FHIR resource of type [R] with [id] from the local storage.
+ *
+ * @param <R> The resource type which should be a subtype of [Resource].
+ * @throws ResourceNotFoundException if the resource is not found
+ */
+@Throws(ResourceNotFoundException::class)
+suspend inline fun <reified R : Resource> FhirEngine.get(id: String): R {
+  return getInternal(R::class.java, id)
 }
 
 interface SyncDownloadContext {

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -79,6 +79,7 @@ interface FhirEngine {
    */
   @Deprecated("Deprecated", ReplaceWith("this.get<R>(id)"))
   suspend fun <R : Resource> load(clazz: Class<R>, id: String): R
+  
 
   /**
    * Removes a FHIR resource given the class and the logical ID.

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -73,21 +73,22 @@ interface FhirEngine {
   suspend fun getLastSyncTimeStamp(): OffsetDateTime?
 
   /**
-   * DO NOT USE. Internal only function to read a FHIR resource given the class and the logical ID.
+   * DO NOT USE. Internal and test only function to load a FHIR resource given the class and the
+   * logical ID.
    *
    * The `@Deprecated` annotation suggests replacement if this function is called.
    */
-  @Deprecated("Internal only function", ReplaceWith("this.get<R>(id)"))
-  suspend fun <R : Resource> getInternal(clazz: Class<R>, id: String): R
+  @Deprecated("Internal and test only function", ReplaceWith("this.get<R>(id)"))
+  suspend fun <R : Resource> load(clazz: Class<R>, id: String): R
 
   /**
-   * DO NOT USE. Internal only function to delete a FHIR resource given the class and the logical
-   * ID.
+   * DO NOT USE. Internal and test only function to delete a FHIR resource given the class and the
+   * logical ID.
    *
    * The `@Deprecated` annotation suggests replacement if this function is called.
    */
-  @Deprecated("Internal only function", ReplaceWith("this.delete<R>(id)"))
-  suspend fun <R : Resource> deleteInternal(clazz: Class<R>, id: String)
+  @Deprecated("Internal and test only function", ReplaceWith("this.delete<R>(id)"))
+  suspend fun <R : Resource> remove(clazz: Class<R>, id: String)
 }
 
 /**
@@ -96,7 +97,7 @@ interface FhirEngine {
  * @param <R> The resource type which should be a subtype of [Resource].
  */
 suspend inline fun <reified R : Resource> FhirEngine.delete(id: String) {
-  deleteInternal(R::class.java, id)
+  remove(R::class.java, id)
 }
 
 /**
@@ -107,7 +108,7 @@ suspend inline fun <reified R : Resource> FhirEngine.delete(id: String) {
  */
 @Throws(ResourceNotFoundException::class)
 suspend inline fun <reified R : Resource> FhirEngine.get(id: String): R {
-  return getInternal(R::class.java, id)
+  return load(R::class.java, id)
 }
 
 interface SyncDownloadContext {

--- a/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -47,11 +47,11 @@ internal class FhirEngineImpl(private val database: Database, private val contex
     database.update(resource)
   }
 
-  override suspend fun <R : Resource> load(clazz: Class<R>, id: String): R {
+  override suspend fun <R : Resource> getInternal(clazz: Class<R>, id: String): R {
     return database.select(clazz, id)
   }
 
-  override suspend fun <R : Resource> remove(clazz: Class<R>, id: String) {
+  override suspend fun <R : Resource> deleteInternal(clazz: Class<R>, id: String) {
     database.delete(clazz, id)
   }
 

--- a/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -47,11 +47,11 @@ internal class FhirEngineImpl(private val database: Database, private val contex
     database.update(resource)
   }
 
-  override suspend fun <R : Resource> getInternal(clazz: Class<R>, id: String): R {
+  override suspend fun <R : Resource> load(clazz: Class<R>, id: String): R {
     return database.select(clazz, id)
   }
 
-  override suspend fun <R : Resource> deleteInternal(clazz: Class<R>, id: String) {
+  override suspend fun <R : Resource> remove(clazz: Class<R>, id: String) {
     database.delete(clazz, id)
   }
 

--- a/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
+++ b/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
@@ -156,11 +156,11 @@ class TestingUtils constructor(private val iParser: IParser) {
 
     override suspend fun <R : Resource> update(resource: R) {}
 
-    override suspend fun <R : Resource> getInternal(clazz: Class<R>, id: String): R {
+    override suspend fun <R : Resource> load(clazz: Class<R>, id: String): R {
       return clazz.newInstance()
     }
 
-    override suspend fun <R : Resource> deleteInternal(clazz: Class<R>, id: String) {}
+    override suspend fun <R : Resource> remove(clazz: Class<R>, id: String) {}
 
     override suspend fun <R : Resource> search(search: Search): List<R> {
       return emptyList()

--- a/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
+++ b/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
@@ -69,7 +69,7 @@ class TestingUtils constructor(private val iParser: IParser) {
   }
 
   /** Reads a [JSONObject] from given file in the `sampledata` dir */
-  fun readJsonFromFile(filename: String): JSONObject {
+  private fun readJsonFromFile(filename: String): JSONObject {
     val inputStream = javaClass.getResourceAsStream(filename)
     val content = inputStream!!.bufferedReader(Charsets.UTF_8).readText()
     return JSONObject(content)
@@ -156,11 +156,11 @@ class TestingUtils constructor(private val iParser: IParser) {
 
     override suspend fun <R : Resource> update(resource: R) {}
 
-    override suspend fun <R : Resource> load(clazz: Class<R>, id: String): R {
+    override suspend fun <R : Resource> getInternal(clazz: Class<R>, id: String): R {
       return clazz.newInstance()
     }
 
-    override suspend fun <R : Resource> remove(clazz: Class<R>, id: String) {}
+    override suspend fun <R : Resource> deleteInternal(clazz: Class<R>, id: String) {}
 
     override suspend fun <R : Resource> search(search: Search): List<R> {
       return emptyList()

--- a/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
@@ -22,6 +22,7 @@ import com.google.android.fhir.db.ResourceNotFoundException
 import com.google.android.fhir.db.impl.dao.LocalChangeToken
 import com.google.android.fhir.db.impl.dao.SquashedLocalChange
 import com.google.android.fhir.db.impl.entities.LocalChangeEntity
+import com.google.android.fhir.get
 import com.google.android.fhir.resource.TestingUtils
 import com.google.common.truth.Truth.assertThat
 import java.util.Date
@@ -50,23 +51,14 @@ class FhirEngineImplTest {
   @Test
   fun save_shouldSaveResource() = runBlocking {
     fhirEngine.save(TEST_PATIENT_2)
-    testingUtils.assertResourceEquals(
-      TEST_PATIENT_2,
-      fhirEngine.load(Patient::class.java, TEST_PATIENT_2_ID)
-    )
+    testingUtils.assertResourceEquals(TEST_PATIENT_2, fhirEngine.get<Patient>(TEST_PATIENT_2_ID))
   }
 
   @Test
   fun saveAll_shouldSaveResource() = runBlocking {
     fhirEngine.save(TEST_PATIENT_1, TEST_PATIENT_2)
-    testingUtils.assertResourceEquals(
-      TEST_PATIENT_1,
-      fhirEngine.load(Patient::class.java, TEST_PATIENT_1_ID)
-    )
-    testingUtils.assertResourceEquals(
-      TEST_PATIENT_2,
-      fhirEngine.load(Patient::class.java, TEST_PATIENT_2_ID)
-    )
+    testingUtils.assertResourceEquals(TEST_PATIENT_1, fhirEngine.get<Patient>(TEST_PATIENT_1_ID))
+    testingUtils.assertResourceEquals(TEST_PATIENT_2, fhirEngine.get<Patient>(TEST_PATIENT_2_ID))
   }
 
   @Test
@@ -87,17 +79,14 @@ class FhirEngineImplTest {
     patient.id = TEST_PATIENT_1_ID
     patient.gender = Enumerations.AdministrativeGender.FEMALE
     fhirEngine.update(patient)
-    testingUtils.assertResourceEquals(
-      patient,
-      fhirEngine.load(Patient::class.java, TEST_PATIENT_1_ID)
-    )
+    testingUtils.assertResourceEquals(patient, fhirEngine.get(TEST_PATIENT_1_ID))
   }
 
   @Test
-  fun load_nonexistentResource_shouldThrowResourceNotFoundException() {
+  suspend fun load_nonexistentResource_shouldThrowResourceNotFoundException() {
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { fhirEngine.load(Patient::class.java, "nonexistent_patient") }
+        runBlocking { fhirEngine.get<Patient>("nonexistent_patient") }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo(
@@ -107,10 +96,7 @@ class FhirEngineImplTest {
 
   @Test
   fun load_shouldReturnResource() = runBlocking {
-    testingUtils.assertResourceEquals(
-      TEST_PATIENT_1,
-      fhirEngine.load(Patient::class.java, TEST_PATIENT_1_ID)
-    )
+    testingUtils.assertResourceEquals(TEST_PATIENT_1, fhirEngine.get<Patient>(TEST_PATIENT_1_ID))
   }
 
   @Test
@@ -136,10 +122,7 @@ class FhirEngineImplTest {
   fun syncDownload_downloadResources() = runBlocking {
     fhirEngine.syncDownload { flowOf((listOf(TEST_PATIENT_2))) }
 
-    testingUtils.assertResourceEquals(
-      TEST_PATIENT_2,
-      fhirEngine.load(Patient::class.java, TEST_PATIENT_2_ID)
-    )
+    testingUtils.assertResourceEquals(TEST_PATIENT_2, fhirEngine.get<Patient>(TEST_PATIENT_2_ID))
   }
 
   companion object {

--- a/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
@@ -79,11 +79,11 @@ class FhirEngineImplTest {
     patient.id = TEST_PATIENT_1_ID
     patient.gender = Enumerations.AdministrativeGender.FEMALE
     fhirEngine.update(patient)
-    testingUtils.assertResourceEquals(patient, fhirEngine.get(TEST_PATIENT_1_ID))
+    testingUtils.assertResourceEquals(patient, fhirEngine.get<Patient>(TEST_PATIENT_1_ID))
   }
 
   @Test
-  suspend fun load_nonexistentResource_shouldThrowResourceNotFoundException() {
+  fun load_nonexistentResource_shouldThrowResourceNotFoundException() {
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
         runBlocking { fhirEngine.get<Patient>("nonexistent_patient") }

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineRetrieveProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineRetrieveProvider.kt
@@ -17,6 +17,7 @@
 package com.google.android.fhir.workflow
 
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.get
 import com.google.android.fhir.search.search
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.CarePlan
@@ -50,7 +51,7 @@ class FhirEngineRetrieveProvider(val fhirEngine: FhirEngine) : TerminologyAwareR
       when (dataType) {
         "Patient" -> {
           if (contextValue is String) {
-            mutableListOf(fhirEngine.load(Patient::class.java, contextValue))
+            mutableListOf(fhirEngine.get<Patient>(contextValue))
           } else {
             val patients =
               fhirEngine.search<Patient> { filter(Patient.ACTIVE, { value = of(true) }) }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #784 

**Description**
Use reified generics in the delete and read APIs in FhirEngine.

For example,

```
fhirEngine.load(Patient::class.java, patientId)
```

becomes

```
fhirEngine.get<Patient>(patientId)
```

and

```
fhirEngine.remove(Patient::class.java, patientId)
```

becomes

```
fhirEngine.delete<Patient>(patientId)
```

The implementation uses `inline` functions with `reified` generics, and we use the `@Deprecated` annotation to suggest replacement if the caller accidentally calls the internal APIs.

**Alternative(s) considered**
NA

**Type**
Choose one: Feature

**Screenshots (if applicable)**
NA

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
