### PR TITLE
Update theme/colors to Material 3.

### DIFF
--- a/catalog/src/main/res/values-night/themes.xml
+++ b/catalog/src/main/res/values-night/themes.xml
@@ -19,20 +19,50 @@
         name="Theme.Androidfhir"
         parent="Theme.Material3.DayNight.NoActionBar"
     >
-        <item name="colorPrimary">@color/blue_300</item>
-        <item name="colorSecondary">@color/blue_300_38</item>
-        <item name="android:colorBackground">@color/grey_900</item>
-        <item name="colorError">@color/red_300</item>
-        <item name="colorSurface">@color/grey_900</item>
-        <item name="colorOnError">@color/grey_900</item>
+      <item name="colorPrimary">@color/primary_blue_80</item>
+      <item name="colorOnPrimary">@color/onPrimary_blue_20</item>
+      <item name="colorPrimaryContainer">@color/primaryContainer_blue_30</item>
+      <item
+            name="colorOnPrimaryContainer"
+        >@color/onPrimaryContainer_blue_90</item>
 
-        <item name="colorOnPrimary">@color/grey_900</item>
-        <item name="colorOnSecondary">@color/blue_100</item>
-        <item name="colorOnBackground">@color/grey_200</item>
-        <item name="colorOnSurface">@color/grey_200</item>
+      <item name="colorSecondary">@color/secondary_blue_80</item>
+      <item name="colorOnSecondary">@color/onSecondary_blue_20</item>
+      <item
+            name="colorSecondaryContainer"
+        >@color/secondaryContainer_blue_30</item>
+      <item
+            name="colorOnSecondaryContainer"
+        >@color/onSecondaryContainer_blue_90</item>
 
-      <item name="colorPrimaryVariant">@color/purple_700</item>
-      <item name="colorSecondaryVariant">@color/teal_700</item>
+      <item name="colorTertiary">@color/tertiary_green_80</item>
+      <item name="colorOnTertiary">@color/onTertiary_green_20</item>
+      <item
+            name="colorTertiaryContainer"
+        >@color/tertiaryContainer_green_30</item>
+      <item
+            name="colorOnTertiaryContainer"
+        >@color/onTertiaryContainer_green_90</item>
+
+      <item name="colorError">@color/error_red_80</item>
+      <item name="colorErrorContainer">@color/errorContainer_red_20</item>
+      <item name="colorOnError">@color/onError_red_30</item>
+      <item name="colorOnErrorContainer">@color/onErrorContainer_red_90</item>
+
+      <item name="android:colorBackground">@color/background_neutral_10</item>
+      <item name="colorOnBackground">@color/onBackground_neutral_90</item>
+
+      <item name="colorSurface">@color/surface_neutral_10</item>
+      <item name="colorOnSurface">@color/onSurface_neutral_90</item>
+
+      <item
+            name="colorSurfaceVariant"
+        >@color/surfaceVariant_neutral_variant_30</item>
+      <item
+            name="colorOnSurfaceVariant"
+        >@color/onSurfaceVariant_neutral_variant_80</item>
+
+      <item name="colorOutline">@color/outline_neutral_variant_60</item>
 
         <!-- Status bar color. -->
         <item
@@ -65,16 +95,50 @@
   </style>
 
     <style name="DarkTheme.MyQuestionnaire" parent="Theme.MyQuestionnaire">
-      <item name="colorPrimary">@color/blue_300</item>
-      <item name="colorSecondary">@color/blue_300_38</item>
-      <item name="android:colorBackground">@color/grey_900</item>
-      <item name="colorError">@color/red_300</item>
-      <item name="colorSurface">@color/grey_900</item>
+      <item name="colorPrimary">@color/primary_blue_80</item>
+      <item name="colorOnPrimary">@color/onPrimary_blue_20</item>
+      <item name="colorPrimaryContainer">@color/primaryContainer_blue_30</item>
+      <item
+            name="colorOnPrimaryContainer"
+        >@color/onPrimaryContainer_blue_90</item>
 
