### PR TITLE
Try Kokoro as CI Tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,6 @@ jobs:
       - name: Check with Gradle
         run: ./gradlew check --scan
 
-      - name: Release artifacts to local repo
-        run: ./gradlew publishReleasePublicationToCIRepository --scan
-      - name: Upload maven repo
-        uses: actions/upload-artifact@v2
-        with:
-          name: maven-repository
-          path: build/ci-repo
-
       - name: Zip artifact for debugging
         if: ${{ failure() }}
         run: zip build.zip ./*/build -r

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,21 @@ jobs:
         uses: ./.github/actions/commonSetup
 
       - name: Spotless check
-        run: ./gradlew spotlessCheck --scan
+        run: ./gradlew spotlessCheck --scan --stacktrace
 
       - name: Build with Gradle
-        run: ./gradlew build --scan
+        run: ./gradlew build --scan --stacktrace
 
       - name: Check with Gradle
-        run: ./gradlew check --scan
+        run: ./gradlew check --scan --stacktrace
+
+      - name: Release artifacts to local repo
+        run: ./gradlew publishReleasePublicationToCIRepository --scan
+      - name: Upload maven repo
+        uses: actions/upload-artifact@v2
+        with:
+          name: maven-repository
+          path: build/ci-repo
 
       - name: Zip artifact for debugging
         if: ${{ failure() }}

--- a/.github/workflows/deviceTests.yml
+++ b/.github/workflows/deviceTests.yml
@@ -90,6 +90,14 @@ jobs:
             ./gradlew :engine:connectedCheck  --stacktrace --scan
             ./gradlew :workflow:connectedCheck --stacktrace --scan
 
+      - name: Generate Jacoco test coverage reports
+        if: matrix.api-level == 30 # Only generate coverage report on API level 30
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          script: ./gradlew jacocoTestReport --info --scan
+
       - name: Zip artifact for debugging
         if: ${{ failure() }}
         run: zip build.zip ./*/build -r

--- a/.github/workflows/deviceTests.yml
+++ b/.github/workflows/deviceTests.yml
@@ -90,22 +90,6 @@ jobs:
             ./gradlew :engine:connectedCheck  --stacktrace --scan
             ./gradlew :workflow:connectedCheck --stacktrace --scan
 
