### PR TITLE
Remove error for input field in Date and DateTime pickers

### DIFF
--- a/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_picker_view.xml
@@ -30,24 +30,25 @@
     />
 
     <com.google.android.material.textfield.TextInputLayout
-        style="?attr/questionnaireTextInputLayoutStyle"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/text_input_layout"
+        style="?attr/questionnaireTextInputLayoutStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:hintEnabled="true"
-        app:endIconMode="custom"
         app:endIconDrawable="@drawable/gm_calendar_today_24"
+        app:endIconMode="custom"
+        app:errorIconDrawable="@null"
+        app:hintEnabled="true"
     >
 
         <com.google.android.material.textfield.TextInputEditText
-            style="?attr/editTextInputTextAppearanceQuestionnaire"
             android:id="@+id/text_input_edit_text"
+            style="?attr/editTextInputTextAppearanceQuestionnaire"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:hint="@string/date"
             android:inputType="none"
             android:singleLine="true"
-            android:hint="@string/date"
         />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_date_time_picker_view.xml
@@ -37,24 +37,25 @@
     >
 
         <com.google.android.material.textfield.TextInputLayout
-            style="?attr/questionnaireTextInputLayoutStyle"
             android:id="@+id/date_input_layout"
+            style="?attr/questionnaireTextInputLayoutStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            app:hintEnabled="true"
-            app:endIconMode="custom"
             app:endIconDrawable="@drawable/gm_calendar_today_24"
+            app:endIconMode="custom"
+            app:errorIconDrawable="@null"
+            app:hintEnabled="true"
         >
 
             <com.google.android.material.textfield.TextInputEditText
-                style="?attr/editTextInputTextAppearanceQuestionnaire"
                 android:id="@+id/date_input_edit_text"
+                style="?attr/editTextInputTextAppearanceQuestionnaire"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:singleLine="true"
-                android:inputType="none"
                 android:hint="@string/date"
+                android:inputType="none"
+                android:singleLine="true"
             />
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -65,25 +66,26 @@
         />
 
         <com.google.android.material.textfield.TextInputLayout
-            style="?attr/questionnaireTextInputLayoutStyle"
             android:id="@+id/time_input_layout"
+            style="?attr/questionnaireTextInputLayoutStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            app:hintEnabled="true"
-            app:endIconMode="custom"
             app:endIconDrawable="@drawable/gm_schedule_24"
+            app:endIconMode="custom"
+            app:errorIconDrawable="@null"
+            app:hintEnabled="true"
         >
 
             <com.google.android.material.textfield.TextInputEditText
-                style="?attr/editTextInputTextAppearanceQuestionnaire"
                 android:id="@+id/time_input_edit_text"
+                style="?attr/editTextInputTextAppearanceQuestionnaire"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:enabled="false"
-                android:singleLine="true"
-                android:inputType="none"
                 android:hint="@string/time"
+                android:inputType="none"
+                android:singleLine="true"
             />
 
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1292 

**Description**
Remove error for input field in Date and DateTime pickers

**Alternative(s) considered**
NA

**Type**
Bug fix

**Screenshots (if applicable)**
![Screenshot_20220418-225857.png](https://user-images.githubusercontent.com/28757340/163884771-fd9b820e-6bc4-4525-b95a-8568c3af7b1b.png)

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
