### PR TITLE
Rewrite logic to find questionnaire item for EnableWhen evaluation

### DIFF
--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -199,7 +199,7 @@ class QuestionnaireViewModelTest(
       }
     val questionnaireResponse =
       QuestionnaireResponse().apply {
-        id = "a-questionnaire-reponse"
+        id = "a-questionnaire-response"
         addItem(
           QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
             linkId = "a-link-id"
@@ -847,7 +847,7 @@ class QuestionnaireViewModelTest(
   }
 
   @Test
-  fun questionnaireItemViewItemList_shouldGenerateQuestionnaireItemViewItemList() = runBlocking {
+  fun `should emit questionnaire state flow`() = runBlocking {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
@@ -866,26 +866,25 @@ class QuestionnaireViewModelTest(
           }
         )
       }
+
     val viewModel = createQuestionnaireViewModel(questionnaire)
+
     val questionnaireItemViewItemList = viewModel.getQuestionnaireItemViewItemList()
-    assertThat(questionnaireItemViewItemList.size).isEqualTo(2)
-    val firstQuestionnaireItemViewItem = questionnaireItemViewItemList[0]
-    val firstQuestionnaireItem = firstQuestionnaireItemViewItem.questionnaireItem
+    assertThat(questionnaireItemViewItemList).hasSize(2)
+
+    val firstQuestionnaireItem = questionnaireItemViewItemList[0].questionnaireItem
     assertThat(firstQuestionnaireItem.linkId).isEqualTo("a-link-id")
     assertThat(firstQuestionnaireItem.text).isEqualTo("Basic questions")
     assertThat(firstQuestionnaireItem.type).isEqualTo(Questionnaire.QuestionnaireItemType.GROUP)
-    assertThat(firstQuestionnaireItemViewItem.questionnaireItem.linkId).isEqualTo("a-link-id")
-    val secondQuestionnaireItemViewItem = questionnaireItemViewItemList[1]
-    val secondQuestionnaireItem = secondQuestionnaireItemViewItem.questionnaireItem
+
+    val secondQuestionnaireItem = questionnaireItemViewItemList[1].questionnaireItem
     assertThat(secondQuestionnaireItem.linkId).isEqualTo("another-link-id")
     assertThat(secondQuestionnaireItem.text).isEqualTo("Name?")
     assertThat(secondQuestionnaireItem.type).isEqualTo(Questionnaire.QuestionnaireItemType.STRING)
-    assertThat(secondQuestionnaireItemViewItem.questionnaireItem.linkId)
-      .isEqualTo("another-link-id")
   }
 
   @Test
-  fun `should skip validation for questionnaire items initially`() = runBlocking {
+  fun `should emit questionnaire state flow without initial validation`() = runBlocking {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
@@ -905,7 +904,7 @@ class QuestionnaireViewModelTest(
   }
 
   @Test
-  fun `should validate questionnaire items that have been modified`() = runBlocking {
+  fun `should emit questionnaire state flow with validation for modified items`() = runBlocking {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
@@ -938,6 +937,69 @@ class QuestionnaireViewModelTest(
       ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
       observer.cancelAndJoin()
     }
+  }
+
+  @Test
+  fun `should emit questionnaire state flow without disabled questions`() = runBlocking {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "question-1"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addInitial().apply { value = BooleanType(false) }
+          }
+        )
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "question-2"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addEnableWhen().apply {
+              answer = BooleanType(true)
+              question = "question-1"
+              operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+            }
+          }
+        )
+      }
+    val viewModel = createQuestionnaireViewModel(questionnaire)
+
+    assertThat(viewModel.getQuestionnaireItemViewItemList().single().questionnaireItem.linkId)
+      .isEqualTo("question-1")
+  }
+
+  @Test
+  fun `should emit questionnaire state flow with enabled questions`() = runBlocking {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "question-1"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addInitial().apply { value = BooleanType(true) }
+          }
+        )
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "question-2"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addEnableWhen().apply {
+              answer = BooleanType(true)
+              question = "question-1"
+              operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+            }
+          }
+        )
+      }
+    val viewModel = createQuestionnaireViewModel(questionnaire)
+
+    val questionnaireItemViewItemList = viewModel.getQuestionnaireItemViewItemList()
+
+    assertThat(questionnaireItemViewItemList).hasSize(2)
+    assertThat(questionnaireItemViewItemList[0].questionnaireItem.linkId).isEqualTo("question-1")
+    assertThat(questionnaireItemViewItemList[1].questionnaireItem.linkId).isEqualTo("question-2")
   }
 
   @Test
@@ -1272,142 +1334,95 @@ class QuestionnaireViewModelTest(
   }
 
   @Test