-      - name: Generate Jacoco test coverage reports
-        if: matrix.api-level == 30 # Only generate coverage report on API level 30
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86_64
-          script: ./gradlew jacocoTestReport --info --scan
-
-      - name: Upload Jacoco test coverage reports to codecov.io
-        if: matrix.api-level == 30 # Only upload coverage on API level 30
-        uses: codecov/codecov-action@v2
-        with:
-          files: engine/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml,datacapture/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml,common/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
-          fail_ci_if_error: true
-          verbose: true
-
       - name: Zip artifact for debugging
         if: ${{ failure() }}
         run: zip build.zip ./*/build -r

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,13 @@ subprojects {
 
 // Create a CI repository and also change versions to include the build number
 afterEvaluate {
-  val buildNumber = System.getenv("KOKORO_BUILD_ID")
+  // Check to see which CI tool is being used (Kokoro or GitHub Actions)
+  val buildNumber =
+    if (project.providers.environmentVariable("KOKORO_BUILD_ID").isPresent) {
+      System.getenv("KOKORO_BUILD_ID")
+    } else {
+      System.getenv("GITHUB_RUN_ID")
+    }
   if (buildNumber != null) {
     subprojects {
       apply(plugin = Plugins.BuildPlugins.mavenPublish)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ subprojects {
 
 // Create a CI repository and also change versions to include the build number
 afterEvaluate {
-  val buildNumber = System.getenv("GITHUB_RUN_ID")
+  val buildNumber = System.getenv("KOKORO_BUILD_ID")
   if (buildNumber != null) {
     subprojects {
       apply(plugin = Plugins.BuildPlugins.mavenPublish)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,13 +40,7 @@ subprojects {
 
 // Create a CI repository and also change versions to include the build number
 afterEvaluate {
-  // Check to see which CI tool is being used (Kokoro or GitHub Actions)
-  val buildNumber =
-    if (project.providers.environmentVariable("KOKORO_BUILD_ID").isPresent) {
-      System.getenv("KOKORO_BUILD_ID")
-    } else {
-      System.getenv("GITHUB_RUN_ID")
-    }
+  val buildNumber = System.getenv("GITHUB_RUN_ID")
   if (buildNumber != null) {
     subprojects {
       apply(plugin = Plugins.BuildPlugins.mavenPublish)

--- a/datacapture/src/main/res/layout/questionnaire_item_multi_select_dialog.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_multi_select_dialog.xml
@@ -60,7 +60,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_half_size"
-            android:text="@android:string/cancel"
+            android:text="@string/cancel"
         />
 
         <Space

--- a/datacapture/src/main/res/values/strings.xml
+++ b/datacapture/src/main/res/values/strings.xml
@@ -30,4 +30,5 @@
     <string name="select_date">Select date</string>
     <string name="select_time">Select time</string>
     <string name="hyphen">-</string>
+    <string name="cancel">Cancel</string>
 </resources>

--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1663,7 +1663,7 @@ class DatabaseImplTest {
             filter(
               Patient.DEATH_DATE,
               {
-                value = of(DateTimeType("2013-03-14"))
+                value = of(DateTimeType("2013-03-14T00:00:00-00:00"))
                 prefix = ParamPrefixEnum.LESSTHAN_OR_EQUALS
               }
             )

--- a/kokoro/README.md
+++ b/kokoro/README.md
@@ -1,0 +1,5 @@
+## Kokoro Infrastructure
+
+The files in this directory serve as plumbing for running tests under Kokoro,
+our internal CI. If there are any changes required to these config files, please
+file an issue.

--- a/kokoro/README.md
+++ b/kokoro/README.md
@@ -1,5 +1,17 @@
 ## Kokoro Infrastructure
 
 The files in this directory serve as plumbing for running tests under Kokoro,
-our internal CI. If there are any changes required to these config files, please
-file an issue.
+our internal CI tool. If there are any changes required to these config files,
+please file an issue.
+
+The [build script](./gcp_ubuntu/kokoro_build.sh) runs each time a PR is opened,
+or when a commit is pushed to an open PR, or when an a PR is merged into the
+master branch. The script runs on a Google Compute Engine machine hosted in our
+own Google Cloud project, with public access to the logs.
+
+The script downloads the dependencies it needs, compiles, builds, and unit tests
+the code, and then uses Firebase Test Lab to run instrumentation tests. Code
+coverage reports are then uploaded to Codecov, where they are displayed on the
+GitHub Pull Request/Repo Homepage.
+
+**WARNING**:Do NOT run the script on your local machine.

--- a/kokoro/gcp_ubuntu/common.cfg
+++ b/kokoro/gcp_ubuntu/common.cfg
@@ -1,0 +1,24 @@
+# -*- protobuffer -*-
+# proto-file: google3/devtools/kokoro/config/proto/build.proto
+# proto-message: BuildConfig
+
+# Fetch Codecov token prior to job starting
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 76773
+      keyname: "android-fhir-codecov-token"
+      backend: "blade:keystore-fastconfigpush"
+    }
+  }
+}
+
+# List artifacts to upload after each build, regardless of whether the build
+# succeeds or fails
+action {
+  define_artifacts {
+    regex: "github/android-fhir/test-results/**"
+    regex: "github/android-fhir/build/ci-repo/**"
+    strip_prefix: "github/android-fhir"
+ }
+}

--- a/kokoro/gcp_ubuntu/continuous.cfg
+++ b/kokoro/gcp_ubuntu/continuous.cfg
@@ -1,0 +1,7 @@
+# -*- protobuffer -*-
+# proto-file: google3/devtools/kokoro/config/proto/build.proto
+# proto-message: BuildConfig
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration.
+build_file: "android-fhir/kokoro/gcp_ubuntu/kokoro_build.sh"

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script should NOT be run locally.
+
+# Script to setup Kokoro to run CI tests for the Android FHIR SDK. The script
+# downloads dependencies, and for each API_LEVEL specified below, creates a new
+# emulator, then runs the ./build script.
+
+# A full build is done for API Level 30. For subsequent API levels, Gradle
+# only runs the instrumentation tests.
+
+# Fail on any error.
+set -e
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+# set -x
+# Code under repo is checked out to ${KOKORO_ARTIFACTS_DIR}/git.
+# The final directory name in this path is determined by the scm name specified
+# in the job configuration.
+export ANDROID_HOME=${HOME}/android_sdk
+export PATH=$PATH:${ANDROID_HOME}/cmdline-tools/latest/bin
+export PATH=$PATH:${ANDROID_HOME}/platform-tools
+export PATH=$PATH:${ANDROID_HOME}/emulator
+export GCS_BUCKET="android-fhir-build-artifacts"
+
+function zip_artifacts() {
+  mkdir -p test-results
+  zip test-results/build.zip ./*/build -r -q
+  find . -type f -regex ".*[t|androidT]est-results/.*xml" \
+    -exec cp {} test-results/ \;
+
+  echo "URLs for screen capture videos:"
+  gsutil ls gs://$GCS_BUCKET/$KOKORO_BUILD_ARTIFACTS_SUBDIR/**/*.mp4 \
+    | sed 's|gs://|https://storage.googleapis.com/|'
+}
+
+function setup() {
+  # Resize partition from 100 GB to max
+  sudo apt -y install cloud-guest-utils
+  sudo growpart /dev/sda 1
+  sudo resize2fs /dev/sda1
+
+  # Set Java version to 11
+  sudo update-java-alternatives --set "/usr/lib/jvm/java-1.11.0-openjdk-amd64"
+
+  # Install npm for spotlessApply
+  sudo npm cache clean -f
+  sudo npm install -g n
+  sudo n stable
+
+  # Setup Android CLI tools
+  wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip \
+    -O ${HOME}/android_sdk.zip -q
+  unzip ${HOME}/android_sdk.zip -d ${ANDROID_HOME}
+  mkdir ${ANDROID_HOME}/cmdline-tools/latest
+  mv ${ANDROID_HOME}/cmdline-tools/bin ${ANDROID_HOME}/cmdline-tools/latest
+  mv ${ANDROID_HOME}/cmdline-tools/lib ${ANDROID_HOME}/cmdline-tools/latest
+
+  yes | sdkmanager --licenses > /dev/null
+  sdkmanager --update > /dev/null
+  sdkmanager "platforms;android-30" "build-tools;30.0.2" > /dev/null
+}
+
+function build_only() {
+  ./gradlew spotlessCheck --info --scan --stacktrace
+  ./gradlew build --info --scan --stacktrace
+  ./gradlew check --info --scan --stacktrace
+}
+
+function run_firebase_testlab() {
+  ./gradlew packageDebugAndroidTest --info --scan --stacktrace
+  LIB_NAMES=("datacapture" "engine" "workflow")
+  firebase_pids=()
+  for lib_name in "${LIB_NAMES[@]}"; do
+   gcloud firebase test android run --type instrumentation \
+      --app demo/build/outputs/apk/androidTest/debug/demo-debug-androidTest.apk \
+      --test $lib_name/build/outputs/apk/androidTest/debug/$lib_name-debug-androidTest.apk \
+      --timeout 30m \
+      --device model=Nexus6P,version=24 \
+      --device model=Nexus6P,version=27 \
+      --device model=Pixel2,version=30 \
+      --environment-variables coverage=true,coverageFile="/sdcard/Download/coverage.ec" \
+      --directories-to-pull /sdcard/Download  \
+      --results-bucket=$GCS_BUCKET \
+      --results-dir=$KOKORO_BUILD_ARTIFACTS_SUBDIR/firebase/$lib_name \
+      --project=android-fhir-instrumeted-tests \
+      --no-use-orchestrator &
+      firebase_pids+=("$!")
+  done
+
+  for firebase_pid in ${firebase_pids[*]}; do
+    wait $firebase_pid
+  done
+
+  mkdir -p {datacapture,engine,workflow}/build/outputs/code_coverage/debugAndroidTest/connected/firebase
+  for lib_name in "${LIB_NAMES[@]}"; do
+    gsutil -m cp -R gs://$GCS_BUCKET/$KOKORO_BUILD_ARTIFACTS_SUBDIR/firebase/$lib_name/Pixel2-30-en-portrait/**/coverage.ec \
+      $lib_name/build/outputs/code_coverage/debugAndroidTest/connected/firebase
+  done
+}
+
+function run_codecov() {
+  ./gradlew jacocoTestReport --exclude-task createDebugCoverageReport --scan --info --stacktrace
+  # Don't write secrets to the logs
+  set +x
+  curl -Os https://uploader.codecov.io/latest/linux/codecov
+  chmod +x codecov
+  CODECOV_TOKEN="$(cat "${KOKORO_KEYSTORE_DIR}/76773_android-fhir-codecov-token")"
+  ./codecov  \
+    -f common/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml \
+    -f datacapture/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml \
+    -f engine/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml \
+    -f workflow/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml \
+    -t ${CODECOV_TOKEN}
+}
+
+setup
+cd ${KOKORO_ARTIFACTS_DIR}/github/android-fhir
+trap zip_artifacts EXIT
+
+build_only
+run_firebase_testlab
+run_codecov
+./gradlew publishReleasePublicationToCIRepository --scan

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -162,4 +162,3 @@ trap zip_artifacts EXIT
 build_only
 device_tests
 code_coverage
