### PR TITLE
Disabled espresso test cases as its flaky

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryEspressoTest.kt
@@ -37,10 +37,11 @@ import org.hamcrest.CoreMatchers.allOf
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-
+@Ignore("https://github.com/google/android-fhir/issues/1323")
 @RunWith(AndroidJUnit4::class)
 class QuestionnaireItemDateTimePickerViewHolderFactoryEspressoTest {
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -36,9 +36,10 @@ import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-
+@Ignore("https://github.com/google/android-fhir/issues/1323")
 class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
   @Rule
   @JvmField


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1323
**Description**
Espresso test cases for drop down and date and time picker widgets are flakey . So diabled both test classes

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Other

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