-      <item name="colorOnPrimary">@color/grey_900</item>
-      <item name="colorOnBackground">@color/grey_200</item>
-      <item name="colorOnSurface">@color/grey_200</item>
-      <item name="colorOnError">@color/grey_900</item>
+      <item name="colorSecondary">@color/secondary_blue_80</item>
+      <item name="colorOnSecondary">@color/onSecondary_blue_20</item>
+      <item
+            name="colorSecondaryContainer"
+        >@color/secondaryContainer_blue_30</item>
+      <item
+            name="colorOnSecondaryContainer"
+        >@color/onSecondaryContainer_blue_90</item>
+
+      <item name="colorTertiary">@color/tertiary_green_80</item>
+      <item name="colorOnTertiary">@color/onTertiary_green_20</item>
+      <item
+            name="colorTertiaryContainer"
+        >@color/tertiaryContainer_green_30</item>
+      <item
+            name="colorOnTertiaryContainer"
+        >@color/onTertiaryContainer_green_90</item>
+
+      <item name="colorError">@color/error_red_80</item>
+      <item name="colorErrorContainer">@color/errorContainer_red_20</item>
+      <item name="colorOnError">@color/onError_red_30</item>
+      <item name="colorOnErrorContainer">@color/onErrorContainer_red_90</item>
+
+      <item name="android:colorBackground">@color/background_neutral_10</item>
+      <item name="colorOnBackground">@color/onBackground_neutral_90</item>
+
+      <item name="colorSurface">@color/surface_neutral_10</item>
+      <item name="colorOnSurface">@color/onSurface_neutral_90</item>
+
+      <item
+            name="colorSurfaceVariant"
+        >@color/surfaceVariant_neutral_variant_30</item>
+      <item
+            name="colorOnSurfaceVariant"
+        >@color/onSurfaceVariant_neutral_variant_80</item>
+
+      <item name="colorOutline">@color/outline_neutral_variant_60</item>
     </style>
 
   <style name="DarkTheme.MyQuestionnaire.Layout">

--- a/catalog/src/main/res/values/colors.xml
+++ b/catalog/src/main/res/values/colors.xml
@@ -40,4 +40,66 @@
     <color name="red_300">#F28B82</color>
     <color name="toolbar_text_color">#5F6368</color>
     <color name="line_24">#DADCE0</color>
