### PR TITLE
OptionExclusive extension support.

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest.kt
@@ -29,10 +29,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.fhir.datacapture.ChoiceOrientationTypes
 import com.google.android.fhir.datacapture.EXTENSION_CHOICE_ORIENTATION_URL
+import com.google.android.fhir.datacapture.EXTENSION_OPTION_EXCLUSIVE_URL
 import com.google.android.fhir.datacapture.R
 import com.google.common.truth.Truth.assertThat
+import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.CodeType
 import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.junit.Test
@@ -252,6 +255,85 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest {
 
     assertThat(answer).hasSize(1)
     assertThat(answer[0].valueCoding.display).isEqualTo("Coding 1")
+  }
+
+  @Test
+  @UiThreadTest
+  fun optionExclusiveAnswerOption_click_deselectsOtherAnswerOptions() {
+    val questionnaireItemViewItem =
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          repeats = true
+          addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value =
+                Coding().apply {
+                  code = "code-1"
+                  display = "display-1"
+                }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            }
+          )
+          addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value =
+                Coding().apply {
+                  code = "code-2"
+                  display = "display-2"
+                }
+            }
+          )
+        },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+      ) {}
+    viewHolder.bind(questionnaireItemViewItem)
+    val checkBoxGroup = viewHolder.itemView.findViewById<ConstraintLayout>(R.id.checkbox_group)
+    (checkBoxGroup.getChildAt(2) as CheckBox).performClick()
+    (checkBoxGroup.getChildAt(1) as CheckBox).performClick()
+    val answer = questionnaireItemViewItem.questionnaireResponseItem.answer
+
+    assertThat(answer).hasSize(1)
+    assertThat(answer[0].valueCoding.display).isEqualTo("display-1")
+  }
+
+  @Test
+  @UiThreadTest
+  fun answerOption_click_deselectsOptionExclusiveAnswerOption() {
+    val questionnaireItemViewItem =
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          repeats = true
+          addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value =
+                Coding().apply {
+                  code = "code-1"
+                  display = "display-1"
+                }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            }
+          )
+          addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value =
+                Coding().apply {
+                  code = "code-2"
+                  display = "display-2"
+                }
+            }
+          )
+        },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+      ) {}
+
+    viewHolder.bind(questionnaireItemViewItem)
+    val checkBoxGroup = viewHolder.itemView.findViewById<ConstraintLayout>(R.id.checkbox_group)
+    (checkBoxGroup.getChildAt(1) as CheckBox).performClick()
+    (checkBoxGroup.getChildAt(2) as CheckBox).performClick()
+    val answer = questionnaireItemViewItem.questionnaireResponseItem.answer
+
+    assertThat(answer).hasSize(1)
+    assertThat(answer[0].valueCoding.display).isEqualTo("display-2")
   }
 
   @Test

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreAnswerOptions.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreAnswerOptions.kt
@@ -17,7 +17,11 @@
 package com.google.android.fhir.datacapture
 
 import com.google.android.fhir.getLocalizedText
+import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Questionnaire
+
+internal const val EXTENSION_OPTION_EXCLUSIVE_URL =
+  "http://hl7.org/fhir/StructureDefinition/questionnaire-optionExclusive"
 
 val Questionnaire.QuestionnaireItemAnswerOptionComponent.displayString: String
   get() {
@@ -30,4 +34,16 @@ val Questionnaire.QuestionnaireItemAnswerOptionComponent.displayString: String
     } else {
       display
     }
+  }
+
+/** Indicates that if this answerOption is selected, no other possible answers may be selected. */
+internal val Questionnaire.QuestionnaireItemAnswerOptionComponent.optionExclusive: Boolean
+  get() {
+    val extension =
+      this.extension.singleOrNull { it.url == EXTENSION_OPTION_EXCLUSIVE_URL } ?: return false
+    val value = extension.value
+    if (value is BooleanType) {
+      return value.booleanValue()
+    }
+    return false
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
@@ -28,6 +28,7 @@ import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.choiceOrientation
 import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
+import com.google.android.fhir.datacapture.optionExclusive
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import org.hl7.fhir.r4.model.Questionnaire
@@ -120,18 +121,49 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
               )
             setOnClickListener {
               when (isChecked) {
-                true ->
+                true -> {
                   questionnaireItemViewItem.addAnswer(
                     QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                       value = answerOption.value
                     }
                   )
-                false ->
+                  if (answerOption.optionExclusive) {
+                    // if this answer option has optionExclusive extension, then deselect other
+                    // answer options.
+                    val optionExclusiveIndex = checkboxGroup.indexOfChild(it) - 1
+                    for (i in 0 until questionnaireItemViewItem.answerOption.size) {
+                      if (optionExclusiveIndex == i) {
+                        continue
+                      }
+                      (checkboxGroup.getChildAt(i + 1) as CheckBox).isChecked = false
+                      questionnaireItemViewItem.removeAnswer(
+                        QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                          value = questionnaireItemViewItem.answerOption[i].value
+                        }
+                      )
+                    }
+                  } else {
+                    // deselect optionExclusive answer option.
+                    for (i in 0 until questionnaireItemViewItem.answerOption.size) {
+                      if (!questionnaireItemViewItem.answerOption[i].optionExclusive) {
+                        continue
+                      }
+                      (checkboxGroup.getChildAt(i + 1) as CheckBox).isChecked = false
+                      questionnaireItemViewItem.removeAnswer(
+                        QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                          value = questionnaireItemViewItem.answerOption[i].value
+                        }
+                      )
+                    }
+                  }
+                }
+                false -> {
                   questionnaireItemViewItem.removeAnswer(
                     QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                       value = answerOption.value
                     }
                   )
+                }
               }
 
               onAnswerChanged(checkboxGroup.context)

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreAnswerOptionsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreAnswerOptionsTest.kt
@@ -20,6 +20,8 @@ import android.os.Build
 import com.google.common.truth.Truth.assertThat
 import java.util.Locale
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Questionnaire
@@ -101,5 +103,26 @@ class MoreAnswerOptionsTest {
     Locale.setDefault(Locale.forLanguageTag("vi-VN"))
 
     assertThat(answerOption.displayString).isEqualTo("Test Code")
+  }
+
+  @Test
+  fun optionExclusiveExtension_valueTrue_returnsTrue() = runBlocking {
+    val answerOptionTest = Coding("test", "option", "1")
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            answerOption =
+              listOf(
+                Questionnaire.QuestionnaireItemAnswerOptionComponent(answerOptionTest).apply {
+                  extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+                },
+              )
+          }
+        )
+      }
+
+    assertThat(questionnaire.item[0].answerOption[0].optionExclusive).isTrue()
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1281

**Description**

- Add option exclusive extension support in answerOption.
- On answer option exclusive click deselects other answer options.
- On answer option click deselects answer option exclusive.
- 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
