### PR TITLE
1439 | Add text into questionnaire-response

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -413,6 +413,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         }
       }
       .map { (questionnaireItem, questionnaireResponseItem) ->
+        questionnaireResponseItem.text = questionnaireItem.localizedTextSpanned?.toString()
         // Nested group items
         questionnaireResponseItem.item =
           getEnabledResponseItems(questionnaireItem.item, questionnaireResponseItem.item)


### PR DESCRIPTION
Fixes part of #1439 

**Description**
Adds text from each questionnaire item into questionnaire-response-item - keeping in mind the localization

**Alternative(s) considered**
Only display text is copied as is. The feature [cqf-exression](https://build.fhir.org/ig/HL7/sdc/examples.html#using-text-and-cqf-expression) is not added due to complexity and concerns over the FHIR spec approach

**Type**
Choose one: (Feature)

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
