### PR TITLE
Create QuestionnaireItemHeaderView for the common question header (prefix+question+hint)

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest.kt
@@ -66,33 +66,6 @@ class QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
   fun shouldSetTextViewText() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
@@ -101,7 +74,7 @@ class QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.contrib.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest.kt
@@ -22,7 +22,6 @@ import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.view.get
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -57,45 +56,16 @@ class QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest {
 
   @Test
   @UiThreadTest
-  fun shouldShowPrefixText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question" },
         QuestionnaireResponse.QuestionnaireResponseItemComponent()
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  @UiThreadTest
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  @UiThreadTest
-  fun shouldSetQuestionText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { text = "Display" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
-      .isEqualTo("Display")
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
+      .isEqualTo("Question")
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest.kt
@@ -21,7 +21,6 @@ import android.widget.RadioButton
 import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -45,34 +44,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
   private val viewHolder = QuestionnaireItemBooleanTypePickerViewHolderFactory.create(parent)
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun bind_shouldSetQuestionText() {
+  fun bind_shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -83,7 +55,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 
@@ -330,7 +302,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_view).text)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text)
       .isEqualTo("Missing answer for required field.")
   }
 
@@ -350,8 +322,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_view).text.isEmpty())
-      .isTrue()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.isEmpty()).isTrue()
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest.kt
@@ -69,7 +69,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
       ) {}
     viewHolder.bind(questionnaireItemViewItem)
 
-    assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer.isEmpty())
+    assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer).isEmpty()
   }
 
   @Test
@@ -223,7 +223,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView.findViewById<RadioButton>(R.id.yes_radio_button).performClick()
 
-    assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer.isEmpty())
+    assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer).isEmpty()
   }
 
   @Test
@@ -266,7 +266,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView.findViewById<RadioButton>(R.id.no_radio_button).performClick()
 
-    assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer.isEmpty())
+    assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer).isEmpty()
   }
 
   @Test
@@ -322,7 +322,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.isEmpty()).isTrue()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text).isEqualTo("")
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest.kt
@@ -23,7 +23,6 @@ import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.children
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -53,40 +52,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest {
   private val viewHolder = QuestionnaireItemCheckBoxGroupViewHolderFactory.create(parent)
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          repeats = true
-          prefix = "Prefix?"
-        },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          repeats = true
-          prefix = ""
-        },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun bind_shouldSetQuestionText() {
+  fun bind_shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -97,7 +63,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 
@@ -392,7 +358,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_view).text)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text)
       .isEqualTo("Missing answer for required field.")
   }
 
@@ -420,8 +386,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_view).text.isEmpty())
-      .isTrue()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.isEmpty()).isTrue()
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -52,34 +51,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextInputLayoutHint() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -87,7 +59,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryEspressoTest.kt
@@ -47,7 +47,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryEspressoTest {
   @Rule
   @JvmField
   var activityScenarioRule: ActivityScenarioRule<TestActivity> =
-    ActivityScenarioRule<TestActivity>(TestActivity::class.java)
+    ActivityScenarioRule(TestActivity::class.java)
 
   private lateinit var parent: FrameLayout
   private lateinit var viewHolder: QuestionnaireItemViewHolder

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryInstrumentedTest.kt
@@ -20,7 +20,6 @@ import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -54,34 +53,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextInputLayoutHint() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -89,7 +61,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDisplayViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDisplayViewHolderFactoryInstrumentedTest.kt
@@ -16,11 +16,9 @@
 
 package com.google.android.fhir.datacapture.views
 
-import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.fhir.datacapture.R
@@ -49,34 +47,7 @@ class QuestionnaireItemDisplayViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Display" },
@@ -84,33 +55,7 @@ class QuestionnaireItemDisplayViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.display_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Display")
-  }
-
-  @Test
-  fun shouldSetTextViewVisible() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { text = "Display" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.display_text_view).visibility)
-      .isEqualTo(View.VISIBLE)
-  }
-
-  @Test
-  fun shouldSetTextViewGone() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { text = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.display_text_view).visibility)
-      .isEqualTo(View.GONE)
   }
 }

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryInstrumentedTest.kt
@@ -20,7 +20,6 @@ import android.widget.AutoCompleteTextView
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -57,36 +56,7 @@ class QuestionnaireItemDropDownViewHolderFactoryInstrumentedTest {
 
   @Test
   @UiThreadTest
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  @UiThreadTest
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  @UiThreadTest
-  fun shouldSetTextInputHint() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -94,7 +64,7 @@ class QuestionnaireItemDropDownViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextDecimalViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextDecimalViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -53,34 +52,7 @@ class QuestionnaireItemEditTextDecimalViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -88,7 +60,7 @@ class QuestionnaireItemEditTextDecimalViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextIntegerViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextIntegerViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -52,34 +51,7 @@ class QuestionnaireItemEditTextIntegerViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -87,7 +59,7 @@ class QuestionnaireItemEditTextIntegerViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextMultiLineViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextMultiLineViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -53,34 +52,7 @@ class QuestionnaireItemEditTextMultiLineViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -88,7 +60,7 @@ class QuestionnaireItemEditTextMultiLineViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextQuantityViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextQuantityViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -54,35 +53,8 @@ class QuestionnaireItemEditTextQuantityViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
   @UiThreadTest
-  fun shouldSetTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -90,7 +62,7 @@ class QuestionnaireItemEditTextQuantityViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextSingleLineViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextSingleLineViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -53,34 +52,7 @@ class QuestionnaireItemEditTextSingleLineViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -88,7 +60,7 @@ class QuestionnaireItemEditTextSingleLineViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactoryInstrumentedTest.kt
@@ -16,11 +16,9 @@
 
 package com.google.android.fhir.datacapture.views
 
-import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -51,34 +49,7 @@ class QuestionnaireItemGroupViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Group header" },
@@ -86,34 +57,8 @@ class QuestionnaireItemGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.group_header).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Group header")
-  }
-
-  @Test
-  fun shouldSetTextViewVisible() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { text = "Group header" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.group_header).visibility)
-      .isEqualTo(View.VISIBLE)
-  }
-
-  @Test
-  fun shouldSetTextViewGone() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { text = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.group_header).visibility)
-      .isEqualTo(View.GONE)
   }
 
   @Test
@@ -126,7 +71,7 @@ class QuestionnaireItemGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.group_header).error)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text)
       .isEqualTo("Missing answer for required field.")
   }
 
