### PR TITLE
Add 100ms delay to the AutoComplete action in emulator tests to fix the test flakiness

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/utilities/AutoCompleteTextViewAction.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/utilities/AutoCompleteTextViewAction.kt
@@ -38,7 +38,7 @@ fun showDropDown(): ViewAction {
     override fun perform(uiController: UiController, view: View?) {
       val autoCompleteTextView = view as AutoCompleteTextView
       autoCompleteTextView.showDropDown()
-      uiController.loopMainThreadUntilIdle()
+      uiController.loopMainThreadForAtLeast(100)
     }
   }
 }

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -36,7 +36,6 @@ import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -73,7 +73,6 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
   }
 
   @Test
-  @Ignore("https://github.com/google/android-fhir/issues/1323")
   fun shouldSetDropDownValueToAutoCompleteTextView() {
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1323

**Description**
Clear and concise code change description. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
