### PR TITLE
Date and Time Picker and Input Widget related issues fixed

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
@@ -149,7 +149,7 @@ internal val Questionnaire.QuestionnaireItemComponent.isHidden: Boolean
   }
 
 /** Whether the QuestionnaireItem should have entry format string. */
-val Questionnaire.QuestionnaireItemComponent.dateEntryFormat: String?
+val Questionnaire.QuestionnaireItemComponent.entryFormat: String?
   get() {
     val extension = extension.singleOrNull { it.url == EXTENSION_ENTRY_FORMAT_URL } ?: return null
     val value = extension.value

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDate.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDate.kt
@@ -21,9 +21,6 @@ import android.os.Build
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.chrono.IsoChronology
-import java.time.format.DateTimeFormatterBuilder
-import java.time.format.FormatStyle
 import java.util.Date
 import java.util.Locale
 
@@ -36,15 +33,3 @@ internal val LocalDate.localizedString: String
 
 // Android ICU is supported API level 24 onwards.
 private fun isAndroidIcuSupported() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
-
-/** Gives date format for current locale of device */
-fun getDefaultDatePattern(): String {
-  val dateFormat =
-    DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-      FormatStyle.SHORT,
-      null,
-      IsoChronology.INSTANCE,
-      Locale.getDefault()
-    )
-  return dateFormat
-}

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -23,11 +23,10 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.dateEntryFormat
+import com.google.android.fhir.datacapture.entryFormat
 import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
 import com.google.android.fhir.datacapture.subtitleText
-import com.google.android.fhir.datacapture.utilities.getDefaultDatePattern
 import com.google.android.fhir.datacapture.utilities.localizedString
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
@@ -116,11 +115,9 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
 
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        questionnaireItemViewItem.questionnaireItem.dateEntryFormat?.let {
+        questionnaireItemViewItem.questionnaireItem.entryFormat?.let {
           textInputLayout.helperText = it
         }
-          ?: run { textInputLayout.helperText = getDefaultDatePattern() }
-
         if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
           prefixTextView.visibility = View.VISIBLE
           prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -52,12 +52,8 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
         textDateQuestion = itemView.findViewById(R.id.question_text_view)
         textInputLayout = itemView.findViewById(R.id.text_input_layout)
         textInputEditText = itemView.findViewById(R.id.text_input_edit_text)
-        // Disable direct text input to only allow input from the date picker dialog
-        textInputEditText.keyListener = null
-        textInputEditText.setOnFocusChangeListener { _, hasFocus: Boolean ->
-          // Do not show the date picker dialog when losing focus.
-          if (!hasFocus) return@setOnFocusChangeListener
 
+        textInputLayout.setEndIconOnClickListener {
           // The application is wrapped in a ContextThemeWrapper in QuestionnaireFragment
           // and again in TextInputEditText during layout inflation. As a result, it is
           // necessary to access the base context twice to retrieve the application object
@@ -65,27 +61,24 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
           val context = itemView.context.tryUnwrapContext()!!
           context.supportFragmentManager.setFragmentResultListener(
             DatePickerFragment.RESULT_REQUEST_KEY,
-            context,
-            { _, result ->
-              // java.time APIs can be used with desugaring
-              val year = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_YEAR)
-              val month = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_MONTH)
-              val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
-              // Month values are 1-12 in java.time but 0-11 in
-              // DatePickerDialog.
-              val localDate = LocalDate.of(year, month + 1, dayOfMonth)
-              textInputEditText.setText(localDate?.localizedString)
+            context
+          ) { _, result ->
+            // java.time APIs can be used with desugaring
+            val year = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_YEAR)
+            val month = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_MONTH)
+            val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
+            // Month values are 1-12 in java.time but 0-11 in
+            // DatePickerDialog.
+            val localDate = LocalDate.of(year, month + 1, dayOfMonth)
+            textInputEditText.setText(localDate?.localizedString)
 
-              val date = DateType(year, month, dayOfMonth)
-              questionnaireItemViewItem.singleAnswerOrNull =
-                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                  value = date
-                }
-              // Clear focus so that the user can refocus to open the dialog
-              textInputEditText.clearFocus()
-              onAnswerChanged(textInputEditText.context)
-            }
-          )
+            val date = DateType(year, month, dayOfMonth)
+            questionnaireItemViewItem.singleAnswerOrNull =
+              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                value = date
+              }
+            onAnswerChanged(textInputEditText.context)
+          }
 
           val selectedDate = questionnaireItemViewItem.singleAnswerOrNull?.valueDateType?.localDate
           DatePickerFragment()

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -21,11 +21,10 @@ import android.view.View
 import android.widget.TextView
 import androidx.core.os.bundleOf
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.dateEntryFormat
+import com.google.android.fhir.datacapture.entryFormat
 import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
 import com.google.android.fhir.datacapture.subtitleText
