### PR TITLE
Upgrade workmanager runtime version to 2.7.1 and desugar lib to 1.1.5

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -151,7 +151,7 @@ object Dependencies {
       const val recyclerView = "1.1.0"
       const val room = "2.3.0"
       const val sqliteKtx = "2.1.0"
-      const val workRuntimeKtx = "2.5.0"
+      const val workRuntimeKtx = "2.7.1"
     }
 
     object Cql {
@@ -169,7 +169,7 @@ object Dependencies {
     }
 
     const val androidFhirCommon = "0.1.0-alpha02"
-    const val desugarJdkLibs = "1.0.9"
+    const val desugarJdkLibs = "1.1.5"
     const val fhirUcum = "1.0.3"
     const val flexBox = "3.0.0"
     const val guava = "28.2-android"


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1236 

**Description**
Upgrade workmanager runtime version to 2.7.1 and desugar lib to 1.1.5

**Alternative(s) considered**
NA

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
