### PR TITLE
Apply datePicker material3 default style.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -111,7 +111,6 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
             ?.toEpochMilli()
             ?: MaterialDatePicker.todayInUtcMilliseconds()
         return MaterialDatePicker.Builder.datePicker()
-          .setTheme(R.style.ThemeOverlay_Questionnaire_DatePicker)
           .setTitleText(R.string.select_date)
           .setSelection(selectedDate)
           .build()

--- a/datacapture/src/main/res/values/strings.xml
+++ b/datacapture/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="save">Save</string>
     <string name="date">Date</string>
     <string name="time">Time</string>
-    <string name="select_date">Select date</string>
+    <string name="select_date">SELECT DATE</string>
     <string name="select_time">Select time</string>
     <string name="hyphen">-</string>
 </resources>

--- a/datacapture/src/main/res/values/styles.xml
+++ b/datacapture/src/main/res/values/styles.xml
@@ -195,50 +195,6 @@
     <style name="ThemeOverlay.App.RadioButton" parent="">
         <item name="colorSecondary">?attr/colorPrimary</item>
     </style>
-
-
-    <style
-        name="ThemeOverlay.Questionnaire.DatePicker"
-        parent="@style/ThemeOverlay.MaterialComponents.MaterialCalendar"
-    >
-        <item
-            name="materialCalendarHeaderLayout"
-        >@style/Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderLayout</item>
-        <item
-            name="materialCalendarHeaderTitle"
-        >@style/Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderTitle</item>
-        <item
-            name="materialCalendarHeaderSelection"
-        >@style/Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderSelection</item>
-        <item
-            name="materialCalendarHeaderToggleButton"
-        >@style/Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderToggleButton</item>
-    </style>
-    <style
-        name="Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderLayout"
-        parent="Widget.MaterialComponents.MaterialCalendar.HeaderLayout"
-    >
-        <item name="android:background">?attr/colorSurface</item>
-        <item name="android:textColor">?attr/colorSurface</item>
-    </style>
-    <style
-        name="Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderTitle"
-        parent="Widget.MaterialComponents.MaterialCalendar.HeaderTitle"
-    >
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
-    <style
-        name="Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderSelection"
-        parent="Widget.MaterialComponents.MaterialCalendar.HeaderSelection"
-    >
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
-    <style
-        name="Widget.Questionnaire.MaterialComponents.MaterialCalendar.HeaderToggleButton"
-        parent="Widget.MaterialComponents.MaterialCalendar.HeaderToggleButton"
-    >
-        <item name="android:tint">?attr/colorOnSurface</item>
-    </style>
     <style
         name="Questionnaire.TextAppearance.MaterialComponents.Body2"
         parent="TextAppearance.MaterialComponents.Body2"


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1410 

**Description**
There is no style to override container background in `ThemeOverlay.Material3.MaterialCalendar` except header layout background. It uses primary color to apply background color to container.
`android:background` can not be used to change the background as it overlaps/hides datepicker title.

Please refer below link for other approaches and there side effects.
https://github.com/google/android-fhir/issues/1410#issuecomment-1132732404
https://github.com/google/android-fhir/issues/1410#issuecomment-1132784515
https://github.com/google/android-fhir/issues/1410#issuecomment-1132792712



**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**
With fix
<img width="438" alt="Screen Shot 2022-05-20 at 5 07 47 PM" src="https://user-images.githubusercontent.com/86107848/169525139-afc0bf7f-23f0-48cc-addc-25a2994851d1.png">


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