-import com.google.android.fhir.datacapture.utilities.getDefaultDatePattern
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import com.google.android.fhir.datacapture.views.DatePickerFragment.Companion.REQUEST_BUNDLE_KEY_DATE
@@ -130,10 +129,9 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
 
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        questionnaireItemViewItem.questionnaireItem.dateEntryFormat?.let {
+        questionnaireItemViewItem.questionnaireItem.entryFormat?.let {
           dateInputLayout.helperText = it
         }
-          ?: run { dateInputLayout.helperText = getDefaultDatePattern() }
 
         if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
           prefixTextView.visibility = View.VISIBLE

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -54,12 +54,8 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
         questionTextView = itemView.findViewById(R.id.question_text_view)
         dateInputLayout = itemView.findViewById(R.id.date_input_layout)
         dateInputEditText = itemView.findViewById(R.id.date_input_edit_text)
-        // Disable direct text input to only allow input from the date picker dialog
-        dateInputEditText.keyListener = null
-        dateInputEditText.setOnFocusChangeListener { _: View, hasFocus: Boolean ->
-          // Do not show the date picker dialog when losing focus.
-          if (!hasFocus) return@setOnFocusChangeListener
 
+        dateInputLayout.setEndIconOnClickListener {
           // The application is wrapped in a ContextThemeWrapper in QuestionnaireFragment
           // and again in TextInputEditText during layout inflation. As a result, it is
           // necessary to access the base context twice to retrieve the application object
@@ -95,19 +91,12 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
           DatePickerFragment()
             .apply { arguments = bundleOf(REQUEST_BUNDLE_KEY_DATE to selectedDate) }
             .show(context.supportFragmentManager, DatePickerFragment.TAG)
-
-          // Clear focus so that the user can refocus to open the dialog
-          questionTextView.clearFocus()
         }
 
         timeInputLayout = itemView.findViewById(R.id.time_input_layout)
         timeInputEditText = itemView.findViewById(R.id.time_input_edit_text)
-        // Disable direct text input to only allow input from the time picker dialog
-        timeInputEditText.keyListener = null
-        timeInputEditText.setOnFocusChangeListener { _: View, hasFocus: Boolean ->
-          // Do not show the date picker dialog when losing focus.
-          if (!hasFocus) return@setOnFocusChangeListener
 
+        timeInputLayout.setEndIconOnClickListener {
           // The application is wrapped in a ContextThemeWrapper in QuestionnaireFragment
           // and again in TextInputEditText during layout inflation. As a result, it is
           // necessary to access the base context twice to retrieve the application object
@@ -124,8 +113,6 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
               LocalDateTime.of(localDate.year, localDate.month + 1, localDate.day, hour, minute, 0)
             updateDateTimeInput(localDateTime)
             updateDateTimeAnswer(localDateTime)
-            // Clear focus so that the user can refocus to open the dialog
-            timeInputEditText.clearFocus()
           }
 
           val selectedTime =

--- a/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
@@ -53,7 +53,9 @@
         android:id="@+id/text_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:startIconDrawable="@drawable/gm_calendar_today_24"
+        app:hintEnabled="true"
+        app:endIconMode="custom"
+        app:endIconDrawable="@drawable/gm_calendar_today_24"
     >
 
         <com.google.android.material.textfield.TextInputEditText
@@ -62,6 +64,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="none"
+            android:singleLine="true"
         />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
@@ -60,7 +60,9 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            app:startIconDrawable="@drawable/gm_calendar_today_24"
+            app:hintEnabled="true"
+            app:endIconMode="custom"
+            app:endIconDrawable="@drawable/gm_calendar_today_24"
         >
 
             <com.google.android.material.textfield.TextInputEditText
@@ -68,6 +70,7 @@
                 android:id="@+id/date_input_edit_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:singleLine="true"
                 android:inputType="none"
             />
 
@@ -84,7 +87,9 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            app:startIconDrawable="@drawable/gm_schedule_24"
+            app:hintEnabled="true"
+            app:endIconMode="custom"
+            app:endIconDrawable="@drawable/gm_schedule_24"
         >
 
             <com.google.android.material.textfield.TextInputEditText
@@ -93,11 +98,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:enabled="false"
+                android:singleLine="true"
                 android:inputType="none"
             />
 
         </com.google.android.material.textfield.TextInputLayout>
-
     </LinearLayout>
-
 </LinearLayout>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
@@ -482,20 +482,26 @@ class MoreQuestionnaireItemComponentsTest {
   }
 
   @Test
-  fun dateEntryFormat_missingFormat_shouldReturnNull() {
-    val questionnaire =
+  fun entryFormat_missingFormat_shouldReturnNull() {
+    val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().apply {
         addExtension(EXTENSION_ENTRY_FORMAT_URL, null)
       }
-    assertThat(questionnaire.dateEntryFormat).isNull()
+    assertThat(questionnaireItem.entryFormat).isNull()
   }
 
   @Test
-  fun dateEntryFormat_shouldReturnDateFormat() {
-    val questionnaire =
+  fun entryFormat_shouldReturnDateFormat() {
+    val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().apply {
         addExtension(EXTENSION_ENTRY_FORMAT_URL, StringType("yyyy-mm-dd"))
       }
-    assertThat(questionnaire.dateEntryFormat).isEqualTo("yyyy-mm-dd")
+    assertThat(questionnaireItem.entryFormat).isEqualTo("yyyy-mm-dd")
+  }
+
+  @Test
+  fun entryFormat_formatExtensionMissing_shouldReturnNull() {
+    val questionnaireItem = Questionnaire.QuestionnaireItemComponent()
+    assertThat(questionnaireItem.entryFormat).isNull()
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Date and Time Picker and Input Widget related issues fixed
1. Time and Date Icon shifted to end of input widget
2. replaced setOnFocusChangeListener with setEndIconOnClickListener



**Type**
Choose one: Bug fix 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
