### PR TITLE
Disable workflow unit test that fails with OOM

### DIFF
--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
@@ -72,7 +72,7 @@ class FhirOperatorTest {
   }
 
   @Test
-  @Ignore("Refactor the API to accommodate local end points")
+  @Ignore("https://github.com/google/android-fhir/issues/1336")
   fun evaluateIndividualSubjectMeasure() = runBlocking {
     val measureReport =
       fhirOperator.evaluateMeasure(

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
@@ -72,6 +72,7 @@ class FhirOperatorTest {
   }
 
   @Test
+  @Ignore("Refactor the API to accommodate local end points")
   fun evaluateIndividualSubjectMeasure() = runBlocking {
     val measureReport =
       fhirOperator.evaluateMeasure(


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Temporarily fixes #1336 

**Description**
Disable workflow unit test that fails with OOM

**Alternative(s) considered**
Disable the test temporarily to allow PRs to be merged. We will re-enable the test once the OOM issue is resolved.

**Type**
Testing

**Screenshots (if applicable)**
NA

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
