### PR TITLE
Cleanup and moved Date and Time pickers to material

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -57,26 +57,6 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
           // necessary to access the base context twice to retrieve the application object
           // from the view's context.
           val context = itemView.context.tryUnwrapContext()!!
-          context.supportFragmentManager.setFragmentResultListener(
-            DatePickerFragment.RESULT_REQUEST_KEY,
-            context
-          ) { _, result ->
-            // java.time APIs can be used with desugaring
-            val year = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_YEAR)
-            val month = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_MONTH)
-            val dayOfMonth = result.getInt(DatePickerFragment.RESULT_BUNDLE_KEY_DAY_OF_MONTH)
-            // Month values are 1-12 in java.time but 0-11 in
-            // DatePickerDialog.
-            val localDate = LocalDate.of(year, month + 1, dayOfMonth)
-            textInputEditText.setText(localDate?.localizedString)
-
-            val date = DateType(year, month, dayOfMonth)
-            questionnaireItemViewItem.singleAnswerOrNull =
-              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                value = date
-              }
-            onAnswerChanged(textInputEditText.context)
-          }
           val selectedDate = questionnaireItemViewItem.singleAnswerOrNull?.valueDateType?.localDate
           val datePicker =
             MaterialDatePicker.Builder.datePicker()

--- a/datacapture/src/main/res/values/strings.xml
+++ b/datacapture/src/main/res/values/strings.xml
@@ -96,4 +96,5 @@
     <string name="date">Date</string>
     <string name="time">Time</string>
     <string name="select_date">Select date</string>
+    <string name="select_time">Select time</string>
 </resources>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
1. Refactored code to remove dead code from `QuestionnaireItemDatePickerViewHolderFactory`.
2. Moved Date and Time Pickers to Material design in `QuestionnaireItemDateTimePickerViewHolderFactory` and cleaned up code as well.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Code health

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