+
+    <color name="primary_blue_40">#0B57D0</color>
+    <color name="onPrimary_blue_100">#FFFFFF</color>
+    <color name="primaryContainer_blue_90">#D3E3FD</color>
+    <color name="onPrimaryContainer_blue_10">#041E49</color>
+
+    <color name="secondary_blue_40">#00639B</color>
+    <color name="onSecondary_blue_100">#FFFFFF</color>
+    <color name="secondaryContainer_blue_90">#C2E7FF</color>
+    <color name="onSecondaryContainer_blue_10">#001D35</color>
+
+    <color name="tertiary_green_40">#146C2E</color>
+    <color name="onTertiary_green_100">#FFFFFF</color>
+    <color name="tertiaryContainer_green_90">#C4EED0</color>
+    <color name="onTertiaryContainer_green_10">#072711</color>
+
+    <color name="error_red_40">#B3261E</color>
+    <color name="errorContainer_red_100">#FFFFFF</color>
+    <color name="onError_red_90">#F9DEDC</color>
+    <color name="onErrorContainer_red_10">#410E0B</color>
+
+    <color name="background_neutral_100">#FFFFFF</color>
+    <color name="onBackground_neutral_10">#1F1F1F</color>
+
+    <color name="surface_neutral_100">#FFFFFF</color>
+    <color name="onSurface_neutral_10">#1F1F1F</color>
+
+    <color name="surfaceVariant_neutral_variant_90">#E1E3E1</color>
+    <color name="onSurfaceVariant_neutral_variant_30">#444746</color>
+
+    <color name="outline_neutral_variant_50">#747775</color>
+
+    <color name="primary_blue_80">#A8C7FA</color>
+    <color name="onPrimary_blue_20">#062E6F</color>
+    <color name="primaryContainer_blue_30">#0842A0</color>
+    <color name="onPrimaryContainer_blue_90">#D3E3FD</color>
+
+    <color name="secondary_blue_80">#7FCFFF</color>
+    <color name="onSecondary_blue_20">#003355</color>
+    <color name="secondaryContainer_blue_30">#004A77</color>
+    <color name="onSecondaryContainer_blue_90">#C2E7FF</color>
+
+    <color name="tertiary_green_80">#146C2E</color>
+    <color name="onTertiary_green_20">#0A3818</color>
+    <color name="tertiaryContainer_green_30">#0F5223</color>
+    <color name="onTertiaryContainer_green_90">#C4EED0</color>
+
+    <color name="error_red_80">#F2B8B5</color>
+    <color name="errorContainer_red_20">#601410</color>
+    <color name="onError_red_30">#8C1D18</color>
+    <color name="onErrorContainer_red_90">#F9DEDC</color>
+
+    <color name="background_neutral_10">#1F1F1F</color>
+    <color name="onBackground_neutral_90">#E3E3E3</color>
+
+    <color name="surface_neutral_10">#1F1F1F</color>
+    <color name="onSurface_neutral_90">#E3E3E3</color>
+
+    <color name="surfaceVariant_neutral_variant_30">#444746</color>
+    <color name="onSurfaceVariant_neutral_variant_80">#C4C7C5</color>
+
+    <color name="outline_neutral_variant_60">#8E918F</color>
 </resources>

--- a/catalog/src/main/res/values/styles.xml
+++ b/catalog/src/main/res/values/styles.xml
@@ -18,17 +18,55 @@
 
     <!-- The custom theme for the questionnaires in this application. -->
     <style name="Theme.MyQuestionnaire" parent="Theme.Questionnaire">
-        <item name="colorPrimary">@color/blue_600</item>
-        <item name="colorSecondary">@color/blue_50</item>
-        <item name="android:colorBackground">@color/white</item>
-        <item name="colorSurface">@color/white</item>
-        <item name="colorError">@color/red_600</item>
 
-        <item name="colorOnPrimary">@color/white</item>
-        <item name="colorOnSecondary">@color/blue_700</item>
-        <item name="colorOnBackground">@color/grey_900</item>
-        <item name="colorOnSurface">@color/grey_800</item>
-        <item name="colorOnError">@color/white</item>
+        <item name="colorPrimary">@color/primary_blue_40</item>
+        <item name="colorOnPrimary">@color/onPrimary_blue_100</item>
+        <item
+            name="colorPrimaryContainer"
+        >@color/primaryContainer_blue_90</item>
+        <item
+            name="colorOnPrimaryContainer"
+        >@color/onPrimaryContainer_blue_10</item>
+
+        <item name="colorSecondary">@color/secondary_blue_40</item>
+        <item name="colorOnSecondary">@color/onSecondary_blue_100</item>
+        <item
+            name="colorSecondaryContainer"
+        >@color/secondaryContainer_blue_90</item>
+        <item
+            name="colorOnSecondaryContainer"
+        >@color/onSecondaryContainer_blue_10</item>
+
+        <item name="colorTertiary">@color/tertiary_green_40</item>
+        <item name="colorOnTertiary">@color/onTertiary_green_100</item>
+        <item
+            name="colorTertiaryContainer"
+        >@color/tertiaryContainer_green_90</item>
+        <item
+            name="colorOnTertiaryContainer"
+        >@color/onTertiaryContainer_green_10</item>
+
+        <item name="colorError">@color/error_red_40</item>
+        <item name="colorErrorContainer">@color/errorContainer_red_100</item>
+        <item name="colorOnError">@color/onError_red_90</item>
+        <item name="colorOnErrorContainer">@color/onErrorContainer_red_10</item>
+
+        <item
+            name="android:colorBackground"
+        >@color/background_neutral_100</item>
+        <item name="colorOnBackground">@color/onBackground_neutral_10</item>
+
+        <item name="colorSurface">@color/surface_neutral_100</item>
+        <item name="colorOnSurface">@color/onSurface_neutral_10</item>
+
+        <item
+            name="colorSurfaceVariant"
+        >@color/surfaceVariant_neutral_variant_90</item>
+        <item
+            name="colorOnSurfaceVariant"
+        >@color/onSurfaceVariant_neutral_variant_30</item>
+
+        <item name="colorOutline">@color/outline_neutral_variant_50</item>
 
         <item name="groupHeaderTextAppearanceQuestionnaire">
             @style/TextAppearance.MyQuestionnaire.GroupHeader

