### PR TITLE
Use newest room version of 2.4.2

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -149,7 +149,7 @@ object Dependencies {
       const val lifecycle = "2.2.0"
       const val navigation = "2.3.4"
       const val recyclerView = "1.1.0"
-      const val room = "2.3.0"
+      const val room = "2.4.2"
       const val sqliteKtx = "2.1.0"
       const val workRuntimeKtx = "2.7.1"
     }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -227,7 +227,7 @@ internal abstract class ResourceDao {
   @RawQuery abstract suspend fun countResources(query: SupportSQLiteQuery): Long
 
   private suspend fun insertResource(resource: Resource) {
-    val resourceUuid = UUID.randomUUID().toString()
+    val resourceUuid = UUID.randomUUID()
     val entity =
       ResourceEntity(
         id = 0,
@@ -246,7 +246,7 @@ internal abstract class ResourceDao {
   private suspend fun updateIndicesForResource(
     index: ResourceIndices,
     resource: ResourceEntity,
-    resourceUuid: String
+    resourceUuid: UUID
   ) {
     // TODO Move StringIndices to persistable types
     //  https://github.com/jingtang10/fhir-engine/issues/31

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.DateIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class DateIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: DateIndex,
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.DateTimeIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class DateTimeIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: DateTimeIndex,
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/NumberIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/NumberIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.NumberIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class NumberIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: NumberIndex,
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/PositionIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/PositionIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.PositionIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class PositionIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: PositionIndex,
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/QuantityIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/QuantityIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.QuantityIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class QuantityIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: QuantityIndex
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/ReferenceIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/ReferenceIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.ReferenceIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class ReferenceIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: ReferenceIndex,
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/ResourceEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/ResourceEntity.kt
@@ -20,6 +20,7 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import java.time.Instant
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -30,7 +31,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class ResourceEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   val resourceId: String,
   val serializedResource: String,

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/StringIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/StringIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.StringIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class StringIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: StringIndex,
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/TokenIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/TokenIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.TokenIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class TokenIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: TokenIndex,
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/UriIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/UriIndexEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.google.android.fhir.index.entities.UriIndex
+import java.util.UUID
 import org.hl7.fhir.r4.model.ResourceType
 
 @Entity(
@@ -43,7 +44,7 @@ import org.hl7.fhir.r4.model.ResourceType
 )
 internal data class UriIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
-  val resourceUuid: String,
+  val resourceUuid: UUID,
   val resourceType: ResourceType,
   @Embedded(prefix = "index_") val index: UriIndex
 )


### PR DESCRIPTION
Use UUID type of resourceUUID

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1218

**Description**
Use the newest room version of 2.4.2 for UUID type support.
Change the resourceUUID from String type to UUID type.

**Alternative(s) considered**


**Type**
Code health
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
