### PR TITLE
Sp/issue 1417

### DIFF
--- a/catalog/src/main/assets/default_layout_questionnaire.json
+++ b/catalog/src/main/assets/default_layout_questionnaire.json
@@ -2,14 +2,10 @@
   "resourceType": "Questionnaire",
   "item": [
     {
-      "linkId": "1",
-      "type": "display",
-      "text": "Personal information",
-      "prefix":"1."
-    },
-    {
       "linkId": "2",
       "type": "string",
+      "text": "Personal information",
+      "prefix":"1.",
       "item": [
         {
           "linkId": "2.1",
@@ -181,14 +177,10 @@
       ]
     },
     {
-      "linkId": "9",
-      "type": "display",
-      "text": "Address",
-      "prefix":"3."
-    },
-    {
       "linkId": "10",
       "type": "string",
+      "text": "Address",
+      "prefix":"3.",
       "item": [
         {
           "linkId": "10.1",
@@ -316,22 +308,13 @@
         }
       ]
     },
-    {
-      "linkId": "15",
-      "type": "display",
-      "text": "Alternative contact person",
-      "prefix":"4.",
-      "item": [
-        {
-          "linkId": "15.1",
-          "text": "The alternative contact would be used in the case of an emergency situation and could be next of kin (e.g. partner, mother, sibling.)",
-          "type": "display"
-        }
-      ]
-    },
+
+
     {
       "linkId": "16",
       "type": "string",
+      "text": "Alternative contact person",
+      "prefix":"4.",
       "item": [
         {
           "linkId": "16.1",
@@ -352,6 +335,11 @@
               }
             }
           ]
+        },
+        {
+          "linkId": "16.2",
+          "text": "The alternative contact would be used in the case of an emergency situation and could be next of kin (e.g. partner, mother, sibling.)",
+          "type": "display"
         }
       ]
     },

--- a/catalog/src/main/res/values-night/themes.xml
+++ b/catalog/src/main/res/values-night/themes.xml
@@ -150,6 +150,11 @@
             name="submitButtonStyleQuestionnaire"
         >@style/App.Layout.SubmitButtonStyle
     </item>
+    <item name="headerItemViewStyleQuestionnaire">@style/HeaderItemViewStyle
+    </item>
+    <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/Questionnaire.TextAppearance.MaterialComponents.BodyMedium</item>
   </style>
 
   <style name="DarkTheme.MyQuestionnaire.PaginatedLayout">
@@ -157,6 +162,13 @@
             name="submitButtonStyleQuestionnaire"
         >@style/App.Layout.SubmitButtonStyle
     </item>
+    <item
+            name="headerItemViewStyleQuestionnaire"
+        >@style/App.Component.HeaderItemViewStyle
+    </item>
+    <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/App.Component.subtitleTextStyle</item>
   </style>
 
   <style name="DarkTheme.MyQuestionnaire.Component">
@@ -164,5 +176,12 @@
             name="submitButtonStyleQuestionnaire"
         >@style/App.Component.SubmitButtonStyle
     </item>
+    <item
+            name="headerItemViewStyleQuestionnaire"
+        >@style/App.Component.HeaderItemViewStyle
+    </item>
+    <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/App.Component.subtitleTextStyle</item>
   </style>
 </resources>

--- a/catalog/src/main/res/values/styles.xml
+++ b/catalog/src/main/res/values/styles.xml
@@ -71,6 +71,16 @@
         <item name="headerTextAppearanceQuestionnaire">
             @style/TextAppearance.Material3.HeadlineMedium
         </item>
+
+        <item
+            name="headerItemViewStyleQuestionnaire"
+        >@style/App.Component.HeaderItemViewStyle
+        </item>
+
+        <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/App.Component.subtitleTextStyle</item>
+
     </style>
 
     <style name="Theme.MyQuestionnaire.DefaultLayout">
@@ -82,13 +92,27 @@
             name="submitButtonStyleQuestionnaire"
         >@style/App.Layout.SubmitButtonStyle
         </item>
-    </style>
+        <item
+            name="headerItemViewStyleQuestionnaire"
+        >@style/HeaderItemViewStyle</item>
+        <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/Questionnaire.TextAppearance.MaterialComponents.BodyMedium</item>
+    </style>|
+
 
     <style name="Theme.MyQuestionnaire.PaginatedLayout">
         <item
             name="submitButtonStyleQuestionnaire"
         >@style/App.Layout.SubmitButtonStyle
         </item>
+        <item
+            name="headerItemViewStyleQuestionnaire"
+        >@style/App.Component.HeaderItemViewStyle
+        </item>
+        <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/App.Component.subtitleTextStyle</item>
     </style>
 
     <style name="Theme.MyQuestionnaire.Component">