--- a/catalog/src/main/res/values/themes.xml
+++ b/catalog/src/main/res/values/themes.xml
@@ -19,20 +19,54 @@
         name="Theme.Androidfhir"
         parent="Theme.Material3.DayNight.NoActionBar"
     >
-        <item name="colorPrimary">@color/blue_600</item>
-        <item name="colorSecondary">@color/blue_50</item>
-        <item name="android:colorBackground">@color/white</item>
-        <item name="colorError">@color/red_600</item>
-        <item name="colorSurface">@color/white</item>
+        <item name="colorPrimary">@color/primary_blue_40</item>
+        <item name="colorOnPrimary">@color/onPrimary_blue_100</item>
+        <item
+            name="colorPrimaryContainer"
+        >@color/primaryContainer_blue_90</item>
+        <item
+            name="colorOnPrimaryContainer"
+        >@color/onPrimaryContainer_blue_10</item>
 
-        <item name="colorOnPrimary">@color/white</item>
-        <item name="colorOnSecondary">@color/blue_700</item>
-        <item name="colorOnBackground">@color/grey_900</item>
-        <item name="colorOnSurface">@color/grey_800</item>
-        <item name="colorOnError">@color/white</item>
+        <item name="colorSecondary">@color/secondary_blue_40</item>
+        <item name="colorOnSecondary">@color/onSecondary_blue_100</item>
+        <item
+            name="colorSecondaryContainer"
+        >@color/secondaryContainer_blue_90</item>
+        <item
+            name="colorOnSecondaryContainer"
+        >@color/onSecondaryContainer_blue_10</item>
 
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorTertiary">@color/tertiary_green_40</item>
+        <item name="colorOnTertiary">@color/onTertiary_green_100</item>
+        <item
+            name="colorTertiaryContainer"
+        >@color/tertiaryContainer_green_90</item>
+        <item
+            name="colorOnTertiaryContainer"
+        >@color/onTertiaryContainer_green_10</item>
+
+        <item name="colorError">@color/error_red_40</item>
+        <item name="colorErrorContainer">@color/errorContainer_red_100</item>
+        <item name="colorOnError">@color/onError_red_90</item>
+        <item name="colorOnErrorContainer">@color/onErrorContainer_red_10</item>
+
+        <item
+            name="android:colorBackground"
+        >@color/background_neutral_100</item>
+        <item name="colorOnBackground">@color/onBackground_neutral_10</item>
+
+        <item name="colorSurface">@color/surface_neutral_100</item>
+        <item name="colorOnSurface">@color/onSurface_neutral_10</item>
+
+        <item
+            name="colorSurfaceVariant"
+        >@color/surfaceVariant_neutral_variant_90</item>
+        <item
+            name="colorOnSurfaceVariant"
+        >@color/onSurfaceVariant_neutral_variant_30</item>
+
+        <item name="colorOutline">@color/outline_neutral_variant_50</item>
 
         <!-- Status bar color. -->
         <item


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1424 

**Description**
Existing catalog app codebase referring material 2 color theme.
It is required to update color theme as per material 3.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
