### PR TITLE
Pull Maven publish logic up into a buildSrc helper

### DIFF
--- a/buildSrc/src/main/kotlin/Releases.kt
+++ b/buildSrc/src/main/kotlin/Releases.kt
@@ -79,28 +79,31 @@ object Releases {
 }
 
 fun Project.publishAsArtifact(artifact: LibraryArtifact) {
-  configure<org.gradle.api.publish.PublishingExtension> {
-    publications {
-      register("release", MavenPublication::class) {
-        from(components["release"])
-        groupId = Releases.groupId
-        artifactId = artifact.artifactId
-        version = artifact.version
-        // Also publish source code for developers' convenience
-        artifact(
-          tasks.create<Jar>("androidSourcesJar") {
-            archiveClassifier.set("sources")
+  afterEvaluate {
+    configure<org.gradle.api.publish.PublishingExtension> {
+      publications {
+        register("release", MavenPublication::class) {
+          from(components["release"])
+          groupId = Releases.groupId
+          artifactId = artifact.artifactId
+          version = artifact.version
+          // Also publish source code for developers' convenience
+          artifact(
+            tasks.create<Jar>("androidSourcesJar") {
+              archiveClassifier.set("sources")
 
-            val android = project.extensions.getByType<com.android.build.gradle.LibraryExtension>()
-            from(android.sourceSets.getByName("main").java.srcDirs)
-          }
-        )
-        pom {
-          name.set(artifact.name)
-          licenses {
-            license {
-              name.set("The Apache License, Version 2.0")
-              url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+              val android =
+                project.extensions.getByType<com.android.build.gradle.LibraryExtension>()
+              from(android.sourceSets.getByName("main").java.srcDirs)
+            }
+          )
+          pom {
+            name.set(artifact.name)
+            licenses {
+              license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+              }
             }
           }
         }

--- a/buildSrc/src/main/kotlin/Releases.kt
+++ b/buildSrc/src/main/kotlin/Releases.kt
@@ -14,35 +14,53 @@
  * limitations under the License.
  */
 
-import org.gradle.api.publish.maven.MavenPom
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+
+interface LibraryArtifact {
+  /** Maven coordinate artifact id. */
+  val artifactId: String
+
+  /** Maven coordinate version. */
+  val version: String
+
+  /** Descriptive name for library. */
+  val name: String
+}
 
 object Releases {
   const val groupId = "com.google.android.fhir"
 
   // Libraries
 
-  object Common {
-    const val artifactId = "common"
-    const val version = "0.1.0-alpha03"
-    const val name = "Android FHIR Common Library"
+  object Common : LibraryArtifact {
+    override val artifactId = "common"
+    override val version = "0.1.0-alpha03"
+    override val name = "Android FHIR Common Library"
   }
 
-  object Engine {
-    const val artifactId = "engine"
-    const val version = "0.1.0-beta01"
-    const val name = "Android FHIR Engine Library"
+  object Engine : LibraryArtifact {
+    override val artifactId = "engine"
+    override val version = "0.1.0-beta01"
+    override val name = "Android FHIR Engine Library"
   }
 
-  object DataCapture {
-    const val artifactId = "data-capture"
-    const val version = "0.1.0-beta03"
-    const val name = "Android FHIR Structured Data Capture Library"
+  object DataCapture : LibraryArtifact {
+    override val artifactId = "data-capture"
+    override val version = "0.1.0-beta03"
+    override val name = "Android FHIR Structured Data Capture Library"
   }
 
-  object Workflow {
-    const val artifactId = "workflow"
-    const val version = "0.1.0-alpha01"
-    const val name = "Android FHIR Workflow Library"
+  object Workflow : LibraryArtifact {
+    override val artifactId = "workflow"
+    override val version = "0.1.0-alpha01"
+    override val name = "Android FHIR Workflow Library"
   }
 
   // Demo apps
@@ -58,12 +76,34 @@ object Releases {
     const val versionCode = 1
     const val versionName = "1.0"
   }
+}
 
-  fun MavenPom.useApache2License() {
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+fun Project.publishAsArtifact(artifact: LibraryArtifact) {
+  configure<org.gradle.api.publish.PublishingExtension> {
+    publications {
+      register("release", MavenPublication::class) {
+        from(components["release"])
+        groupId = Releases.groupId
+        artifactId = artifact.artifactId
+        version = artifact.version
+        // Also publish source code for developers' convenience
+        artifact(
+          tasks.create<Jar>("androidSourcesJar") {
+            archiveClassifier.set("sources")
+
+            val android = project.extensions.getByType<com.android.build.gradle.LibraryExtension>()
+            from(android.sourceSets.getByName("main").java.srcDirs)
+          }
+        )
+        pom {
+          name.set(artifact.name)
+          licenses {
+            license {
+              name.set("The Apache License, Version 2.0")
+              url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+          }
+        }
       }
     }
   }

--- a/buildSrc/src/main/kotlin/Releases.kt
+++ b/buildSrc/src/main/kotlin/Releases.kt
@@ -78,7 +78,7 @@ object Releases {
   }
 }
 
-fun Project.publishAsArtifact(artifact: LibraryArtifact) {
+fun Project.publishArtifact(artifact: LibraryArtifact) {
   afterEvaluate {
     configure<org.gradle.api.publish.PublishingExtension> {
       publications {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,3 @@
-import Releases.useApache2License
-
 plugins {
   id(Plugins.BuildPlugins.androidLib)
   id(Plugins.BuildPlugins.kotlinAndroid)
@@ -7,29 +5,7 @@ plugins {
   jacoco
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      register("release", MavenPublication::class) {
-        from(components["release"])
-        groupId = Releases.groupId
-        artifactId = Releases.Common.artifactId
-        version = Releases.Common.version
-        // Also publish source code for developers' convenience
-        artifact(
-          tasks.create<Jar>("androidSourcesJar") {
-            archiveClassifier.set("sources")
-            from(android.sourceSets.getByName("main").java.srcDirs)
-          }
-        )
-        pom {
-          name.set(Releases.Common.name)
-          useApache2License()
-        }
-      }
-    }
-  }
-}
+afterEvaluate { publishAsArtifact(Releases.Common) }
 
 createJacocoTestReportTask()
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   jacoco
 }
 
-afterEvaluate { publishAsArtifact(Releases.Common) }
+publishAsArtifact(Releases.Common)
 
 createJacocoTestReportTask()
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   jacoco
 }
 
-publishAsArtifact(Releases.Common)
+publishArtifact(Releases.Common)
 
 createJacocoTestReportTask()
 

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   jacoco
 }
 
-publishAsArtifact(Releases.DataCapture)
+publishArtifact(Releases.DataCapture)
 
 createJacocoTestReportTask()
 

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -1,5 +1,3 @@
-import Releases.useApache2License
-
 plugins {
   id(Plugins.BuildPlugins.androidLib)
   id(Plugins.BuildPlugins.kotlinAndroid)
@@ -8,27 +6,8 @@ plugins {
 }
 
 afterEvaluate {
-  publishing {
-    publications {
-      register("release", MavenPublication::class) {
-        from(components["release"])
-        groupId = Releases.groupId
-        artifactId = Releases.DataCapture.artifactId
-        version = Releases.DataCapture.version
-        // Also publish source code for developers' convenience
-        artifact(
-          tasks.create<Jar>("androidSourcesJar") {
-            archiveClassifier.set("sources")
-            from(android.sourceSets.getByName("main").java.srcDirs)
-          }
-        )
-        pom {
-          name.set(Releases.DataCapture.name)
-          useApache2License()
-        }
-      }
-    }
-  }
+  android
+  publishAsArtifact(Releases.DataCapture)
 }
 
 createJacocoTestReportTask()

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -5,10 +5,7 @@ plugins {
   jacoco
 }
 
-afterEvaluate {
-  android
-  publishAsArtifact(Releases.DataCapture)
-}
+publishAsArtifact(Releases.DataCapture)
 
 createJacocoTestReportTask()
 

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -1,5 +1,3 @@
-import Releases.useApache2License
-
 plugins {
   id(Plugins.BuildPlugins.androidLib)
   id(Plugins.BuildPlugins.kotlinAndroid)
@@ -8,29 +6,7 @@ plugins {
   jacoco
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      register("release", MavenPublication::class) {
-        from(components["release"])
-        groupId = Releases.groupId
-        artifactId = Releases.Engine.artifactId
-        version = Releases.Engine.version
-        // Also publish source code for developers' convenience
-        artifact(
-          tasks.create<Jar>("androidSourcesJar") {
-            archiveClassifier.set("sources")
-            from(android.sourceSets.getByName("main").java.srcDirs)
-          }
-        )
-        pom {
-          name.set(Releases.Engine.name)
-          useApache2License()
-        }
-      }
-    }
-  }
-}
+afterEvaluate { publishAsArtifact(Releases.Engine) }
 
 createJacocoTestReportTask()
 

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
   jacoco
 }
 
-publishAsArtifact(Releases.Engine)
+publishArtifact(Releases.Engine)
 
 createJacocoTestReportTask()
 

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
   jacoco
 }
 
-afterEvaluate { publishAsArtifact(Releases.Engine) }
+publishAsArtifact(Releases.Engine)
 
 createJacocoTestReportTask()
 

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   jacoco
 }
 
-publishAsArtifact(Releases.Workflow)
+publishArtifact(Releases.Workflow)
 
 createJacocoTestReportTask()
 

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -1,5 +1,3 @@
-import Releases.useApache2License
-
 plugins {
   id(Plugins.BuildPlugins.androidLib)
   id(Plugins.BuildPlugins.kotlinAndroid)
@@ -7,29 +5,7 @@ plugins {
   jacoco
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      register("release", MavenPublication::class) {
-        from(components["release"])
-        groupId = Releases.groupId
-        artifactId = Releases.Workflow.artifactId
-        version = Releases.Workflow.version
-        // Also publish source code for developers' convenience
-        artifact(
-          tasks.create<Jar>("androidSourcesJar") {
-            archiveClassifier.set("sources")
-            from(android.sourceSets.getByName("main").java.srcDirs)
-          }
-        )
-        pom {
-          name.set(Releases.Workflow.name)
-          useApache2License()
-        }
-      }
-    }
-  }
-}
+afterEvaluate { publishAsArtifact(Releases.Workflow) }
 
 createJacocoTestReportTask()
 

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   jacoco
 }
 
-afterEvaluate { publishAsArtifact(Releases.Workflow) }
+publishAsArtifact(Releases.Workflow)
 
 createJacocoTestReportTask()
 


### PR DESCRIPTION
Eliminates duplicated, complex logic across `build.gradle.kts` library files.

Tested by verifying `./gradlew :engine:publishToMavenLocal` runs successfully

**Type**
Choose one: (Code health)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