@@ -152,6 +97,6 @@ class QuestionnaireItemGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.group_header).error).isNull()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text).isEqualTo("")
   }
 }

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderViewInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderViewInstrumentedTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture.views
+
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.appcompat.view.ContextThemeWrapper
+import androidx.core.view.isVisible
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.fhir.datacapture.R
+import com.google.common.truth.Truth.assertThat
+import org.hl7.fhir.r4.model.Questionnaire
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class QuestionnaireItemHeaderViewInstrumentedTest {
+  private val parent =
+    FrameLayout(
+      ContextThemeWrapper(
+        InstrumentationRegistry.getInstrumentation().targetContext,
+        R.style.Theme_Questionnaire
+      )
+    )
+  private val view = QuestionnaireItemHeaderView(parent.context, null)
+
+  @Test
+  fun shouldShowPrefix() {
+    view.bind(Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" })
+
+    assertThat(view.findViewById<TextView>(R.id.prefix).isVisible).isTrue()
+    assertThat(view.findViewById<TextView>(R.id.prefix).text.toString()).isEqualTo("Prefix?")
+  }
+
+  @Test
+  fun shouldHidePrefix() {
+    view.bind(Questionnaire.QuestionnaireItemComponent().apply { prefix = "" })
+
+    assertThat(view.findViewById<TextView>(R.id.prefix).isVisible).isFalse()
+  }
+
+  @Test
+  fun shouldShowQuestion() {
+    view.bind(
+      Questionnaire.QuestionnaireItemComponent().apply {
+        repeats = true
+        text = "Question?"
+      }
+    )
+
+    assertThat(view.findViewById<TextView>(R.id.question).text.toString()).isEqualTo("Question?")
+  }
+
+  @Test
+  fun shouldShowHint() {
+    view.bind(
+      Questionnaire.QuestionnaireItemComponent().apply {
+        item =
+          listOf(
+            Questionnaire.QuestionnaireItemComponent().apply {
+              linkId = "nested-display-question"
+              text = "subtitle text"
+              type = Questionnaire.QuestionnaireItemType.DISPLAY
+            }
+          )
+      }
+    )
+
+    assertThat(view.findViewById<TextView>(R.id.hint).isVisible).isTrue()
+    assertThat(view.findViewById<TextView>(R.id.hint).text.toString()).isEqualTo("subtitle text")
+  }
+
+  @Test
+  fun shouldHideHint() {
+    view.bind(Questionnaire.QuestionnaireItemComponent())
+
+    assertThat(view.findViewById<TextView>(R.id.hint).visibility).isEqualTo(View.GONE)
+  }
+}

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemMultiSelectHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemMultiSelectHolderFactoryInstrumentedTest.kt
@@ -18,7 +18,6 @@ package com.google.android.fhir.datacapture.views
 
 import android.widget.FrameLayout
 import android.widget.TextView
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -36,40 +35,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class QuestionnaireItemMultiSelectHolderFactoryInstrumentedTest {
   @get:Rule val rule = activityScenarioRule<TestActivity>()
-
-  @Test
-  fun shouldShowPrefixText() = withViewHolder { holder ->
-    holder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          repeats = true
-          prefix = "Prefix?"
-          linkId = "1"
-        },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(holder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(holder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() = withViewHolder { holder ->
-    holder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          repeats = true
-          prefix = ""
-          linkId = "1"
-        },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(holder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isFalse()
-  }
 
   @Test
   fun emptyResponseOptions_showNoneSelected() = withViewHolder { holder ->

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest.kt
@@ -23,7 +23,6 @@ import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.children
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -50,34 +49,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest {
   private val viewHolder = QuestionnaireItemRadioGroupViewHolderFactory.create(parent)
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun bind_shouldSetHeaderText() {
+  fun bind_shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -85,7 +57,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 
@@ -348,7 +320,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_view).text)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text)
       .isEqualTo("Missing answer for required field.")
   }
 
@@ -375,8 +347,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_view).text.isEmpty())
-      .isTrue()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.isEmpty()).isTrue()
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.view.isVisible
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -51,34 +50,7 @@ class QuestionnaireItemSliderViewHolderFactoryInstrumentedTest {
   }
 
   @Test
-  fun shouldShowPrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "Prefix?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible).isTrue()
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).text.toString())
-      .isEqualTo("Prefix?")
-  }
-
-  @Test
-  fun shouldHidePrefixText() {
-    viewHolder.bind(
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { prefix = "" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent()
-      ) {}
-    )
-
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.prefix_text_view).isVisible)
-      .isFalse()
-  }
-
-  @Test
-  fun shouldSetHeaderTextViewText() {
+  fun shouldSetQuestionHeader() {
     viewHolder.bind(
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -86,7 +58,7 @@ class QuestionnaireItemSliderViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).text.toString())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question).text.toString())
       .isEqualTo("Question?")
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryInstrumentedTest.kt
@@ -144,7 +144,7 @@ class QuestionnaireItemSliderViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).error).isNull()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.toString()).isEqualTo("")
   }
 
   @Test
@@ -172,7 +172,7 @@ class QuestionnaireItemSliderViewHolderFactoryInstrumentedTest {
       ) {}
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.question_text_view).error)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.toString())
       .isEqualTo("Minimum value allowed is:50")
   }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponents.kt
@@ -42,17 +42,19 @@ internal enum class ItemControlTypes(
 
 // Please note these URLs do not point to any FHIR Resource and are broken links. They are being
 // used until we can engage the FHIR community to add these extensions officially.
-internal const val EXTENSION_ITEM_CONTROL_URL_UNOFFICIAL =
+internal const val EXTENSION_ITEM_CONTROL_URL_ANDROID_FHIR =
   "https://github.com/google/android-fhir/StructureDefinition/questionnaire-itemControl"
-internal const val EXTENSION_ITEM_CONTROL_SYSTEM_UNOFFICIAL =
+internal const val EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR =
   "https://github.com/google/android-fhir/questionnaire-item-control"
 
 // Below URLs exist and are supported by HL7
 internal const val EXTENSION_ITEM_CONTROL_URL =
   "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
 internal const val EXTENSION_ITEM_CONTROL_SYSTEM = "http://hl7.org/fhir/questionnaire-item-control"
+
 internal const val EXTENSION_HIDDEN_URL =
   "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
+
 internal const val EXTENSION_ENTRY_FORMAT_URL =
   "http://hl7.org/fhir/StructureDefinition/entryFormat"
 
@@ -62,7 +64,7 @@ internal val Questionnaire.QuestionnaireItemComponent.itemControl: ItemControlTy
     val codeableConcept =
       this.extension
         .firstOrNull {
-          it.url == EXTENSION_ITEM_CONTROL_URL || it.url == EXTENSION_ITEM_CONTROL_URL_UNOFFICIAL
+          it.url == EXTENSION_ITEM_CONTROL_URL || it.url == EXTENSION_ITEM_CONTROL_URL_ANDROID_FHIR
         }
         ?.value as
         CodeableConcept?
@@ -70,7 +72,7 @@ internal val Questionnaire.QuestionnaireItemComponent.itemControl: ItemControlTy
       codeableConcept?.coding
         ?.firstOrNull {
           it.system == EXTENSION_ITEM_CONTROL_SYSTEM ||
-            it.system == EXTENSION_ITEM_CONTROL_SYSTEM_UNOFFICIAL
+            it.system == EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR
         }
         ?.code
     return ItemControlTypes.values().firstOrNull { it.extensionCode == code }
@@ -136,6 +138,32 @@ internal val Questionnaire.QuestionnaireItemComponent.localizedPrefixSpanned: Sp
   get() = prefixElement?.getLocalizedText()?.toSpanned()
 
 /**
+ * A nested questionnaire item of type display (if present) is used as the hint of the parent
+ * question.
+ */
+internal val Questionnaire.QuestionnaireItemComponent.localizedHintSpanned: Spanned?
+  get() =
+    item
+      .firstOrNull { questionnaireItem ->
+        questionnaireItem.type == Questionnaire.QuestionnaireItemType.DISPLAY &&
+          questionnaireItem.displayItemControl == null
+      }
+      ?.localizedTextSpanned
+
+/**
+ * A nested questionnaire item of type display with code [DisplayItemControlType.FLYOVER] (if
+ * present) is used as the fly-over text of the parent question.
+ */
+internal val Questionnaire.QuestionnaireItemComponent.localizedFlyoverSpanned: Spanned?
+  get() =
+    item
+      .firstOrNull { questionnaireItem ->
+        questionnaireItem.type == Questionnaire.QuestionnaireItemType.DISPLAY &&
+          questionnaireItem.displayItemControl == DisplayItemControlType.FLYOVER
+      }
+      ?.localizedTextSpanned
+
+/**
  * Whether the QuestionnaireItem should be hidden according to the hidden extension or lack thereof.
  */
 internal val Questionnaire.QuestionnaireItemComponent.isHidden: Boolean
@@ -182,32 +210,6 @@ fun Questionnaire.QuestionnaireItemComponent.createQuestionnaireResponseItem():
     }
   }
 }
