### PR TITLE
Use ResourceType for FHIR Engine data access APIs

### DIFF
--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
@@ -26,13 +26,13 @@ import com.google.android.fhir.db.ResourceNotFoundException
 import com.google.android.fhir.db.impl.entities.LocalChangeEntity
 import com.google.android.fhir.logicalId
 import com.google.android.fhir.resource.TestingUtils
-import com.google.android.fhir.resource.versionId
 import com.google.android.fhir.search.Operation
 import com.google.android.fhir.search.Order
 import com.google.android.fhir.search.Search
 import com.google.android.fhir.search.StringFilterModifier
 import com.google.android.fhir.search.getQuery
 import com.google.android.fhir.search.has
+import com.google.android.fhir.versionId
 import com.google.common.truth.Truth.assertThat
 import java.math.BigDecimal
 import java.time.Instant
@@ -56,7 +56,6 @@ import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.Practitioner
 import org.hl7.fhir.r4.model.Quantity
 import org.hl7.fhir.r4.model.Reference
-import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
 import org.hl7.fhir.r4.model.RiskAssessment
 import org.json.JSONArray
@@ -97,7 +96,7 @@ class DatabaseImplTest {
     database.insert(TEST_PATIENT_2)
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(Patient::class.java, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
     )
   }
 
@@ -109,23 +108,23 @@ class DatabaseImplTest {
     database.insert(*patients.toTypedArray())
     testingUtils.assertResourceEquals(
       TEST_PATIENT_1,
-      database.select(Patient::class.java, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
     )
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(Patient::class.java, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
     )
   }
 
   @Test
   fun update_existentResource_shouldUpdateResource() = runBlocking {
     val patient = Patient()
-    patient.setId(TEST_PATIENT_1_ID)
-    patient.setGender(Enumerations.AdministrativeGender.FEMALE)
+    patient.id = TEST_PATIENT_1_ID
+    patient.gender = Enumerations.AdministrativeGender.FEMALE
     database.update(patient)
     testingUtils.assertResourceEquals(
       patient,
-      database.select(Patient::class.java, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
     )
   }
 
@@ -144,20 +143,10 @@ class DatabaseImplTest {
   }
 
   @Test
-  fun select_invalidResourceType_shouldThrowIllegalArgumentException() {
-    val illegalArgumentException =
-      assertThrows(IllegalArgumentException::class.java) {
-        runBlocking { database.select(Resource::class.java, "resource_id") }
-      }
-    assertThat(illegalArgumentException.message)
-      .isEqualTo("Cannot resolve resource type for " + Resource::class.java.name)
-  }
-
-  @Test
   fun select_nonexistentResource_shouldThrowResourceNotFoundException() {
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(Patient::class.java, "nonexistent_patient") }
+        runBlocking { database.select(ResourceType.Patient, "nonexistent_patient") }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo("Resource not found with type Patient and id nonexistent_patient!")
@@ -167,7 +156,7 @@ class DatabaseImplTest {
   fun select_shouldReturnResource() = runBlocking {
     testingUtils.assertResourceEquals(
       TEST_PATIENT_1,
-      database.select(Patient::class.java, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
     )
   }
 
@@ -236,7 +225,7 @@ class DatabaseImplTest {
       }
     database.update(updatedPatient)
 
-    val selectedEntity = database.selectEntity(Patient::class.java, "remote-patient-1")
+    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-1")
     assertThat(selectedEntity.resourceId).isEqualTo("remote-patient-1")
     assertThat(selectedEntity.versionId).isEqualTo(patient.meta.versionId)
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(patient.meta.lastUpdated.toInstant())
@@ -249,7 +238,7 @@ class DatabaseImplTest {
 
   @Test
   fun delete_shouldAddDeleteLocalChange() = runBlocking {
-    database.delete(Patient::class.java, TEST_PATIENT_1_ID)
+    database.delete(ResourceType.Patient, TEST_PATIENT_1_ID)
     val (_, resourceType, resourceId, _, type, payload) =
       database
         .getAllLocalChanges()
@@ -263,7 +252,7 @@ class DatabaseImplTest {
 
   @Test
   fun delete_nonExistent_shouldNotInsertLocalChange() = runBlocking {
-    database.delete(Patient::class.java, "nonexistent_patient")
+    database.delete(ResourceType.Patient, "nonexistent_patient")
     assertThat(
         database.getAllLocalChanges().map { it.localChange }.none {
           it.type.equals(LocalChangeEntity.Type.DELETE) &&
@@ -313,7 +302,7 @@ class DatabaseImplTest {
           }
       }
     database.insertRemote(patient)
-    val selectedEntity = database.selectEntity(Patient::class.java, "remote-patient-1")
+    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-1")
     assertThat(selectedEntity.versionId).isEqualTo("remote-patient-1-version-1")
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(patient.meta.lastUpdated.toInstant())
   }
@@ -322,7 +311,7 @@ class DatabaseImplTest {
   fun insert_remoteResourceWithNoMeta_shouldSaveNullRemoteVersionAndLastUpdated() = runBlocking {
     val patient = Patient().apply { id = "remote-patient-2" }
     database.insertRemote(patient)
-    val selectedEntity = database.selectEntity(Patient::class.java, "remote-patient-2")
+    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-2")
     assertThat(selectedEntity.versionId).isNull()
     assertThat(selectedEntity.lastUpdatedRemote).isNull()
   }
@@ -331,7 +320,7 @@ class DatabaseImplTest {
   fun insert_localResourceWithNoMeta_shouldSaveNullRemoteVersionAndLastUpdated() = runBlocking {
     val patient = Patient().apply { id = "local-patient-2" }
     database.insert(patient)
-    val selectedEntity = database.selectEntity(Patient::class.java, "local-patient-2")
+    val selectedEntity = database.selectEntity(ResourceType.Patient, "local-patient-2")
     assertThat(selectedEntity.versionId).isNull()
     assertThat(selectedEntity.lastUpdatedRemote).isNull()
   }
@@ -356,7 +345,7 @@ class DatabaseImplTest {
         )
       }
     }
-    val selectedEntity = database.selectEntity(Patient::class.java, "remote-patient-3")
+    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-3")
     assertThat(selectedEntity.versionId).isEqualTo(remoteMeta.versionId)
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(remoteMeta.lastUpdated.toInstant())
   }
@@ -423,7 +412,7 @@ class DatabaseImplTest {
   @Test
   fun delete_remoteResource_shouldReturnDeleteLocalChange() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
-    database.delete(Patient::class.java, TEST_PATIENT_2_ID)
+    database.delete(ResourceType.Patient, TEST_PATIENT_2_ID)
     val (_, resourceType, resourceId, _, type, payload, versionId) =
       database.getAllLocalChanges().map { it.localChange }.single {
         it.resourceId.equals(TEST_PATIENT_2_ID)
@@ -438,11 +427,11 @@ class DatabaseImplTest {
   @Test
   fun delete_remoteResource_updateResource_shouldReturnDeleteLocalChange() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
-    TEST_PATIENT_2.setName(listOf(HumanName().addGiven("John").setFamily("Doe")))
+    TEST_PATIENT_2.name = listOf(HumanName().addGiven("John").setFamily("Doe"))
     database.update(TEST_PATIENT_2)
-    TEST_PATIENT_2.setName(listOf(HumanName().addGiven("Jimmy").setFamily("Doe")))
+    TEST_PATIENT_2.name = listOf(HumanName().addGiven("Jimmy").setFamily("Doe"))
     database.update(TEST_PATIENT_2)
-    database.delete(Patient::class.java, TEST_PATIENT_2_ID)
+    database.delete(ResourceType.Patient, TEST_PATIENT_2_ID)
     val (_, resourceType, resourceId, _, type, payload) =
       database.getAllLocalChanges().map { it.localChange }.single {
         it.resourceId.equals(TEST_PATIENT_2_ID)
@@ -2648,8 +2637,8 @@ class DatabaseImplTest {
 
     init {
       TEST_PATIENT_1.meta.id = "v1-of-patient1"
-      TEST_PATIENT_1.setId(TEST_PATIENT_1_ID)
-      TEST_PATIENT_1.setGender(Enumerations.AdministrativeGender.MALE)
+      TEST_PATIENT_1.id = TEST_PATIENT_1_ID
+      TEST_PATIENT_1.gender = Enumerations.AdministrativeGender.MALE
     }
 
     const val TEST_PATIENT_2_ID = "test_patient_2"
@@ -2657,8 +2646,8 @@ class DatabaseImplTest {
 
     init {
       TEST_PATIENT_2.meta.id = "v1-of-patient2"
-      TEST_PATIENT_2.setId(TEST_PATIENT_2_ID)
-      TEST_PATIENT_2.setGender(Enumerations.AdministrativeGender.MALE)
+      TEST_PATIENT_2.id = TEST_PATIENT_2_ID
+      TEST_PATIENT_2.gender = Enumerations.AdministrativeGender.MALE
     }
 
     @JvmStatic @Parameters(name = "encrypted={0}") fun data(): Array<Boolean> = arrayOf(true, false)

--- a/engine/src/main/java/com/google/android/fhir/MoreResources.kt
+++ b/engine/src/main/java/com/google/android/fhir/MoreResources.kt
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.resource
+package com.google.android.fhir
 
 import java.lang.reflect.InvocationTargetException
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
 
 /** The HAPI Fhir package prefix for R4 resources. */
-internal val R4_RESOURCE_PACKAGE_PREFIX = "org.hl7.fhir.r4.model."
+internal const val R4_RESOURCE_PACKAGE_PREFIX = "org.hl7.fhir.r4.model."
 
 /** Returns the FHIR resource type. */
-internal fun <R : Resource> getResourceType(clazz: Class<R>): ResourceType {
+fun <R : Resource> getResourceType(clazz: Class<R>): ResourceType {
   try {
     return clazz.getConstructor().newInstance().resourceType
   } catch (e: NoSuchMethodException) {
@@ -39,7 +39,7 @@ internal fun <R : Resource> getResourceType(clazz: Class<R>): ResourceType {
 }
 
 /** Returns the {@link Class} object for the resource type. */
-internal fun <R : Resource> getResourceClass(resourceType: String): Class<R> {
+fun <R : Resource> getResourceClass(resourceType: String): Class<R> {
   // Remove any curly brackets in the resource type string. This is to work around an issue with
   // JSON deserialization in the CQL engine on Android. The resource type string incorrectly
   // includes namespace prefix in curly brackets, e.g. "{http://hl7.org/fhir}Patient" instead of

--- a/engine/src/main/java/com/google/android/fhir/MoreResources.kt
+++ b/engine/src/main/java/com/google/android/fhir/MoreResources.kt
@@ -23,7 +23,11 @@ import org.hl7.fhir.r4.model.ResourceType
 /** The HAPI Fhir package prefix for R4 resources. */
 internal const val R4_RESOURCE_PACKAGE_PREFIX = "org.hl7.fhir.r4.model."
 
-/** Returns the FHIR resource type. */
+/**
+ * Returns the FHIR resource type.
+ *
+ * @throws IllegalArgumentException if class name cannot be mapped to valid resource type
+ */
 fun <R : Resource> getResourceType(clazz: Class<R>): ResourceType {
   try {
     return clazz.getConstructor().newInstance().resourceType

--- a/engine/src/main/java/com/google/android/fhir/db/Database.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/Database.kt
@@ -51,7 +51,7 @@ internal interface Database {
    *
    * @param <R> The resource type
    */
-  suspend fun <R : Resource> update(vararg resources: R)
+  suspend fun update(vararg resources: Resource)
 
   /** Updates the `resource` meta in the FHIR resource database. */
   suspend fun updateVersionIdAndLastUpdated(
@@ -68,7 +68,7 @@ internal interface Database {
    * @throws ResourceNotFoundException if the resource is not found in the database
    */
   @Throws(ResourceNotFoundException::class)
-  suspend fun <R : Resource> select(clazz: Class<R>, id: String): R
+  suspend fun select(type: ResourceType, id: String): Resource
 
   /**
    * Selects the saved `ResourceEntity` of type `clazz` with `id`.
@@ -77,7 +77,7 @@ internal interface Database {
    * @throws ResourceNotFoundException if the resource is not found in the database
    */
   @Throws(ResourceNotFoundException::class)
-  suspend fun <R : Resource> selectEntity(clazz: Class<R>, id: String): ResourceEntity
+  suspend fun selectEntity(type: ResourceType, id: String): ResourceEntity
 
   /**
    * Return the last update data of a resource based on the resource type. If no resource of
@@ -101,7 +101,7 @@ internal interface Database {
    *
    * @param <R> The resource type
    */
-  suspend fun <R : Resource> delete(clazz: Class<R>, id: String)
+  suspend fun delete(type: ResourceType, id: String)
 
   suspend fun <R : Resource> search(query: SearchQuery): List<R>
 

--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
@@ -32,7 +32,6 @@ import com.google.android.fhir.db.impl.entities.LocalChangeEntity
 import com.google.android.fhir.db.impl.entities.ResourceEntity
 import com.google.android.fhir.db.impl.entities.SyncedResourceEntity
 import com.google.android.fhir.logicalId
-import com.google.android.fhir.resource.getResourceType
 import com.google.android.fhir.search.SearchQuery
 import java.time.Instant
 import org.hl7.fhir.r4.model.Resource
@@ -113,10 +112,10 @@ internal class DatabaseImpl(
     db.withTransaction { resourceDao.insertAll(resource.toList()) }
   }
 
-  override suspend fun <R : Resource> update(vararg resources: R) {
+  override suspend fun update(vararg resources: Resource) {
     db.withTransaction {
       resources.forEach {
-        val oldResourceEntity = selectEntity(it.javaClass, it.logicalId)
+        val oldResourceEntity = selectEntity(it.resourceType, it.logicalId)
         resourceDao.update(it)
         localChangeDao.addUpdate(oldResourceEntity, it)
       }
@@ -139,14 +138,14 @@ internal class DatabaseImpl(
     }
   }
 
-  override suspend fun <R : Resource> select(clazz: Class<R>, id: String): R {
+  override suspend fun select(type: ResourceType, id: String): Resource {
     return db.withTransaction {
-      val type = getResourceType(clazz)
       resourceDao.getResource(resourceId = id, resourceType = type)?.let {
-        iParser.parseResource(clazz, it)
+        iParser.parseResource(it)
       }
         ?: throw ResourceNotFoundException(type.name, id)
-    }
+    } as
+      Resource
   }
 
   override suspend fun lastUpdate(resourceType: ResourceType): String? {
@@ -163,15 +162,14 @@ internal class DatabaseImpl(
     }
   }
 
-  override suspend fun <R : Resource> delete(clazz: Class<R>, id: String) {
+  override suspend fun delete(type: ResourceType, id: String) {
     db.withTransaction {
       val remoteVersionId: String? =
         try {
-          selectEntity(clazz, id).versionId
+          selectEntity(type, id).versionId
         } catch (e: ResourceNotFoundException) {
           null
         }
-      val type = getResourceType(clazz)
       val rowsDeleted = resourceDao.deleteResource(resourceId = id, resourceType = type)
       if (rowsDeleted > 0)
         localChangeDao.addDelete(
@@ -213,9 +211,8 @@ internal class DatabaseImpl(
     db.withTransaction { localChangeDao.discardLocalChanges(token) }
   }
 
-  override suspend fun <R : Resource> selectEntity(clazz: Class<R>, id: String): ResourceEntity {
+  override suspend fun selectEntity(type: ResourceType, id: String): ResourceEntity {
     return db.withTransaction {
-      val type = getResourceType(clazz)
       resourceDao.getResourceEntity(resourceId = id, resourceType = type)
         ?: throw ResourceNotFoundException(type.name, id)
     }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/LocalChangeDao.kt
@@ -25,8 +25,8 @@ import com.google.android.fhir.db.impl.entities.LocalChangeEntity
 import com.google.android.fhir.db.impl.entities.LocalChangeEntity.Type
 import com.google.android.fhir.db.impl.entities.ResourceEntity
 import com.google.android.fhir.logicalId
-import com.google.android.fhir.resource.versionId
 import com.google.android.fhir.toTimeZoneString
+import com.google.android.fhir.versionId
 import java.util.Date
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -36,9 +36,9 @@ import com.google.android.fhir.db.impl.entities.TokenIndexEntity
 import com.google.android.fhir.db.impl.entities.UriIndexEntity
 import com.google.android.fhir.index.ResourceIndexer
 import com.google.android.fhir.index.ResourceIndices
+import com.google.android.fhir.lastUpdated
 import com.google.android.fhir.logicalId
-import com.google.android.fhir.resource.lastUpdated
-import com.google.android.fhir.resource.versionId
+import com.google.android.fhir.versionId
 import java.time.Instant
 import java.util.UUID
 import org.hl7.fhir.r4.model.Resource

--- a/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -43,16 +43,16 @@ internal class FhirEngineImpl(private val database: Database, private val contex
     return database.insert(*resource)
   }
 
+  override suspend fun get(type: ResourceType, id: String): Resource {
+    return database.select(type, id)
+  }
+
   override suspend fun update(vararg resource: Resource) {
     database.update(*resource)
   }
 
-  override suspend fun <R : Resource> load(clazz: Class<R>, id: String): R {
-    return database.select(clazz, id)
-  }
-
-  override suspend fun <R : Resource> remove(clazz: Class<R>, id: String) {
-    database.delete(clazz, id)
+  override suspend fun delete(type: ResourceType, id: String) {
+    database.delete(type, id)
   }
 
   override suspend fun <R : Resource> search(search: Search): List<R> {

--- a/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
+++ b/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
@@ -140,12 +140,12 @@ class TestingUtils constructor(private val iParser: IParser) {
       download: suspend (SyncDownloadContext) -> Flow<List<Resource>>
     ) {
       download(
-          object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType): String {
-              return "123456788"
-            }
+        object : SyncDownloadContext {
+          override suspend fun getLatestTimestampFor(type: ResourceType): String {
+            return "123456788"
           }
-        )
+        }
+      )
         .collect {}
     }
     override suspend fun count(search: Search): Long {

--- a/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
+++ b/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
@@ -120,11 +120,11 @@ class TestingUtils constructor(private val iParser: IParser) {
 
     override suspend fun update(vararg resource: Resource) {}
 
-    override suspend fun <R : Resource> get(clazz: Class<R>, id: String): R {
-      return clazz.newInstance()
+    override suspend fun get(type: ResourceType, id: String): Resource {
+      return Patient()
     }
 
-    override suspend fun <R : Resource> delete(clazz: Class<R>, id: String) {}
+    override suspend fun delete(type: ResourceType, id: String) {}
 
     override suspend fun <R : Resource> search(search: Search): List<R> {
       return emptyList()
@@ -140,12 +140,12 @@ class TestingUtils constructor(private val iParser: IParser) {
       download: suspend (SyncDownloadContext) -> Flow<List<Resource>>
     ) {
       download(
-        object : SyncDownloadContext {
-          override suspend fun getLatestTimestampFor(type: ResourceType): String {
-            return "123456788"
+          object : SyncDownloadContext {
+            override suspend fun getLatestTimestampFor(type: ResourceType): String {
+              return "123456788"
+            }
           }
-        }
-      )
+        )
         .collect {}
     }
     override suspend fun count(search: Search): Long {

--- a/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
+++ b/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
@@ -120,11 +120,11 @@ class TestingUtils constructor(private val iParser: IParser) {
 
     override suspend fun update(vararg resource: Resource) {}
 
-    override suspend fun <R : Resource> load(clazz: Class<R>, id: String): R {
+    override suspend fun <R : Resource> get(clazz: Class<R>, id: String): R {
       return clazz.newInstance()
     }
 
-    override suspend fun <R : Resource> remove(clazz: Class<R>, id: String) {}
+    override suspend fun <R : Resource> delete(clazz: Class<R>, id: String) {}
 
     override suspend fun <R : Resource> search(search: Search): List<R> {
       return emptyList()

--- a/engine/src/test/java/com/google/android/fhir/MoreResourcesTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/MoreResourcesTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.resource
+package com.google.android.fhir
 
 import android.os.Build
 import com.google.common.truth.Truth.assertThat
@@ -28,7 +28,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P])
-class ResourcesTest {
+class MoreResourcesTest {
   @Test
   fun getResourceType() {
     assertThat(getResourceType(Patient::class.java)).isEqualTo(ResourceType.Patient)


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1277 

**Description**
Have the following APIs instead:

```
  suspend fun create(vararg resource: Resource): List<String>
  suspend fun get(type: ResourceType, id: String): Resource
  suspend fun update(vararg resource: Resource)
  suspend fun delete(type: ResourceType, id: String)
```

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