@@ -96,6 +120,13 @@
             name="submitButtonStyleQuestionnaire"
         >@style/App.Component.SubmitButtonStyle
         </item>
+        <item
+            name="headerItemViewStyleQuestionnaire"
+        >@style/App.Component.HeaderItemViewStyle
+        </item>
+        <item
+            name="subtitleTextAppearanceQuestionnaire"
+        >@style/App.Component.subtitleTextStyle</item>
     </style>
 
     <style
@@ -110,6 +141,20 @@
         parent="Questionnaire.SubmitButtonStyle"
     >
         <item name="android:visibility">gone</item>
+    </style>
+
+    <style
+        name="App.Component.HeaderItemViewStyle"
+        parent="HeaderItemViewStyle"
+    >
+        <item name="android:layout_marginBottom">24dp</item>
+    </style>
+
+    <style
+        name="App.Component.subtitleTextStyle"
+        parent="Questionnaire.TextAppearance.MaterialComponents.BodyMedium"
+    >
+        <item name="android:layout_marginTop">12dp</item>
     </style>
 
     <style

--- a/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
@@ -41,7 +41,6 @@
             android:id="@+id/yes_radio_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="@dimen/padding_default"
             android:text="@string/yes"
         />
         <RadioButton
@@ -49,6 +48,7 @@
             android:id="@+id/no_radio_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/padding_default"
             android:text="@string/no"
         />
     </RadioGroup>

--- a/datacapture/src/main/res/layout/questionnaire_item_header.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_header.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="?attr/headerItemViewStyleQuestionnaire"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
 >

--- a/datacapture/src/main/res/values/attrs.xml
+++ b/datacapture/src/main/res/values/attrs.xml
@@ -16,6 +16,7 @@
 -->
 <resources>
     <attr name="groupHeaderTextAppearanceQuestionnaire" format="reference" />
+    <attr name="headerItemViewStyleQuestionnaire" format="reference" />
     <attr name="headerTextAppearanceQuestionnaire" format="reference" />
     <attr name="subtitleTextAppearanceQuestionnaire" format="reference" />
     <attr name="dialogHeaderTextAppearanceQuestionnaire" format="reference" />

--- a/datacapture/src/main/res/values/dimens.xml
+++ b/datacapture/src/main/res/values/dimens.xml
@@ -44,7 +44,4 @@
     <dimen name="padding_half_size">8dp</dimen>
     <dimen name="padding_quarter_size">4dp</dimen>
     <dimen name="dialog_button_text_size_default">14sp</dimen>
-    <dimen name="questionView_margin">24dp</dimen>
-    <dimen name="headerItemView_bottom_margin">24dp</dimen>
-    <dimen name="booleanView_margin">8dp</dimen>
 </resources>

--- a/datacapture/src/main/res/values/dimens.xml
+++ b/datacapture/src/main/res/values/dimens.xml
@@ -44,4 +44,7 @@
     <dimen name="padding_half_size">8dp</dimen>
     <dimen name="padding_quarter_size">4dp</dimen>
     <dimen name="dialog_button_text_size_default">14sp</dimen>
+    <dimen name="questionView_margin">24dp</dimen>
+    <dimen name="headerItemView_bottom_margin">24dp</dimen>
+    <dimen name="booleanView_margin">8dp</dimen>
 </resources>

--- a/datacapture/src/main/res/values/styles.xml
+++ b/datacapture/src/main/res/values/styles.xml
@@ -40,6 +40,9 @@
       <item
             name="headerTextAppearanceQuestionnaire"
         >@style/TextAppearance.Material3.TitleMedium</item>
+      <item
+            name="headerItemViewStyleQuestionnaire"
+        >@style/HeaderItemViewStyle</item>
         <item
             name="subtitleTextAppearanceQuestionnaire"
         >@style/Questionnaire.TextAppearance.MaterialComponents.BodyMedium</item>
@@ -211,8 +214,11 @@
         name="Questionnaire.TextAppearance.MaterialComponents.BodyMedium"
         parent="TextAppearance.Material3.BodyMedium"
     >
-    <item name="android:layout_marginTop">12dp</item>
-    <item name="android:layout_marginBottom">12dp</item>
+    <item name="android:layout_marginTop">4dp</item>
+  </style>
+
+  <style name="HeaderItemViewStyle">
+    <item name="android:layout_marginBottom">16dp</item>
   </style>
 
 </resources>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1417 

**Description**

1. Update default dimension for margin between question text and hint text, and header item view and rest of the view in sdc module.
2. Provide default styles to override these values in application code. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