-./gradlew publishReleasePublicationToCIRepository --scan --stacktrace

--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -1,0 +1,7 @@
+# -*- protobuffer -*-
+# proto-file: google3/devtools/kokoro/config/proto/build.proto
+# proto-message: BuildConfig
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration.
+build_file: "android-fhir/kokoro/gcp_ubuntu/kokoro_build.sh"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,29 @@
-plugins { id("com.gradle.enterprise") version ("3.10") }
+import androidx.build.gradle.gcpbuildcache.GcpBuildCache
+import androidx.build.gradle.gcpbuildcache.GcpBuildCacheServiceFactory
+
+plugins {
+  id("com.gradle.enterprise") version ("3.10")
+  id("androidx.build.gradle.gcpbuildcache") version "1.0.0-beta01"
+}
 
 gradleEnterprise {
   buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
     termsOfServiceAgree = "yes"
     capture { isTaskInputFiles = true }
+  }
+}
+
+val kokoroRun = providers.environmentVariable("KOKORO_BUILD_ID").isPresent
+
+if (kokoroRun == true) {
+  buildCache {
+    registerBuildCacheService(GcpBuildCache::class, GcpBuildCacheServiceFactory::class)
+    remote(GcpBuildCache::class) {
+      projectId = "android-fhir-build"
+      bucketName = "android-fhir-build-cache"
+      isPush = true
+    }
   }
 }
 

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -14,6 +14,11 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
+
+  packagingOptions {
+    resources.excludes.addAll(listOf("META-INF/ASL-2.0.txt", "META-INF/LGPL-3.0.txt"))
+  }
+
   kotlinOptions { jvmTarget = JavaVersion.VERSION_1_8.toString() }
 }
 


### PR DESCRIPTION
Use Kokoro as a CI Tool. 

It is a script-based, meaning that developers can run the `build.sh` script locally to see if there PRs will build and pass when run against Kokoro.

The tool completes its run in 30 minutes, halving the time from GitHub

Also added a `--record_screen` flag to `build.sh` so that users can record their screen locally when testing.

When Kokoro runs, it always adds this flag and uploads the screen capture as part of the artefacts it uploads. The artefacts also include the build logs, the `ci-repo` directory, the `build.zip` file, and any `xml` files from testing


I have kept the GitHub Actions config for now, and think we should use both CI tools for the time being, just for people to become familiar with Kokoro. We can migrate to using only Kokoro in a few weeks.