### PR TITLE
Date changed to short format instead of default (medium)

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -28,12 +28,12 @@ internal val LocalDate.localizedString: String
   get() {
     val date = Date.from(atStartOfDay(ZoneId.systemDefault())?.toInstant())
     return if (isAndroidIcuSupported()) {
-      DateFormat.getDateInstance(DateFormat.DEFAULT).format(date)
+      DateFormat.getDateInstance(DateFormat.SHORT).format(date)
     } else {
-      SimpleDateFormat.getDateInstance(java.text.DateFormat.DEFAULT, Locale.getDefault())
+      SimpleDateFormat.getDateInstance(java.text.DateFormat.SHORT, Locale.getDefault())
         .format(date)
     }
   }
 
 // Android ICU is supported API level 24 onwards.
-internal fun isAndroidIcuSupported() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+private fun isAndroidIcuSupported() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -30,8 +30,7 @@ internal val LocalDate.localizedString: String
     return if (isAndroidIcuSupported()) {
       DateFormat.getDateInstance(DateFormat.SHORT).format(date)
     } else {
-      SimpleDateFormat.getDateInstance(java.text.DateFormat.SHORT, Locale.getDefault())
-        .format(date)
+      SimpleDateFormat.getDateInstance(java.text.DateFormat.SHORT, Locale.getDefault()).format(date)
     }
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimesTest.kt
@@ -35,7 +35,7 @@ class MoreLocalDateTimesTest {
   fun localizedString_US() {
     Locale.setDefault(Locale.US)
     val localDateTime = LocalDateTime.of(LocalDate.of(2010, 10, 18), LocalTime.of(18, 10, 10))
-    assertThat(localDateTime.localizedDateString).isEqualTo("Oct 18, 2010")
+    assertThat(localDateTime.localizedDateString).isEqualTo("10/18/10")
     assertThat(localDateTime.toLocalizedTimeString(ApplicationProvider.getApplicationContext()))
       .isEqualTo("6:10 PM")
   }
@@ -45,7 +45,7 @@ class MoreLocalDateTimesTest {
     org.robolectric.shadows.ShadowSettings.set24HourTimeFormat(true)
     Locale.setDefault(Locale.US)
     val localDateTime = LocalDateTime.of(LocalDate.of(2010, 10, 18), LocalTime.of(18, 10, 10))
-    assertThat(localDateTime.localizedDateString).isEqualTo("Oct 18, 2010")
+    assertThat(localDateTime.localizedDateString).isEqualTo("10/18/10")
     assertThat(localDateTime.toLocalizedTimeString(ApplicationProvider.getApplicationContext()))
       .isEqualTo("18:10")
   }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
@@ -33,7 +33,7 @@ class MoreLocalDatesTest {
   fun localizedString_US() {
     Locale.setDefault(Locale.US)
     val localDate = LocalDate.of(2010, 10, 18)
-    assertThat(localDate.localizedString).isEqualTo("Oct 18, 2010")
+    assertThat(localDate.localizedString).isEqualTo("10/18/10")
   }
 
   @Test
@@ -47,6 +47,6 @@ class MoreLocalDatesTest {
   fun localizedString_Italy() {
     Locale.setDefault(Locale.ITALY)
     val localDate = LocalDate.of(2010, 10, 18)
-    assertThat(localDate.localizedString).isEqualTo("18 ott 2010")
+    assertThat(localDate.localizedString).isEqualTo("18/10/10")
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
@@ -81,7 +81,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
     assertThat(
         viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text.toString()
       )
-      .isEqualTo("Nov 19, 2020")
+      .isEqualTo("11/19/20")
   }
 
   @Test
@@ -119,7 +119,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
     assertThat(
         viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text.toString()
       )
-      .isEqualTo("Nov 19, 2020")
+      .isEqualTo("11/19/20")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
@@ -95,7 +95,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
     assertThat(
         viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text.toString()
       )
-      .isEqualTo("Feb 5, 2020")
+      .isEqualTo("2/5/20")
     assertThat(
         viewHolder.itemView.findViewById<TextView>(R.id.time_input_edit_text).text.toString()
       )


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Changed Date format from `MEDIUM (e.g. Oct 18, 2010 )` to `SHORT (e.g. 10/18/10)`

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
