### PR TITLE
Update medium font.

### DIFF
--- a/catalog/src/main/assets/default_layout_questionnaire.json
+++ b/catalog/src/main/assets/default_layout_questionnaire.json
@@ -10,22 +10,106 @@
     {
       "linkId": "2",
       "type": "string",
-      "text": "First Name"
+      "item": [
+        {
+          "linkId": "2.1",
+          "text": "First Name",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "3",
       "type": "string",
-      "text": "Family Name"
+      "item": [
+        {
+          "linkId": "3.1",
+          "text": "Family Name",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "4",
       "type": "integer",
-      "text": "ID number"
+      "item": [
+        {
+          "linkId": "4.1",
+          "text": "ID number",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "5",
       "type": "integer",
-      "text": "Mobile number"
+      "item": [
+        {
+          "linkId": "5.1",
+          "text": "Mobile number",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "6",
@@ -57,17 +141,19 @@
     },
     {
       "linkId": "7",
-      "type": "display",
+      "type": "date",
       "text": "Date of birth",
-      "prefix":"2."
+      "prefix":"2.",
+      "item": [
+        {
+          "linkId": "7.1",
+          "text": "If the real DOB is unknown, provide an estimated year.",
+          "type": "display"
+        }
+      ]
     },
     {
       "linkId": "8",
-      "type": "date",
-      "text": "If the real DOB is unknown, provide an estimated year."
-    },
-    {
-      "linkId": "9",
       "type": "choice",
       "repeats": true,
       "extension": [
@@ -95,51 +181,183 @@
       ]
     },
     {
-      "linkId": "10",
+      "linkId": "9",
       "type": "display",
       "text": "Address",
       "prefix":"3."
     },
     {
+      "linkId": "10",
+      "type": "string",
+      "item": [
+        {
+          "linkId": "10.1",
+          "text": "House number and street",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "linkId": "11",
       "type": "string",
-      "text": "House number and street"
+      "item": [
+        {
+          "linkId": "11.1",
+          "text": "Apartment, unit",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "12",
       "type": "string",
-      "text": "Apartment, unit"
+      "item": [
+        {
+          "linkId": "12.1",
+          "text": "City, town or village",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "13",
       "type": "string",
-      "text": "City, town or village"
+      "item": [
+        {
+          "linkId": "13.1",
+          "text": "County",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "14",
       "type": "string",
-      "text": "County"
+      "item": [
+        {
+          "linkId": "14.1",
+          "text": "Postal Code",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "linkId": "15",
-      "type": "string",
-      "text": "Postal Code"
+      "type": "display",
+      "text": "Alternative contact person",
+      "prefix":"4.",
+      "item": [
+        {
+          "linkId": "15.1",
+          "text": "The alternative contact would be used in the case of an emergency situation and could be next of kin (e.g. partner, mother, sibling.)",
+          "type": "display"
+        }
+      ]
     },
     {
       "linkId": "16",
-      "type": "display",
-      "text": "Alternative contact person",
-      "prefix":"4."
-    },
-    {
-      "linkId": "18",
       "type": "string",
-      "text": "Name"
+      "item": [
+        {
+          "linkId": "16.1",
+          "text": "Name",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
-      "linkId": "19",
+      "linkId": "17",
       "type": "choice",
-      "text": "Relationship",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -153,6 +371,28 @@
             ],
             "text": "Drop down"
           }
+        }
+      ],
+      "item": [
+        {
+          "linkId": "17.1",
+          "text": "Relationship",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
         }
       ],
       "answerOption": [
@@ -189,12 +429,33 @@
       ]
     },
     {
-      "linkId": "20",
+      "linkId": "18",
       "type": "string",
-      "text": "Phone number"
+      "item": [
+        {
+          "linkId": "18.1",
+          "text": "Phone number",
+          "type": "display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "flyover",
+                    "display": "Fly-over"
+                  }
+                ],
+                "text": "Flyover"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
-      "linkId": "20",
+      "linkId": "19",
       "type": "choice",
       "text": "What is the highest level of education achieved?",
       "prefix":"5.",
@@ -211,6 +472,13 @@
             ],
             "text": "Radio button"
           }
+        }
+      ],
+      "item": [
+        {
+          "linkId": "19.1",
+          "text": "Select one",
+          "type": "display"
         }
       ],
       "answerOption": [
@@ -241,7 +509,7 @@
       ]
     },
     {
-      "linkId": "21",
+      "linkId": "20",
       "type": "choice",
       "repeats": true,
       "text": "Who does the client live with?",
@@ -259,6 +527,13 @@
             ],
             "text": "Checkbox"
           }
+        }
+      ],
+      "item": [
+        {
+          "linkId": "20.1",
+          "text": "Check all that apply",
+          "type": "display"
         }
       ],
       "answerOption": [
@@ -301,7 +576,7 @@
       ]
     },
     {
-      "linkId": "22",
+      "linkId": "21",
       "type": "choice",
       "text": "Has the client received this year’s seasonal flu vaccine?",
       "prefix":"7.",
@@ -318,6 +593,13 @@
             ],
             "text": "Radio button"
           }
+        }
+      ],
+      "item": [
+        {
+          "linkId": "21.1",
+          "text": "Select one",
+          "type": "display"
         }
       ],
       "answerOption": [
@@ -342,13 +624,20 @@
       ]
     },
     {
-      "linkId": "23",
+      "linkId": "22",
       "type": "date",
       "text": "When was their last menstrual period? (LMP)",
-      "prefix": "8."
+      "prefix": "8.",
+      "item": [
+        {
+          "linkId": "22.1",
+          "text":"First day of the most recent period",
+          "type": "display"
+        }
+      ]
     },
     {
-      "linkId": "24",
+      "linkId": "23",
       "type": "integer",
       "text": "How many times have they been pregnant?",
       "prefix": "9.",
@@ -366,10 +655,17 @@
             "text": "Slider"
           }
         }
+      ],
+      "item": [
+        {
+          "linkId": "23.1",
+          "text":"Including this pregnancy. Also referred to as gravida.",
+          "type": "display"
+        }
       ]
     },
     {
-      "linkId": "25",
+      "linkId": "24",
       "type": "dateTime",
       "text": "What was the date and time of the ultrasound?",
       "prefix": "10."

--- a/catalog/src/main/res/values/styles.xml
+++ b/catalog/src/main/res/values/styles.xml
@@ -75,15 +75,17 @@
     </style>
     <style
         name="TextAppearance.MyQuestionnaire.Layout.Header.Text"
-        parent="TextAppearance.MaterialComponents.Subtitle1"
+        parent="TextAppearance.MaterialComponents.Subtitle2"
     >
         <item
             name="materialThemeOverlay"
         >@style/ThemeOverlay.App.Layout.Header.Text</item>
-        <item name="android:textStyle">bold</item>
         <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:letterSpacing">0.1</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:letterSpacing">0.01</item>
+        <item name="android:lineSpacingExtra">4sp</item>
     </style>
+
     <style name="ThemeOverlay.App.Layout.Header.Text" parent="">
         <item name="colorOnSurface">@color/grey_900</item>
     </style>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1362 

**Description**
`TextAppearance.MaterialComponents.Subtitle2` has medium font weight but it does not have font size 16 sp. 
Inherit Subtitle2 font instead of Subtitle1 and override textSize with 16 sp value.
With this change it is not required to add roboto font with medium font weight separately.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
https://github.com/google/android-fhir/pull/1364

**Type**
Choose one: Bug fix 

**Screenshots (if applicable)**

![Screenshot_20220512-174355](https://user-images.githubusercontent.com/86107848/168074524-35207692-128e-49ba-b007-ba9415ad0f94.png)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
