### PR TITLE
Temporarily disable QuestionnaireItemDropDownViewHolderFactoryEspressoTest

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -23,7 +23,8 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isPlatformPopup
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.fhir.datacapture.R
@@ -64,10 +65,7 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
 
     onView(withId(R.id.auto_complete)).perform(showDropDown())
-    onView(withText("-"))
-      .inRoot(isPlatformPopup())
-      .check(matches(isDisplayed()))
-      .perform(click())
+    onView(withText("-")).inRoot(isPlatformPopup()).check(matches(isDisplayed())).perform(click())
     assertThat(viewHolder.itemView.findViewById<TextView>(R.id.auto_complete).text.toString())
       .isEqualTo("-")
     assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer).isEmpty()

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -23,6 +23,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isPlatformPopup
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -20,12 +20,10 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.RootMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.RootMatchers.isPlatformPopup
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.fhir.datacapture.R
@@ -44,14 +42,14 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
   @Rule
   @JvmField
   var activityScenarioRule: ActivityScenarioRule<TestActivity> =
-    ActivityScenarioRule<TestActivity>(TestActivity::class.java)
+    ActivityScenarioRule(TestActivity::class.java)
 
   private lateinit var parent: FrameLayout
   private lateinit var viewHolder: QuestionnaireItemViewHolder
 
   @Before
   fun setup() {
-    activityScenarioRule.getScenario().onActivity { activity -> parent = FrameLayout(activity) }
+    activityScenarioRule.scenario.onActivity { activity -> parent = FrameLayout(activity) }
     viewHolder = QuestionnaireItemDropDownViewHolderFactory.create(parent)
     setTestLayout(viewHolder.itemView)
   }
@@ -67,9 +65,9 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
 
     onView(withId(R.id.auto_complete)).perform(showDropDown())
     onView(withText("-"))
-      .inRoot(RootMatchers.isPlatformPopup())
+      .inRoot(isPlatformPopup())
       .check(matches(isDisplayed()))
-      .perform(ViewActions.click())
+      .perform(click())
     assertThat(viewHolder.itemView.findViewById<TextView>(R.id.auto_complete).text.toString())
       .isEqualTo("-")
     assertThat(questionnaireItemViewItem.questionnaireResponseItem.answer).isEmpty()
@@ -87,9 +85,9 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
 
     onView(withId(R.id.auto_complete)).perform(showDropDown())
     onView(withText("Coding 3"))
-      .inRoot(RootMatchers.isPlatformPopup())
+      .inRoot(isPlatformPopup())
       .check(matches(isDisplayed()))
-      .perform(ViewActions.click())
+      .perform(click())
     assertThat(viewHolder.itemView.findViewById<TextView>(R.id.auto_complete).text.toString())
       .isEqualTo("Coding 3")
     assertThat(
@@ -100,12 +98,12 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
 
   /** Method to run code snippet on UI/main thread */
   private fun runOnUI(action: () -> Unit) {
-    activityScenarioRule.getScenario().onActivity { activity -> action() }
+    activityScenarioRule.scenario.onActivity { action() }
   }
 
   /** Method to set content view for test activity */
   private fun setTestLayout(view: View) {
-    activityScenarioRule.getScenario().onActivity { activity -> activity.setContentView(view) }
+    activityScenarioRule.scenario.onActivity { activity -> activity.setContentView(view) }
     InstrumentationRegistry.getInstrumentation().waitForIdleSync()
   }
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -36,6 +36,7 @@ import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -75,6 +76,7 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
   }
 
   @Test
+  @Ignore("https://github.com/google/android-fhir/issues/1323")
   fun shouldSetDropDownValueToAutoCompleteTextView() {
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(


### PR DESCRIPTION
`QuestionnaireItemDropDownViewHolderFactoryEspressoTest#shouldSetDropDownValueToAutoCompleteTextView`

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1323 

**Description**

- Temporarily disable `QuestionnaireItemDropDownViewHolderFactoryEspressoTest#shouldSetDropDownValueToAutoCompleteTextView`
- Improve imports
- Use property access syntax
- Remove unnecessary explicit type arguments

**Alternative(s) considered**
NA

**Type**
Testing

**Screenshots (if applicable)**
NA

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