-
-/**
- * A nested questionnaire item of type display (if present) is used as the subtitle of the parent
- * question.
- */
-internal val Questionnaire.QuestionnaireItemComponent.subtitleText: Spanned?
-  get() =
-    item
-      .firstOrNull { questionnaireItem ->
-        questionnaireItem.type == Questionnaire.QuestionnaireItemType.DISPLAY &&
-          questionnaireItem.displayItemControl == null
-      }
-      ?.localizedTextSpanned
-
-/**
- * A nested questionnaire item of type display with code [DisplayItemControlType.FLYOVER] (if
- * present) is used as the fly-over text of the parent question.
- */
-internal val Questionnaire.QuestionnaireItemComponent.flyOverText: Spanned?
-  get() =
-    item
-      .firstOrNull { questionnaireItem ->
-        questionnaireItem.type == Questionnaire.QuestionnaireItemType.DISPLAY &&
-          questionnaireItem.displayItemControl == DisplayItemControlType.FLYOVER
-      }
-      ?.localizedTextSpanned
 
 /**
  * Returns a list of answers from the initial values of the questionnaire item. `null` if no intial

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactory.kt
@@ -25,15 +25,12 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import android.widget.TextView
 import androidx.appcompat.widget.AppCompatAutoCompleteTextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import androidx.core.view.get
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.displayString
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import com.google.android.flexbox.FlexboxLayout
@@ -48,8 +45,7 @@ internal object QuestionnaireItemAutoCompleteViewHolderFactory :
 
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var questionTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var textInputLayout: TextInputLayout
       private lateinit var autoCompleteTextView: AppCompatAutoCompleteTextView
 
@@ -67,8 +63,7 @@ internal object QuestionnaireItemAutoCompleteViewHolderFactory :
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        questionTextView = itemView.findViewById(R.id.question_text_view)
+        header = itemView.findViewById(R.id.header)
         autoCompleteTextView = itemView.findViewById(R.id.autoCompleteTextView)
         chipContainer = itemView.findViewById(R.id.flexboxLayout)
         textInputLayout = itemView.findViewById(R.id.text_input_layout)
@@ -137,13 +132,7 @@ internal object QuestionnaireItemAutoCompleteViewHolderFactory :
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
-        questionTextView.text = questionnaireItemViewItem.questionnaireItem.localizedTextSpanned
+        header.bind(questionnaireItemViewItem.questionnaireItem)
 
         val answerOptionString = questionnaireItemViewItem.answerOption.map { it.displayString }
         val adapter =

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
@@ -21,9 +21,6 @@ import android.widget.RadioButton
 import android.widget.RadioGroup
 import android.widget.TextView
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
-import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import org.hl7.fhir.r4.model.BooleanType
@@ -33,38 +30,27 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_boolean_type_picker_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var questionTextView: TextView
-      private lateinit var questionSubTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var radioGroup: RadioGroup
       private lateinit var yesRadioButton: RadioButton
       private lateinit var noRadioButton: RadioButton
-      private lateinit var errorTextView: TextView
+      private lateinit var error: TextView
 
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        questionTextView = itemView.findViewById(R.id.question_text_view)
-        questionSubTextView = itemView.findViewById(R.id.subtitle_text_view)
+        header = itemView.findViewById(R.id.header)
         radioGroup = itemView.findViewById(R.id.radio_group)
         yesRadioButton = itemView.findViewById(R.id.yes_radio_button)
         noRadioButton = itemView.findViewById(R.id.no_radio_button)
-        errorTextView = itemView.findViewById(R.id.error_text_view)
+        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
         val (questionnaireItem, questionnaireResponseItem) = questionnaireItemViewItem
-        questionTextView.text = questionnaireItem.localizedTextSpanned
-        questionSubTextView.text = questionnaireItem.subtitleText
 
-        if (!questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
+        header.bind(questionnaireItem)
 
         when (questionnaireItemViewItem.singleAnswerOrNull?.valueBooleanType?.value) {
           true -> {
@@ -117,7 +103,7 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {
-        errorTextView.text =
+        error.text =
           if (validationResult.getSingleStringValidationMessage() == "") null
           else validationResult.getSingleStringValidationMessage()
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
@@ -26,10 +26,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import com.google.android.fhir.datacapture.ChoiceOrientationTypes
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.choiceOrientation
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
 import com.google.android.fhir.datacapture.optionExclusive
-import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import org.hl7.fhir.r4.model.Questionnaire
@@ -39,35 +36,26 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_checkbox_group_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var questionTextView: TextView
-      private lateinit var questionSubtitleTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var checkboxGroup: ConstraintLayout
       private lateinit var flow: Flow
-      private lateinit var errorTextView: TextView
+      private lateinit var error: TextView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        questionTextView = itemView.findViewById(R.id.question_text_view)
-        questionSubtitleTextView = itemView.findViewById(R.id.subtitle_text_view)
+        header = itemView.findViewById(R.id.header)
         checkboxGroup = itemView.findViewById(R.id.checkbox_group)
         flow = itemView.findViewById(R.id.checkbox_flow)
-        errorTextView = itemView.findViewById(R.id.error_text_view)
+        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
         val (questionnaireItem, _) = questionnaireItemViewItem
         val choiceOrientation =
           questionnaireItem.choiceOrientation ?: ChoiceOrientationTypes.VERTICAL
-        questionTextView.text = questionnaireItem.localizedTextSpanned
-        questionSubtitleTextView.text = questionnaireItem.subtitleText
+
+        header.bind(questionnaireItem)
+
         // Keep the Flow layout which is always the first child
         checkboxGroup.removeViews(1, checkboxGroup.childCount - 1)
         when (choiceOrientation) {
@@ -89,7 +77,7 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {
-        errorTextView.text =
+        error.text =
           if (validationResult.getSingleStringValidationMessage() == "") null
           else validationResult.getSingleStringValidationMessage()
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -19,14 +19,10 @@ package com.google.android.fhir.datacapture.views
 import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.entryFormat
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
-import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.utilities.localizedString
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
@@ -44,18 +40,14 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_date_picker_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var textDateQuestion: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var textInputLayout: TextInputLayout
-      private lateinit var questionSubtitleTextView: TextView
       private lateinit var textInputEditText: TextInputEditText
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        textDateQuestion = itemView.findViewById(R.id.question_text_view)
+        header = itemView.findViewById(R.id.header)
         textInputLayout = itemView.findViewById(R.id.text_input_layout)
-        questionSubtitleTextView = itemView.findViewById(R.id.subtitle_text_view)
         textInputEditText = itemView.findViewById(R.id.text_input_edit_text)
 
         textInputLayout.setEndIconOnClickListener {
@@ -107,28 +99,19 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
             onAnswerChanged(textInputEditText.context)
           }
           datePicker.show(context.supportFragmentManager, TAG)
-
-          // Clear focus so that the user can refocus to open the dialog
-          textDateQuestion.clearFocus()
         }
       }
 
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        questionnaireItemViewItem.questionnaireItem.entryFormat?.let {
-          textInputLayout.helperText = it
-        }
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
-        textDateQuestion.text = questionnaireItemViewItem.questionnaireItem.localizedTextSpanned
-        questionSubtitleTextView.text = questionnaireItemViewItem.questionnaireItem.subtitleText
+        header.bind(questionnaireItemViewItem.questionnaireItem)
+
         textInputEditText.setText(
           questionnaireItemViewItem.singleAnswerOrNull?.valueDateType?.localDate?.localizedString
         )
+        questionnaireItemViewItem.questionnaireItem.entryFormat?.let {
+          textInputLayout.helperText = it
+        }
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -18,13 +18,9 @@ package com.google.android.fhir.datacapture.views
 
 import android.annotation.SuppressLint
 import android.view.View
-import android.widget.TextView
 import androidx.core.os.bundleOf
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.entryFormat
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
-import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import com.google.android.fhir.datacapture.views.DatePickerFragment.Companion.REQUEST_BUNDLE_KEY_DATE
@@ -43,9 +39,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_date_time_picker_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var questionTextView: TextView
-      private lateinit var questionSubtitleTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var dateInputLayout: TextInputLayout
       private lateinit var dateInputEditText: TextInputEditText
       private lateinit var timeInputLayout: TextInputLayout
@@ -55,9 +49,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       private var localTime: LocalTime? = null
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        questionTextView = itemView.findViewById(R.id.question_text_view)
-        questionSubtitleTextView = itemView.findViewById(R.id.subtitle_text_view)
+        header = itemView.findViewById(R.id.header)
         dateInputLayout = itemView.findViewById(R.id.date_input_layout)
         dateInputEditText = itemView.findViewById(R.id.date_input_edit_text)
 
@@ -160,18 +152,10 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
 
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
+        header.bind(questionnaireItemViewItem.questionnaireItem)
         questionnaireItemViewItem.questionnaireItem.entryFormat?.let {
           dateInputLayout.helperText = it
         }
-
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
-        questionTextView.text = questionnaireItemViewItem.questionnaireItem.localizedTextSpanned
-        questionSubtitleTextView.text = questionnaireItemViewItem.questionnaireItem.subtitleText
         val dateTime = questionnaireItemViewItem.singleAnswerOrNull?.valueDateTimeType
         updateDateTimeInput(
           dateTime?.let {
@@ -219,7 +203,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
                 )
               )
             )
-        onAnswerChanged(prefixTextView.context)
+        onAnswerChanged(header.context)
       }
     }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDialogSelectViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDialogSelectViewHolderFactory.kt
@@ -18,8 +18,6 @@ package com.google.android.fhir.datacapture.views
 
 import android.annotation.SuppressLint
 import android.view.View
-import android.view.View.GONE
-import android.view.View.VISIBLE
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.core.os.bundleOf
@@ -30,7 +28,6 @@ import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.common.datatype.asStringValue
 import com.google.android.fhir.datacapture.displayString
 import com.google.android.fhir.datacapture.itemControl
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.localizedTextSpanned
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
@@ -57,7 +54,7 @@ internal object QuestionnaireItemDialogSelectViewHolderFactory :
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         val activity =
-          requireNotNull(holder.question.context.tryUnwrapContext()) {
+          requireNotNull(holder.header.context.tryUnwrapContext()) {
             "Can only use dialog select in an AppCompatActivity context"
           }
         val viewModel: QuestionnaireItemDialogSelectViewModel by activity.viewModels()
@@ -65,10 +62,7 @@ internal object QuestionnaireItemDialogSelectViewHolderFactory :
         val (item, response) = questionnaireItemViewItem
 
         // Bind static data
-        holder.prefix.text = item.localizedPrefixSpanned
-        holder.prefix.visibility =
-          if (item.localizedPrefixSpanned.isNullOrEmpty()) GONE else VISIBLE
-        holder.question.text = item.localizedTextSpanned
+        holder.header.bind(item)
 
         activity.lifecycleScope.launch {
           // Set the initial selected options state from the FHIR data model
@@ -118,8 +112,7 @@ internal object QuestionnaireItemDialogSelectViewHolderFactory :
     }
 
   private class DialogSelectViewHolder(itemView: View) {
-    val prefix: TextView = itemView.findViewById(R.id.prefix_text_view)
-    val question: TextView = itemView.findViewById(R.id.question_text_view)
+    val header: QuestionnaireItemHeaderView = itemView.findViewById(R.id.header)
     val summary: TextView = itemView.findViewById(R.id.multi_select_summary)
     val summaryHolder: TextInputLayout = itemView.findViewById(R.id.multi_select_summary_holder)
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDisplayViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDisplayViewHolderFactory.kt
@@ -17,40 +17,22 @@
 package com.google.android.fhir.datacapture.views
 
 import android.view.View
-import android.widget.TextView
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
 import com.google.android.fhir.datacapture.validation.ValidationResult
 
 internal object QuestionnaireItemDisplayViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_display_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var displayTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        displayTextView = itemView.findViewById(R.id.display_text_view)
+        header = itemView.findViewById(R.id.header)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
-        displayTextView.text = questionnaireItemViewItem.questionnaireItem.localizedTextSpanned
-
-        displayTextView.visibility =
-          if (displayTextView.text.isEmpty()) {
-            View.GONE
-          } else {
-            View.VISIBLE
-          }
+        header.bind(questionnaireItemViewItem.questionnaireItem)
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactory.kt
@@ -21,13 +21,9 @@ import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
-import android.widget.TextView
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.displayString
-import com.google.android.fhir.datacapture.flyOverText
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
-import com.google.android.fhir.datacapture.subtitleText
+import com.google.android.fhir.datacapture.localizedFlyoverSpanned
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import com.google.android.material.textfield.TextInputLayout
@@ -37,33 +33,22 @@ internal object QuestionnaireItemDropDownViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_drop_down_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var questionTextView: TextView
-      private lateinit var questionSubtitleTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var textInputLayout: TextInputLayout
       private lateinit var autoCompleteTextView: AutoCompleteTextView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
       private lateinit var context: Context
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        questionTextView = itemView.findViewById(R.id.question_text_view)
-        questionSubtitleTextView = itemView.findViewById(R.id.subtitle_text_view)
+        header = itemView.findViewById(R.id.header)
         textInputLayout = itemView.findViewById(R.id.text_input_layout)
         autoCompleteTextView = itemView.findViewById(R.id.auto_complete)
         context = itemView.context
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
-        questionTextView.text = questionnaireItemViewItem.questionnaireItem.localizedTextSpanned
-        questionSubtitleTextView.text = questionnaireItemViewItem.questionnaireItem.subtitleText
-        textInputLayout.hint = questionnaireItemViewItem.questionnaireItem.flyOverText
+        header.bind(questionnaireItemViewItem.questionnaireItem)
+        textInputLayout.hint = questionnaireItemViewItem.questionnaireItem.localizedFlyoverSpanned
         val answerOptionString =
           this.questionnaireItemViewItem.answerOption.map { it.displayString }.toMutableList()
         answerOptionString.add(0, "-")

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -22,13 +22,9 @@ import android.view.View
 import android.view.View.FOCUS_DOWN
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
-import android.widget.TextView
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.flyOverText
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
-import com.google.android.fhir.datacapture.subtitleText
+import com.google.android.fhir.datacapture.localizedFlyoverSpanned
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import com.google.android.material.textfield.TextInputEditText
@@ -45,17 +41,13 @@ internal abstract class QuestionnaireItemEditTextViewHolderDelegate(
   private val rawInputType: Int,
   private val isSingleLine: Boolean
 ) : QuestionnaireItemViewHolderDelegate {
-  private lateinit var prefixTextView: TextView
-  private lateinit var questionTextView: TextView
-  private lateinit var questionSubtitleTextView: TextView
+  private lateinit var header: QuestionnaireItemHeaderView
   private lateinit var textInputLayout: TextInputLayout
   private lateinit var textInputEditText: TextInputEditText
   override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
   override fun init(itemView: View) {
-    prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-    questionTextView = itemView.findViewById(R.id.question_text_view)
-    questionSubtitleTextView = itemView.findViewById(R.id.subtitle_text_view)
+    header = itemView.findViewById(R.id.header)
     textInputLayout = itemView.findViewById(R.id.text_input_layout)
     textInputEditText = itemView.findViewById(R.id.text_input_edit_text)
     textInputEditText.setRawInputType(rawInputType)
@@ -67,15 +59,8 @@ internal abstract class QuestionnaireItemEditTextViewHolderDelegate(
   }
 
   override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-    if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-      prefixTextView.visibility = View.VISIBLE
-      prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-    } else {
-      prefixTextView.visibility = View.GONE
-    }
-    questionSubtitleTextView.text = questionnaireItemViewItem.questionnaireItem.subtitleText
-    textInputLayout.hint = questionnaireItemViewItem.questionnaireItem.flyOverText
-    questionTextView.text = questionnaireItemViewItem.questionnaireItem.localizedTextSpanned
+    header.bind(questionnaireItemViewItem.questionnaireItem)
+    textInputLayout.hint = questionnaireItemViewItem.questionnaireItem.localizedFlyoverSpanned
     textInputEditText.setText(getText(questionnaireItemViewItem.singleAnswerOrNull))
     textInputEditText.setOnFocusChangeListener { view, focused ->
       if (!focused) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemGroupViewHolderFactory.kt
@@ -19,8 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.view.View
 import android.widget.TextView
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 
@@ -28,33 +26,21 @@ internal object QuestionnaireItemGroupViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_group_header_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var groupHeader: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
+      private lateinit var error: TextView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        groupHeader = itemView.findViewById(R.id.group_header)
+        header = itemView.findViewById(R.id.header)
+        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
-        groupHeader.text = questionnaireItemViewItem.questionnaireItem.localizedTextSpanned
-        groupHeader.visibility =
-          if (groupHeader.text.isEmpty()) {
-            View.GONE
-          } else {
-            View.VISIBLE
-          }
+        header.bind(questionnaireItemViewItem.questionnaireItem)
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {
-        groupHeader.error =
+        error.text =
           if (validationResult.getSingleStringValidationMessage() == "") null
           else validationResult.getSingleStringValidationMessage()
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderView.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderView.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.google.android.fhir.datacapture.R
+import com.google.android.fhir.datacapture.localizedHintSpanned
+import com.google.android.fhir.datacapture.localizedPrefixSpanned
+import com.google.android.fhir.datacapture.localizedTextSpanned
+import org.hl7.fhir.r4.model.Questionnaire
+
+/** View for the prefix, question, and hint of a questionnaire item. */
+internal class QuestionnaireItemHeaderView(context: Context, attrs: AttributeSet?) :
+  LinearLayout(context, attrs) {
+
+  init {
+    LayoutInflater.from(context).inflate(R.layout.questionnaire_item_header, this, true)
+  }
+
+  private var prefix: TextView = findViewById(R.id.prefix)
+  private var question: TextView = findViewById(R.id.question)
+  private var hint: TextView = findViewById(R.id.hint)
+
+  fun bind(questionnaireItem: Questionnaire.QuestionnaireItemComponent) {
+    questionnaireItem.localizedPrefixSpanned.also {
+      if (!it.isNullOrEmpty()) {
+        prefix.visibility = View.VISIBLE
+        prefix.text = it
+      } else {
+        prefix.visibility = View.GONE
+      }
+    }
+    question.text = questionnaireItem.localizedTextSpanned
+    questionnaireItem.localizedHintSpanned.also {
+      if (!it.isNullOrEmpty()) {
+        hint.visibility = View.VISIBLE
+        hint.text = it
+      } else {
+        hint.visibility = View.GONE
+      }
+    }
+  }
+}

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderView.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderView.kt
@@ -41,7 +41,7 @@ internal class QuestionnaireItemHeaderView(context: Context, attrs: AttributeSet
   private var hint: TextView = findViewById(R.id.hint)
 
   fun bind(questionnaireItem: Questionnaire.QuestionnaireItemComponent) {
-    questionnaireItem.localizedPrefixSpanned.also {
+    questionnaireItem.localizedPrefixSpanned.let {
       if (!it.isNullOrEmpty()) {
         prefix.visibility = View.VISIBLE
         prefix.text = it
@@ -50,7 +50,7 @@ internal class QuestionnaireItemHeaderView(context: Context, attrs: AttributeSet
       }
     }
     question.text = questionnaireItem.localizedTextSpanned
-    questionnaireItem.localizedHintSpanned.also {
+    questionnaireItem.localizedHintSpanned.let {
       if (!it.isNullOrEmpty()) {
         hint.visibility = View.VISIBLE
         hint.text = it

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
@@ -28,9 +28,6 @@ import com.google.android.fhir.datacapture.ChoiceOrientationTypes
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.choiceOrientation
 import com.google.android.fhir.datacapture.displayString
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
-import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import org.hl7.fhir.r4.model.Questionnaire
@@ -40,33 +37,22 @@ internal object QuestionnaireItemRadioGroupViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_radio_group_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var questionTextView: TextView
-      private lateinit var questionSubtitleTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var radioGroup: ConstraintLayout
       private lateinit var flow: Flow
-      private lateinit var errorTextView: TextView
+      private lateinit var error: TextView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        questionTextView = itemView.findViewById(R.id.question_text_view)
-        questionSubtitleTextView = itemView.findViewById(R.id.subtitle_text_view)
+        header = itemView.findViewById(R.id.header)
         radioGroup = itemView.findViewById(R.id.radio_group)
         flow = itemView.findViewById(R.id.flow)
-        errorTextView = itemView.findViewById(R.id.error_text_view)
+        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
         val questionnaireItem = questionnaireItemViewItem.questionnaireItem
-        questionTextView.text = questionnaireItem.localizedTextSpanned
-        questionSubtitleTextView.text = questionnaireItem.subtitleText
+        header.bind(questionnaireItem)
         // Keep the Flow layout which is the first child
         radioGroup.removeViews(1, radioGroup.childCount - 1)
         val choiceOrientation =
@@ -90,7 +76,7 @@ internal object QuestionnaireItemRadioGroupViewHolderFactory :
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {
-        errorTextView.text =
+        error.text =
           if (validationResult.getSingleStringValidationMessage() == "") null
           else validationResult.getSingleStringValidationMessage()
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactory.kt
@@ -19,9 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.view.View
 import android.widget.TextView
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.localizedPrefixSpanned
-import com.google.android.fhir.datacapture.localizedTextSpanned
-import com.google.android.fhir.datacapture.subtitleText
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.validation.getSingleStringValidationMessage
 import com.google.android.material.slider.Slider
@@ -32,31 +29,21 @@ internal object QuestionnaireItemSliderViewHolderFactory :
   QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_slider) {
   override fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate =
     object : QuestionnaireItemViewHolderDelegate {
-      private lateinit var prefixTextView: TextView
-      private lateinit var sliderHeader: TextView
-      private lateinit var questionSubtitleTextView: TextView
+      private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var slider: Slider
+      private lateinit var error: TextView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
-        prefixTextView = itemView.findViewById(R.id.prefix_text_view)
-        sliderHeader = itemView.findViewById(R.id.question_text_view)
-        questionSubtitleTextView = itemView.findViewById(R.id.subtitle_text_view)
+        header = itemView.findViewById(R.id.header)
         slider = itemView.findViewById(R.id.slider)
+        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         this.questionnaireItemViewItem = questionnaireItemViewItem
-        if (!questionnaireItemViewItem.questionnaireItem.prefix.isNullOrEmpty()) {
-          prefixTextView.visibility = View.VISIBLE
-          prefixTextView.text = questionnaireItemViewItem.questionnaireItem.localizedPrefixSpanned
-        } else {
-          prefixTextView.visibility = View.GONE
-        }
-        val questionnaireItem = questionnaireItemViewItem.questionnaireItem
+        header.bind(questionnaireItemViewItem.questionnaireItem)
         val answer = questionnaireItemViewItem.singleAnswerOrNull
-        sliderHeader.text = questionnaireItem.localizedTextSpanned
-        questionSubtitleTextView.text = questionnaireItem.subtitleText
         slider.valueFrom = 0.0F
         slider.valueTo = 100.0F
         slider.stepSize = 10.0F
@@ -73,7 +60,7 @@ internal object QuestionnaireItemSliderViewHolderFactory :
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {
-        sliderHeader.error =
+        error.text =
           if (validationResult.getSingleStringValidationMessage() == "") null
           else validationResult.getSingleStringValidationMessage()
       }

--- a/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
@@ -22,33 +22,9 @@
     android:layout_marginVertical="@dimen/item_margin_vertical"
     android:orientation="vertical"
 >
-
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-    <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-    <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-        />
-    </LinearLayout>
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 
@@ -75,9 +51,6 @@
         />
     </RadioGroup>
 
-    <include
-        android:id="@+id/error_text_view"
-        layout="@layout/input_error_text_view"
-    />
+    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
 
 </LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
@@ -22,6 +22,7 @@
     android:layout_marginVertical="@dimen/item_margin_vertical"
     android:orientation="vertical"
 >
+
     <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
         android:id="@+id/header"
         android:layout_width="match_parent"

--- a/datacapture/src/main/res/layout/questionnaire_item_checkbox_group_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_checkbox_group_view.xml
@@ -23,34 +23,9 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
-
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 
@@ -75,9 +50,6 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <include
-        android:id="@+id/error_text_view"
-        layout="@layout/input_error_text_view"
-    />
+    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
 
 </LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
@@ -23,34 +23,9 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
-
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 

--- a/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
@@ -24,34 +24,9 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
-
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 

--- a/datacapture/src/main/res/layout/questionnaire_item_display_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_display_view.xml
@@ -23,19 +23,10 @@
     android:orientation="horizontal"
 >
 
-    <TextView
-        style="?attr/headerTextAppearanceQuestionnaire"
-        android:id="@+id/prefix_text_view"
-        android:layout_width="wrap_content"
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingEnd="@dimen/prefix_padding_end"
-        android:visibility="gone"
     />
 
-    <TextView
-        style="?attr/headerTextAppearanceQuestionnaire"
-        android:id="@+id/display_text_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-    />
 </LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_drop_down_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_drop_down_view.xml
@@ -20,34 +20,9 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
-
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 

--- a/datacapture/src/main/res/layout/questionnaire_item_edit_text_auto_complete_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_edit_text_auto_complete_view.xml
@@ -24,30 +24,12 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:id="@+id/linearLayout2"
-    >
+    />
 
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
     <com.google.android.material.textfield.TextInputLayout
         style="?attr/questionnaireTextInputLayoutStyle"
         android:id="@+id/text_input_layout"

--- a/datacapture/src/main/res/layout/questionnaire_item_edit_text_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_edit_text_view.xml
@@ -23,34 +23,9 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
-
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 

--- a/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_group_header_view.xml
@@ -23,19 +23,12 @@
     android:orientation="horizontal"
 >
 
-    <TextView
-        style="?attr/groupHeaderTextAppearanceQuestionnaire"
-        android:id="@+id/prefix_text_view"
-        android:layout_width="wrap_content"
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/prefix_padding_end"
-        android:visibility="gone"
     />
 
-    <TextView
-        style="?attr/groupHeaderTextAppearanceQuestionnaire"
-        android:id="@+id/group_header"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-    />
+    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
+
 </LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_header.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_header.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/item_margin_horizontal"
+    android:layout_marginVertical="@dimen/item_margin_vertical"
+    android:orientation="vertical"
+>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+    >
+
+        <TextView
+            android:id="@+id/prefix"
+            style="?attr/headerTextAppearanceQuestionnaire"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/prefix_padding_end"
+        />
+
+        <TextView
+            android:id="@+id/question"
+            style="?attr/headerTextAppearanceQuestionnaire"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+        />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/hint"
+        style="?attr/subtitleTextAppearanceQuestionnaire"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+    />
+
+</LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_header.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_header.xml
@@ -1,41 +1,39 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<LinearLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginHorizontal="@dimen/item_margin_horizontal"
-    android:layout_marginVertical="@dimen/item_margin_vertical"
-    android:orientation="vertical"
 >
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/prefix"
+        style="?attr/headerTextAppearanceQuestionnaire"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
+        android:paddingEnd="@dimen/prefix_padding_end"
+        app:layout_constraintEnd_toStartOf="@+id/question"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+    />
 
-        <TextView
-            android:id="@+id/prefix"
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-        />
-
-        <TextView
-            android:id="@+id/question"
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
+    <TextView
+        android:id="@+id/question"
+        style="?attr/headerTextAppearanceQuestionnaire"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/prefix"
+        app:layout_constraintTop_toTopOf="parent"
+    />
 
     <TextView
         android:id="@+id/hint"
         style="?attr/subtitleTextAppearanceQuestionnaire"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/question"
     />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_option_select_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_option_select_view.xml
@@ -24,31 +24,11 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            tools:text="Prefix"
-            tools:visibility="visible"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
+    />
 
     <com.google.android.material.textfield.TextInputLayout
         style="?attr/questionnaireExposedMenuLayoutStyle"

--- a/datacapture/src/main/res/layout/questionnaire_item_radio_group_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_radio_group_view.xml
@@ -24,34 +24,9 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
-
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 
@@ -75,9 +50,6 @@
 
 </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <include
-        android:id="@+id/error_text_view"
-        layout="@layout/input_error_text_view"
-    />
+    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
 
 </LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_slider.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_slider.xml
@@ -23,34 +23,9 @@
     android:orientation="vertical"
 >
 
-    <LinearLayout
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-    >
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/prefix_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/prefix_padding_end"
-            android:visibility="gone"
-        />
-
-        <TextView
-            style="?attr/headerTextAppearanceQuestionnaire"
-            android:id="@+id/question_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-        />
-
-    </LinearLayout>
-
-    <TextView
-        style="?attr/subtitleTextAppearanceQuestionnaire"
-        android:id="@+id/subtitle_text_view"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
     />
 
@@ -59,4 +34,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
     />
+
+    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
+
 </LinearLayout>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireItemComponentsTest.kt
@@ -85,13 +85,13 @@ class MoreQuestionnaireItemComponentsTest {
       Questionnaire.QuestionnaireItemComponent().setType(Questionnaire.QuestionnaireItemType.STRING)
     questionnaireItem.addExtension(
       Extension()
-        .setUrl(EXTENSION_ITEM_CONTROL_URL_UNOFFICIAL)
+        .setUrl(EXTENSION_ITEM_CONTROL_URL_ANDROID_FHIR)
         .setValue(
           CodeableConcept()
             .addCoding(
               Coding()
                 .setCode(ItemControlTypes.PHONE_NUMBER.extensionCode)
-                .setSystem(EXTENSION_ITEM_CONTROL_SYSTEM_UNOFFICIAL)
+                .setSystem(EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR)
             )
         )
     )
@@ -181,7 +181,12 @@ class MoreQuestionnaireItemComponentsTest {
   }
 
   @Test
-  fun localizedTextSpanned_default() {
+  fun localizedTextSpanned_noText_shouldReturnNull() {
+    assertThat(Questionnaire.QuestionnaireItemComponent().localizedTextSpanned).isNull()
+  }
+
+  @Test
+  fun localizedTextSpanned_shouldReturnText() {
     val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().apply {
         text = "Patient Information in <strong>strong</strong>"
@@ -192,16 +197,7 @@ class MoreQuestionnaireItemComponentsTest {
   }
 
   @Test
-  fun localizedPrefixSpanned_default() {
-    val questionnaireItem =
-      Questionnaire.QuestionnaireItemComponent().apply { prefix = "One in <strong>strong</strong>" }
-    Locale.setDefault(Locale.US)
-
-    assertThat(questionnaireItem.localizedPrefixSpanned.toString()).isEqualTo("One in strong")
-  }
-
-  @Test
-  fun localizedTextSpanned_vietnameseTranslation_usLocale_shouldReturnDefault() {
+  fun localizedTextSpanned_nonMatchingLocale_shouldReturnText() {
     val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().apply {
         text = "Patient Information"
@@ -220,7 +216,61 @@ class MoreQuestionnaireItemComponentsTest {
   }
 
   @Test
-  fun localizedPrefixSpanned_vietnameseTranslation_usLocale_shouldReturnDefault() {
+  fun localizedTextSpanned_matchingLocale_shouldReturnLocalizedText() {
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        text = "Patient Information"
+        textElement.apply {
+          addExtension(
+            Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+              addExtension(Extension("lang", StringType("vi-VN")))
+              addExtension(Extension("content", StringType("Thông tin bệnh nhân")))
+            }
+          )
+        }
+      }
+    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
+
+    assertThat(questionnaireItem.localizedTextSpanned.toString()).isEqualTo("Thông tin bệnh nhân")
+  }
+
+  @Test
+  fun localizedTextSpanned_matchingLocaleWithoutCountryCode_shouldReturnLocalizedText() {
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        text = "Patient Information"
+        textElement.apply {
+          addExtension(
+            Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+              addExtension(Extension("lang", StringType("vi")))
+              addExtension(Extension("content", StringType("Thông tin bệnh nhân")))
+            }
+          )
+        }
+      }
+    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
+
+    assertThat(questionnaireItem.localizedTextSpanned.toString()).isEqualTo("Thông tin bệnh nhân")
+  }
+
+  @Test
+  fun localizedPrefixSpanned_noPrefix_shouldReturnNull() {
+    val questionnaireItem = Questionnaire.QuestionnaireItemComponent()
+
+    assertThat(questionnaireItem.localizedPrefixSpanned).isNull()
+  }
+
+  @Test
+  fun localizedPrefixSpanned_shouldReturnPrefix() {
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().apply { prefix = "One in <strong>strong</strong>" }
+    Locale.setDefault(Locale.US)
+
+    assertThat(questionnaireItem.localizedPrefixSpanned.toString()).isEqualTo("One in strong")
+  }
+
+  @Test
+  fun localizedPrefixSpanned_nonMatchingLocale_shouldReturnText() {
     val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().apply {
         prefix = "One"
@@ -239,26 +289,7 @@ class MoreQuestionnaireItemComponentsTest {
   }
 
   @Test
-  fun localizedTextSpanned_vietnameseTranslation_vietnameseLocale_shouldReturnVietnamese() {
-    val questionnaireItem =
-      Questionnaire.QuestionnaireItemComponent().apply {
-        text = "Patient Information"
-        textElement.apply {
-          addExtension(
-            Extension(ToolingExtensions.EXT_TRANSLATION).apply {
-              addExtension(Extension("lang", StringType("vi-VN")))
-              addExtension(Extension("content", StringType("Thông tin bệnh nhân")))
-            }
-          )
-        }
-      }
-    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
-
-    assertThat(questionnaireItem.localizedTextSpanned.toString()).isEqualTo("Thông tin bệnh nhân")
-  }
-
-  @Test
-  fun localizedPrefixSpanned_vietnameseTranslation_vietnameseLocale_shouldReturnVietnamese() {
+  fun localizedPrefixSpanned_matchingLocale_shouldReturnLocalizedText() {
     val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().apply {
         prefix = "One"
@@ -277,26 +308,7 @@ class MoreQuestionnaireItemComponentsTest {
   }
 
   @Test
-  fun localizedTextSpanned_vietnameseTranslationWithoutCountryCode_vietnameseLocale_shouldReturnVietnamese() {
-    val questionnaireItem =
-      Questionnaire.QuestionnaireItemComponent().apply {
-        text = "Patient Information"
-        textElement.apply {
-          addExtension(
-            Extension(ToolingExtensions.EXT_TRANSLATION).apply {
-              addExtension(Extension("lang", StringType("vi")))
-              addExtension(Extension("content", StringType("Thông tin bệnh nhân")))
-            }
-          )
-        }
-      }
-    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
-
-    assertThat(questionnaireItem.localizedTextSpanned.toString()).isEqualTo("Thông tin bệnh nhân")
-  }
-
-  @Test
-  fun localizedPrefixSpanned_vietnameseTranslationWithoutCountryCode_vietnameseLocale_shouldReturnVietnamese() {
+  fun localizedPrefixSpanned_matchingLocaleWithoutCountryCode_shouldReturnLocalizedText() {
     val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().apply {
         prefix = "One"
@@ -312,6 +324,303 @@ class MoreQuestionnaireItemComponentsTest {
     Locale.setDefault(Locale.forLanguageTag("vi-VN"))
 
     assertThat(questionnaireItem.localizedPrefixSpanned.toString()).isEqualTo("Một")
+  }
+
+  @Test
+  fun localizedHintSpanned_noNestedDisplayItem_shouldReturnNull() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+        }
+      )
+
+    assertThat(questionItemList.first().localizedHintSpanned).isNull()
+  }
+
+  @Test
+  fun localizedHintSpanned_shouldReturnText() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "subtitle text"
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+              }
+            )
+        }
+      )
+    Locale.setDefault(Locale.US)
+
+    assertThat(questionItemList.first().localizedHintSpanned.toString()).isEqualTo("subtitle text")
+  }
+
+  @Test
+  fun localizedHintSpanned_nonMatchingLocale_shouldReturnText() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "subtitle text"
+                textElement.apply {
+                  addExtension(
+                    Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+                      addExtension(Extension("lang", StringType("vi-VN")))
+                      addExtension(Extension("content", StringType("phụ đề")))
+                    }
+                  )
+                }
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+              }
+            )
+        }
+      )
+    Locale.setDefault(Locale.US)
+
+    assertThat(questionItemList.first().localizedHintSpanned.toString()).isEqualTo("subtitle text")
+  }
+
+  @Test
+  fun localizedHintSpanned_matchingLocale_shouldReturnLocalizedText() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "subtitle text"
+                textElement.apply {
+                  addExtension(
+                    Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+                      addExtension(Extension("lang", StringType("vi-VN")))
+                      addExtension(Extension("content", StringType("phụ đề")))
+                    }
+                  )
+                }
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+              }
+            )
+        }
+      )
+    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
+
+    assertThat(questionItemList.first().localizedHintSpanned.toString()).isEqualTo("phụ đề")
+  }
+
+  @Test
+  fun localizedHintSpanned_matchingLocaleWithoutCountryCode_shouldReturnLocalizedText() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "subtitle text"
+                textElement.apply {
+                  addExtension(
+                    Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+                      addExtension(Extension("lang", StringType("vi")))
+                      addExtension(Extension("content", StringType("phụ đề")))
+                    }
+                  )
+                }
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+              }
+            )
+        }
+      )
+    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
+
+    assertThat(questionItemList.first().localizedHintSpanned.toString()).isEqualTo("phụ đề")
+  }
+
+  @Test
+  fun localizedFlyoverSpanned_noFlyover_shouldReturnNull() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+        }
+      )
+
+    assertThat(questionItemList.first().localizedFlyoverSpanned).isNull()
+  }
+
+  @Test
+  fun localizedFlyoverSpanned_shouldReturnFlyover() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "flyover text"
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+                addExtension(
+                  EXTENSION_ITEM_CONTROL_URL,
+                  CodeableConcept().apply {
+                    addCoding().apply {
+                      system = EXTENSION_ITEM_CONTROL_SYSTEM
+                      code = "flyover"
+                    }
+                  }
+                )
+              }
+            )
+        }
+      )
+
+    assertThat(questionItemList.first().localizedFlyoverSpanned.toString())
+      .isEqualTo("flyover text")
+  }
+
+  @Test
+  fun localizedFlyoverSpanned_nonMatchingLocale_shouldReturnFlyover() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "flyover text"
+                textElement.apply {
+                  addExtension(
+                    Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+                      addExtension(Extension("lang", StringType("vi-VN")))
+                      addExtension(Extension("content", StringType("gợi ý")))
+                    }
+                  )
+                }
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+                addExtension(
+                  EXTENSION_ITEM_CONTROL_URL,
+                  CodeableConcept().apply {
+                    addCoding().apply {
+                      system = EXTENSION_ITEM_CONTROL_SYSTEM
+                      code = "flyover"
+                    }
+                  }
+                )
+              }
+            )
+        }
+      )
+    Locale.setDefault(Locale.US)
+
+    assertThat(questionItemList.first().localizedFlyoverSpanned.toString())
+      .isEqualTo("flyover text")
+  }
+
+  @Test
+  fun localizedFlyoverSpanned_matchingLocale_shouldReturnFlyover() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "flyover text"
+                textElement.apply {
+                  addExtension(
+                    Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+                      addExtension(Extension("lang", StringType("vi-VN")))
+                      addExtension(Extension("content", StringType("gợi ý")))
+                    }
+                  )
+                }
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+                addExtension(
+                  EXTENSION_ITEM_CONTROL_URL,
+                  CodeableConcept().apply {
+                    addCoding().apply {
+                      system = EXTENSION_ITEM_CONTROL_SYSTEM
+                      code = "flyover"
+                    }
+                  }
+                )
+              }
+            )
+        }
+      )
+    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
+
+    assertThat(questionItemList.first().localizedFlyoverSpanned.toString()).isEqualTo("gợi ý")
+  }
+
+  @Test
+  fun localizedFlyoverSpanned_matchingLocaleWithoutCountryCode_shouldReturnFlyover() {
+    val questionItemList =
+      listOf(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          linkId = "parent-question"
+          text = "parent question text"
+          type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          item =
+            listOf(
+              Questionnaire.QuestionnaireItemComponent().apply {
+                linkId = "nested-display-question"
+                text = "flyover text"
+                textElement.apply {
+                  addExtension(
+                    Extension(ToolingExtensions.EXT_TRANSLATION).apply {
+                      addExtension(Extension("lang", StringType("vi")))
+                      addExtension(Extension("content", StringType("gợi ý")))
+                    }
+                  )
+                }
+                type = Questionnaire.QuestionnaireItemType.DISPLAY
+                addExtension(
+                  EXTENSION_ITEM_CONTROL_URL,
+                  CodeableConcept().apply {
+                    addCoding().apply {
+                      system = EXTENSION_ITEM_CONTROL_SYSTEM
+                      code = "flyover"
+                    }
+                  }
+                )
+              }
+            )
+        }
+      )
+    Locale.setDefault(Locale.forLanguageTag("vi-VN"))
+
+    assertThat(questionItemList.first().localizedFlyoverSpanned.toString()).isEqualTo("gợi ý")
   }
 
   @Test