-  fun questionnaireItemWithInitialValue_enableWhenFalse_removeItemFromResponse() = runBlocking {
+  fun `should return questionnaire response without disabled questions`() = runBlocking {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
         addItem(
           Questionnaire.QuestionnaireItemComponent().apply {
-            linkId = "a-group-item"
-            text = "Group question"
-            type = Questionnaire.QuestionnaireItemType.GROUP
-            addItem(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "question-1"
-                text = "Basic question"
-                type = Questionnaire.QuestionnaireItemType.BOOLEAN
-                addInitial().apply { value = BooleanType(false) }
-              }
-            )
-            addItem(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "question-2"
-                text = "Basic question"
-                type = Questionnaire.QuestionnaireItemType.BOOLEAN
-                addEnableWhen().apply {
-                  answer = BooleanType(true)
-                  question = "question-1"
-                  operator = Questionnaire.QuestionnaireItemOperator.EQUAL
-                }
-                addInitial().apply { value = BooleanType(true) }
-              }
-            )
+            linkId = "question-1"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addInitial().apply { value = BooleanType(false) }
+          }
+        )
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "question-2"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addEnableWhen().apply {
+              answer = BooleanType(true)
+              question = "question-1"
+              operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+            }
           }
         )
       }
-    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
-    val questionnaireResponseJsonString =
-      """
-  {
-    "resourceType": "QuestionnaireResponse",
-    "item": [
-      {
-        "linkId": "a-group-item",
-        "item": [
-          {
-            "linkId": "question-1",
-            "answer": [
-              {
-                "valueBoolean": false
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-      """.trimIndent()
-    state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, serializedQuestionnaire)
+    state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, printer.encodeResourceToString(questionnaire))
 
     val viewModel = QuestionnaireViewModel(context, state)
 
     assertResourceEquals(
       viewModel.getQuestionnaireResponse(),
-      printer.parseResource(questionnaireResponseJsonString)
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+            linkId = "question-1"
+            addAnswer(
+              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                value = BooleanType(false)
+              }
+            )
+          }
+        )
+      }
     )
   }
 
   @Test
-  fun questionnaireItemWithInitialValue_enableWhenTrue_addItemToResponse() = runBlocking {
+  fun `should return questionnaire response with enabled questions`() = runBlocking {
     val questionnaire =
       Questionnaire().apply {
         id = "a-questionnaire"
         addItem(
           Questionnaire.QuestionnaireItemComponent().apply {
-            linkId = "a-group-item"
-            text = "Group question"
-            type = Questionnaire.QuestionnaireItemType.GROUP
-            addItem(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "question-1"
-                text = "Basic question"
-                type = Questionnaire.QuestionnaireItemType.BOOLEAN
-                addInitial().apply { value = BooleanType(true) }
-              }
-            )
-            addItem(
-              Questionnaire.QuestionnaireItemComponent().apply {
-                linkId = "question-2"
-                text = "Basic question"
-                type = Questionnaire.QuestionnaireItemType.BOOLEAN
-                addEnableWhen().apply {
-                  answer = BooleanType(true)
-                  question = "question-1"
-                  operator = Questionnaire.QuestionnaireItemOperator.EQUAL
-                }
-                addInitial().apply { value = BooleanType(true) }
-              }
-            )
+            linkId = "question-1"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addInitial().apply { value = BooleanType(true) }
+          }
+        )
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "question-2"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            addEnableWhen().apply {
+              answer = BooleanType(true)
+              question = "question-1"
+              operator = Questionnaire.QuestionnaireItemOperator.EQUAL
+            }
           }
         )
       }
-    val serializedQuestionnaire = printer.encodeResourceToString(questionnaire)
-    val questionnaireResponseJsonString =
-      """
-        {
-          "resourceType": "QuestionnaireResponse",
-          "item": [
-            {
-              "linkId": "a-group-item",
-              "item": [
-                {
-                  "linkId": "question-1",
-                  "answer": [
-                    {
-                      "valueBoolean": true
-                    }
-                  ]
-                },
-                {
-                  "linkId": "question-2",
-                  "answer": [
-                    {
-                      "valueBoolean": true
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      """.trimIndent()
-    state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, serializedQuestionnaire)
+    state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, printer.encodeResourceToString(questionnaire))
 
     val viewModel = QuestionnaireViewModel(context, state)
 
     assertResourceEquals(
       viewModel.getQuestionnaireResponse(),
-      printer.parseResource(questionnaireResponseJsonString)
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+            linkId = "question-1"
+            addAnswer(
+              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                value = BooleanType(true)
+              }
+            )
+          }
+        )
+        addItem(
+          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply { linkId = "question-2" }
+        )
+      }
     )
   }
 
@@ -1441,7 +1456,7 @@ class QuestionnaireViewModelTest(
   }
 
   @Test
-  fun nestedDisplayItem_parentQuestionItemIsNotGroup_doesNotcreateQuestionnaireStateItem() =
+  fun nestedDisplayItem_parentQuestionItemIsNotGroup_doesNotCreateQuestionnaireStateItem() =
       runBlocking {
     val questionnaire =
       Questionnaire().apply {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1345

**Description**
See FHIR spec for how EnableWhen should work: https://www.hl7.org/fhir/questionnaire-definitions.html#Questionnaire.item.enableWhen.question

In this PR:
- added a pre-order trace to keep track of questionnaire response items in pre-order
- added a parent map to track questionnaire response items' parents
- in the logic to find questionnaire response item of a certain linkId, try to find ancestor first (using the parent map), then find the nearest item preceding the item, and then the nearest item succeeding the item (using the pre-order trace)

**Alternative(s) considered**
The current approach uses a map from link id to questionnaires. But this might not work since it's possible to have multiple questionnaire responses to the same question with a link id.

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
