### PR TITLE
Fixed keyboard now showing up in open-choice dialog.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
@@ -92,8 +92,9 @@ internal class OptionSelectDialogFragment(
                 WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
             )
             // Adjust the dialog after the keyboard is on so that OK-CANCEL buttons are visible.
-            // it.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-            if (Build.VERSION.SDK_INT > 29) {
+            // SOFT_INPUT_ADJUST_RESIZE is deprecated and the suggested alternative
+            // setDecorFitsSystemWindows is available api level 30 and above.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
               it.setDecorFitsSystemWindows(false)
             } else {
               it.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
@@ -17,15 +17,16 @@
 package com.google.android.fhir.datacapture.views
 
 import android.app.Dialog
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.RadioButton
-import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
@@ -35,6 +36,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.fhir.datacapture.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -74,12 +76,31 @@ internal class OptionSelectDialogFragment(
       }
     }
 
-    return AlertDialog.Builder(requireContext())
+    return MaterialAlertDialogBuilder(requireContext())
       .setTitle(title)
       .setView(view)
       .setPositiveButton(android.R.string.ok) { _, _ -> saveSelections(adapter.currentList) }
       .setNegativeButton(android.R.string.cancel) { _, _ -> }
       .create()
+      .apply {
+        setOnShowListener {
+          dialog?.window?.let {
+            // Android: EditText in Dialog doesn't pull up soft keyboard
+            // https://stackoverflow.com/a/9118027
+            it.clearFlags(
+              WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
+            )
+            // Adjust the dialog after the keyboard is on so that OK-CANCEL buttons are visible.
+            // it.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+            if (Build.VERSION.SDK_INT > 29) {
+              it.setDecorFitsSystemWindows(false)
+            } else {
+              it.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+            }
+          }
+        }
+      }
   }
 
   /** Saves the current selections in the RecyclerView into the ViewModel. */
@@ -175,7 +196,6 @@ private class OptionSelectAdapter(val multiSelectEnabled: Boolean) :
       }
       is OptionSelectRow.OtherEditText -> {
         holder as OptionSelectViewHolder.OtherEditText
-        println("kmost Binding item $item")
         holder.delete.visibility = if (multiSelectEnabled) View.VISIBLE else View.GONE
         holder.delete.setOnClickListener {
           val newList = currentList.filterIndexed { index, _ -> index != holder.adapterPosition }
@@ -337,7 +357,6 @@ private sealed class OptionSelectViewHolder(parent: ViewGroup, layout: Int) :
     init {
       editText.doAfterTextChanged {
         val text = it?.toString().orEmpty()
-        println("kmost text change recorded: $currentItem changed to $text")
         currentItem?.currentText = text
       }
     }

--- a/datacapture/src/main/res/layout/questionnaire_item_option_item_other_text.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_option_item_other_text.xml
@@ -16,16 +16,23 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
+    android:gravity="center_vertical"
 >
-  <EditText
-        android:id="@+id/edit_text"
+  <com.google.android.material.textfield.TextInputLayout
+        style="?attr/questionnaireTextInputLayoutStyle"
+        android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:hint="@string/open_choice_other_hint"
-        android:importantForAutofill="no"
-        android:inputType="text"
-    />
+    >
+    <com.google.android.material.textfield.TextInputEditText
+            android:hint="@string/open_choice_other_hint"
+            style="?attr/editTextInputTextAppearanceQuestionnaire"
+            android:id="@+id/edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+        />
+  </com.google.android.material.textfield.TextInputLayout>
   <ImageView
         android:id="@+id/delete_button"
         android:layout_width="wrap_content"
@@ -33,5 +40,7 @@
         android:layout_gravity="center_vertical"
         android:padding="8dp"
         android:src="@drawable/gm_remove_circle_outline_24"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        app:tint="?colorPrimary"
     />
 </LinearLayout>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1293

**Description**
Android was preventing keyboard to show up in `EditText` inside a `RecyclerView` in a `AlertDialog`. 
Changes done are as: 

1. Clear dialog windows flags to allow keyboard to show up. (see https://stackoverflow.com/a/9118027)
2. Adjust soft input mode for Dialog to resize itself when keyboard shows up so that the Ok-Cancel buttons are visible.
3. Moved the input `EditText` to `TextInputLayout` .
4. Fixed deleteButton by adding tint color so that it is visible in all the applied themes.
5. Moved from default `AlertDialog.Builder` to `MaterialAlertDialogBuilder`.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug fix 

**Screenshots (if applicable)**

https://user-images.githubusercontent.com/18224849/163564895-f1056780-7bcd-4c92-b1c6-46f12b275334.mov



**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
