### PR TITLE
Add spotify/ruler plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
     classpath(Plugins.androidGradlePlugin)
     classpath(Plugins.kotlinGradlePlugin)
     classpath(Plugins.navSafeArgsGradlePlugin)
+    classpath(Plugins.rulerGradlePlugin)
   }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
   implementation("com.android.tools.build:gradle:7.1.1")
 
   implementation("app.cash.licensee:licensee-gradle-plugin:1.3.0")
+
+  implementation("com.spotify.ruler:ruler-gradle-plugin:1.2.1")
 }

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -26,6 +26,7 @@ object Plugins {
     const val kotlin = "kotlin"
     const val navSafeArgs = "androidx.navigation.safeargs.kotlin"
     const val spotless = "com.diffplug.spotless"
+    const val ruler = "com.spotify.ruler"
   }
 
   // classpath plugins
@@ -34,6 +35,7 @@ object Plugins {
     "org.jetbrains.kotlin:kotlin-gradle-plugin:${Dependencies.Versions.Kotlin.stdlib}"
   const val navSafeArgsGradlePlugin =
     "androidx.navigation:navigation-safe-args-gradle-plugin:${Dependencies.Versions.Androidx.navigation}"
+  const val rulerGradlePlugin = "com.spotify.ruler:ruler-gradle-plugin:1.2.1"
 
   object Versions {
     const val androidGradlePlugin = "7.0.2"

--- a/buildSrc/src/main/kotlin/RulerConfig.kt
+++ b/buildSrc/src/main/kotlin/RulerConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/RulerConfig.kt
+++ b/buildSrc/src/main/kotlin/RulerConfig.kt
@@ -21,9 +21,9 @@ import org.gradle.kotlin.dsl.configure
 fun Project.configureRuler() {
   apply(plugin = Plugins.BuildPlugins.ruler)
   configure<com.spotify.ruler.plugin.RulerExtension> {
-      abi.set("arm64-v8a")
-      locale.set("en")
-      screenDensity.set(480)
-      sdkVersion.set(27)
+    abi.set("arm64-v8a")
+    locale.set("en")
+    screenDensity.set(480)
+    sdkVersion.set(27)
   }
 }

--- a/buildSrc/src/main/kotlin/RulerConfig.kt
+++ b/buildSrc/src/main/kotlin/RulerConfig.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+
+fun Project.configureRuler() {
+  apply(plugin = Plugins.BuildPlugins.ruler)
+  configure<com.spotify.ruler.plugin.RulerExtension> {
+      abi.set("arm64-v8a")
+      locale.set("en")
+      screenDensity.set(480)
+      sdkVersion.set(27)
+  }
+}

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   id(Plugins.BuildPlugins.kotlinAndroid)
   id(Plugins.BuildPlugins.navSafeArgs)
 }
+
 configureRuler()
 
 android {

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   id(Plugins.BuildPlugins.kotlinAndroid)
   id(Plugins.BuildPlugins.navSafeArgs)
 }
+configureRuler()
 
 android {
   compileSdk = Sdk.compileSdk

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   id(Plugins.BuildPlugins.kotlinKapt)
   id(Plugins.BuildPlugins.navSafeArgs)
 }
+
 configureRuler()
 
 android {

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   id(Plugins.BuildPlugins.kotlinKapt)
   id(Plugins.BuildPlugins.navSafeArgs)
 }
+configureRuler()
 
 android {
   compileSdk = Sdk.compileSdk


### PR DESCRIPTION
**Description**
Adds `:analyzeDebugBundle` and `:analyzeReleaseBundle` tasks, which generate
HTML and JSON reports detailing the size breakdown of various libraries
in an app.

For example, Ruler reports that mlkit adds ~13.4MB to the demo app install-size, and ~7.3MB to its download-size


**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Code health)

**Screenshots (if applicable)**

![image](https://user-images.githubusercontent.com/3058312/170418062-028cb79c-a09d-4307-bb0a-58e7bd0dc85f.png)

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