@@ -426,59 +735,6 @@ class MoreQuestionnaireItemComponentsTest {
         (questionResponse.item[0].answer[0].item[0].answer[0].value as BooleanType).booleanValue()
       )
       .isEqualTo(true)
-  }
-
-  @Test
-  fun subtitleText_nestedDisplayItemPresent_returnsNestedDisplayText() {
-    val questionItemList =
-      listOf(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          linkId = "parent-question"
-          text = "parent question text"
-          type = Questionnaire.QuestionnaireItemType.BOOLEAN
-          item =
-            listOf(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "nested-display-question"
-                text = "subtitle text"
-                type = Questionnaire.QuestionnaireItemType.DISPLAY
-              }
-            )
-        }
-      )
-
-    assertThat(questionItemList.first().subtitleText.toString()).isEqualTo("subtitle text")
-  }
-
-  @Test
-  fun flyOverText_nestedDisplayItemWithFlyOverCode_returnsFlyOverText() {
-    val questionItemList =
-      listOf(
-        Questionnaire.QuestionnaireItemComponent().apply {
-          linkId = "parent-question"
-          text = "parent question text"
-          type = Questionnaire.QuestionnaireItemType.BOOLEAN
-          item =
-            listOf(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "nested-display-question"
-                text = "flyover text"
-                type = Questionnaire.QuestionnaireItemType.DISPLAY
-                addExtension(
-                  EXTENSION_ITEM_CONTROL_URL,
-                  CodeableConcept().apply {
-                    addCoding().apply {
-                      system = EXTENSION_ITEM_CONTROL_SYSTEM
-                      code = "flyover"
-                    }
-                  }
-                )
-              }
-            )
-        }
-      )
-
-    assertThat(questionItemList.first().flyOverText.toString()).isEqualTo("flyover text")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemAdapterTest.kt
@@ -129,13 +129,13 @@ class QuestionnaireItemAdapterTest {
       Questionnaire.QuestionnaireItemComponent().setType(Questionnaire.QuestionnaireItemType.STRING)
     questionnaireItem.addExtension(
       Extension()
-        .setUrl(EXTENSION_ITEM_CONTROL_URL_UNOFFICIAL)
+        .setUrl(EXTENSION_ITEM_CONTROL_URL_ANDROID_FHIR)
         .setValue(
           CodeableConcept()
             .addCoding(
               Coding()
                 .setCode(ItemControlTypes.PHONE_NUMBER.extensionCode)
-                .setSystem(EXTENSION_ITEM_CONTROL_SYSTEM_UNOFFICIAL)
+                .setSystem(EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR)
             )
         )
     )


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1291 

**Description**

Extract common view for question headers.

- Create QuestionnaireItemHeaderView for the prefix, question and hint text which shares the same look-and-feel for all widgets
- Create tests for this view and simplify tests for other widgets

Additional refactoring:

- Add missing hint for auto complete
- Rename custom extension URLs from `EXTENSION_***_UNOFFICIAL` to `EXTENSION_***_ANDROID_FHIR`
- Rename `Questionnaire.QuestionnaireItemComponent.subtitleText` to `Questionnaire.QuestionnaireItemComponent.localizedHintSpanned` because it's localized and hint is slightly more accurate than subtitle
- Rename `Questionnaire.QuestionnaireItemComponent.flyOverText` to `Questionnaire.QuestionnaireItemComponent.localizedFlyoverSpanned` because it's localized

**Alternative(s) considered**
NA

**Type**
Bug fix + Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
