### PR TITLE
Date Time input Widget hint and helper text added

### DIFF
--- a/catalog/src/main/assets/date_picker_questionnaire.json
+++ b/catalog/src/main/assets/date_picker_questionnaire.json
@@ -4,7 +4,13 @@
     {
       "linkId": "1",
       "text": "When was your last menstrual period? (LMP)",
-      "type": "date"
+      "type": "date",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/entryFormat",
+          "valueString": "yyyy-mm-dd"
+        }
+      ]
     }
   ]
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
@@ -24,6 +24,7 @@ import org.hl7.fhir.r4.model.CodeType
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.StringType
 
 /** UI controls relevant to capturing question data. */
 internal enum class ItemControlTypes(
@@ -52,6 +53,8 @@ internal const val EXTENSION_ITEM_CONTROL_URL =
 internal const val EXTENSION_ITEM_CONTROL_SYSTEM = "http://hl7.org/fhir/questionnaire-item-control"
 internal const val EXTENSION_HIDDEN_URL =
   "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
+internal const val EXTENSION_ENTRY_FORMAT_URL =
+  "http://hl7.org/fhir/StructureDefinition/entryFormat"
 
 // Item control code, or null
 internal val Questionnaire.QuestionnaireItemComponent.itemControl: ItemControlTypes?
@@ -143,6 +146,17 @@ internal val Questionnaire.QuestionnaireItemComponent.isHidden: Boolean
       return value.booleanValue()
     }
     return false
+  }
+
+/** Whether the QuestionnaireItem should have entry format string. */
+val Questionnaire.QuestionnaireItemComponent.dateEntryFormat: String?
+  get() {
+    val extension = extension.singleOrNull { it.url == EXTENSION_ENTRY_FORMAT_URL } ?: return null
+    val value = extension.value
+    if (value is StringType) {
+      return value.toString()
+    }
+    return null
   }
 
 /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDate.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDate.kt
@@ -21,6 +21,9 @@ import android.os.Build
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.FormatStyle
 import java.util.Date
 import java.util.Locale
 
@@ -33,3 +36,15 @@ internal val LocalDate.localizedString: String
 
 // Android ICU is supported API level 24 onwards.
 private fun isAndroidIcuSupported() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+
+/** Gives date format for current locale of device */
+fun getDefaultDatePattern(): String {
+  val dateFormat =
+    DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+      FormatStyle.SHORT,
+      null,
+      IsoChronology.INSTANCE,
+      Locale.getDefault()
+    )
+  return dateFormat
+}

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -24,8 +24,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.os.bundleOf
 import com.google.android.fhir.datacapture.R
+import com.google.android.fhir.datacapture.dateEntryFormat
 import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
+import com.google.android.fhir.datacapture.utilities.getDefaultDatePattern
 import com.google.android.fhir.datacapture.utilities.localizedString
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
@@ -98,6 +100,11 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
 
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+        questionnaireItemViewItem.questionnaireItem.dateEntryFormat?.let {
+          textInputLayout.helperText = it
+        }
+          ?: run { textInputLayout.helperText = getDefaultDatePattern() }
+
         if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
           prefixTextView.visibility = View.VISIBLE
           prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -21,8 +21,10 @@ import android.view.View
 import android.widget.TextView
 import androidx.core.os.bundleOf
 import com.google.android.fhir.datacapture.R
+import com.google.android.fhir.datacapture.dateEntryFormat
 import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
+import com.google.android.fhir.datacapture.utilities.getDefaultDatePattern
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import com.google.android.fhir.datacapture.views.DatePickerFragment.Companion.REQUEST_BUNDLE_KEY_DATE
@@ -138,6 +140,11 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
 
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+        questionnaireItemViewItem.questionnaireItem.dateEntryFormat?.let {
+          dateInputLayout.helperText = it
+        }
+          ?: run { dateInputLayout.helperText = getDefaultDatePattern() }
+
         if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
           prefixTextView.visibility = View.VISIBLE
           prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned

--- a/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
@@ -62,6 +62,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="none"
+            android:hint="@string/date"
         />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
@@ -69,6 +69,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="none"
+                android:hint="@string/date"
             />
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -94,6 +95,7 @@
                 android:layout_height="wrap_content"
                 android:enabled="false"
                 android:inputType="none"
+                android:hint="@string/time"
             />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/datacapture/src/main/res/values/strings.xml
+++ b/datacapture/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
 
     <string name="open_choice_other">Other</string>
     <string name="open_choice_other_hint">Enter custom option</string>
-    <string name="open_choice_other_add_another">Add another answer</string> 
+    <string name="open_choice_other_add_another">Add another answer</string>
     <string name="app_name">MLKit Showcase</string>
 
     <string name="entry_java_title">Java</string>
@@ -90,7 +90,9 @@
     <string
         name="pref_key_delay_loading_barcode_result"
         translatable="false"
-    >barcode_dlbr</string> 
+    >barcode_dlbr</string>
     <string name="no">No</string>
     <string name="yes">Yes</string>
+    <string name="date">Date</string>
+    <string name="time">Time</string>
 </resources>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
@@ -480,4 +480,22 @@ class MoreQuestionnaireItemComponentsTest {
 
     assertThat(questionItemList.first().flyOverText.toString()).isEqualTo("flyover text")
   }
+
+  @Test
+  fun dateEntryFormat_missingFormat_shouldReturnNull() {
+    val questionnaire =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        addExtension(EXTENSION_ENTRY_FORMAT_URL, null)
+      }
+    assertThat(questionnaire.dateEntryFormat).isNull()
+  }
+
+  @Test
+  fun dateEntryFormat_shouldReturnDateFormat() {
+    val questionnaire =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        addExtension(EXTENSION_ENTRY_FORMAT_URL, StringType("yyyy-mm-dd"))
+      }
+    assertThat(questionnaire.dateEntryFormat).isEqualTo("yyyy-mm-dd")
+  }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Date Time input Widget hint and helper text added
1. Hint added as "Time" and "Date" for Time And Date input Widget resp
2. Format string is added as Helper text added for Date input widget if its available from questionnaire json else reading it from device locale.

**Type**
Choose one: Feature 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
