### PR TITLE
Make multi-line text widget taller by default

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 
 object QuestionnaireItemPhoneNumberViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_edit_text_view) {
+  QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_edit_text_single_line_view) {
   override fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate =
-    object : QuestionnaireItemEditTextViewHolderDelegate(InputType.TYPE_CLASS_PHONE, true) {
+    object : QuestionnaireItemEditTextViewHolderDelegate(InputType.TYPE_CLASS_PHONE) {
 
       override fun getValue(
         text: String

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,10 +62,12 @@ import org.hl7.fhir.r4.utils.StructureMapUtilities
  * [population](http://build.fhir.org/ig/HL7/sdc/populate.html).
  *
  * This class supports
- * [Definition-based extraction](http://build.fhir.org/ig/HL7/sdc/extraction.html#definition-based-extraction),
- * [StructureMap-based extraction](http://hl7.org/fhir/uv/sdc/extraction.html#structuremap-based-extraction),
- * and
- * [expression-based population](http://build.fhir.org/ig/HL7/sdc/populate.html#expression-based-population).
+ * [Definition-based extraction](http://build.fhir.org/ig/HL7/sdc/extraction.html#definition-based-extraction)
+ * ,
+ * [StructureMap-based extraction](http://hl7.org/fhir/uv/sdc/extraction.html#structuremap-based-extraction)
+ * , and
+ * [expression-based population](http://build.fhir.org/ig/HL7/sdc/populate.html#expression-based-population)
+ * .
  *
  * See the [developer guide](https://github.com/google/android-fhir/wiki/SDCL%3A-Use-ResourceMapper)
  * for more information.
@@ -87,7 +89,8 @@ object ResourceMapper {
    * [Bundle] is returned if [structureMapExtractionContext] is not provided.
    *
    * Otherwise, this method will perform
-   * [Definition-based extraction](http://hl7.org/fhir/uv/sdc/extraction.html#definition-based-extraction).
+   * [Definition-based extraction](http://hl7.org/fhir/uv/sdc/extraction.html#definition-based-extraction)
+   * .
    *
    * @param questionnaire A [Questionnaire] with data extraction extensions.
    * @param questionnaireResponse A [QuestionnaireResponse] with answers for [questionnaire].

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/StructureMapExtractionContext.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/StructureMapExtractionContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +21,14 @@ import org.hl7.fhir.r4.context.IWorkerContext
 import org.hl7.fhir.r4.model.StructureMap
 import org.hl7.fhir.r4.utils.StructureMapUtilities
 
-/**
- * Data used during StructureMap-based extraction.
- */
+/** Data used during StructureMap-based extraction. */
 data class StructureMapExtractionContext(
   /** The application context. */
   val context: Context,
   /**
    * Optionally pass a custom version of [StructureMapUtilities.ITransformerServices] to support
    * specific use cases.
-   **/
+   */
   val transformSupportServices: StructureMapUtilities.ITransformerServices? = null,
   /**
    * A lambda function which returns a [StructureMap]. Depending on your app this could be

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextDecimalViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextDecimalViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,18 @@
 package com.google.android.fhir.datacapture.views
 
 import android.text.InputType
+import com.google.android.fhir.datacapture.R
 import org.hl7.fhir.r4.model.DecimalType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object QuestionnaireItemEditTextDecimalViewHolderFactory :
-  QuestionnaireItemEditTextViewHolderFactory() {
+  QuestionnaireItemEditTextViewHolderFactory(
+    R.layout.questionnaire_item_edit_text_single_line_view
+  ) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object :
       QuestionnaireItemEditTextViewHolderDelegate(
         InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL,
-        isSingleLine = true
       ) {
       override fun getValue(
         text: String

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextIntegerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextIntegerViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,18 @@
 package com.google.android.fhir.datacapture.views
 
 import android.text.InputType
+import com.google.android.fhir.datacapture.R
 import org.hl7.fhir.r4.model.IntegerType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object QuestionnaireItemEditTextIntegerViewHolderFactory :
-  QuestionnaireItemEditTextViewHolderFactory() {
+  QuestionnaireItemEditTextViewHolderFactory(
+    R.layout.questionnaire_item_edit_text_single_line_view
+  ) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object :
       QuestionnaireItemEditTextViewHolderDelegate(
         InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED,
-        true
       ) {
       override fun getValue(
         text: String

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextMultiLineViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextMultiLineViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@
 
 package com.google.android.fhir.datacapture.views
 
+import com.google.android.fhir.datacapture.R
+
 internal object QuestionnaireItemEditTextMultiLineViewHolderFactory :
-  QuestionnaireItemEditTextViewHolderFactory() {
+  QuestionnaireItemEditTextViewHolderFactory(
+    R.layout.questionnaire_item_edit_text_multi_line_view
+  ) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    QuestionnaireItemEditTextStringViewHolderDelegate(false)
+    QuestionnaireItemEditTextStringViewHolderDelegate()
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextQuantityViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextQuantityViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.google.android.fhir.datacapture.views
 
 import android.text.InputType
+import com.google.android.fhir.datacapture.R
 import org.hl7.fhir.r4.model.Quantity
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
@@ -25,12 +26,13 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse
  * is being handled right now. Will use a separate layout to handle the unit in the quantity.
  */
 internal object QuestionnaireItemEditTextQuantityViewHolderFactory :
-  QuestionnaireItemEditTextViewHolderFactory() {
+  QuestionnaireItemEditTextViewHolderFactory(
+    R.layout.questionnaire_item_edit_text_single_line_view
+  ) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     object :
       QuestionnaireItemEditTextViewHolderDelegate(
-        InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED,
-        isSingleLine = true
+        InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED
       ) {
       override fun getValue(
         text: String

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextSingleLineViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextSingleLineViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@
 
 package com.google.android.fhir.datacapture.views
 
+import com.google.android.fhir.datacapture.R
+
 internal object QuestionnaireItemEditTextSingleLineViewHolderFactory :
-  QuestionnaireItemEditTextViewHolderFactory() {
+  QuestionnaireItemEditTextViewHolderFactory(
+    R.layout.questionnaire_item_edit_text_single_line_view
+  ) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    QuestionnaireItemEditTextStringViewHolderDelegate(true)
+    QuestionnaireItemEditTextStringViewHolderDelegate()
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextStringViewHolderDelegate.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextStringViewHolderDelegate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,9 @@ import org.hl7.fhir.r4.model.StringType
  *
  * Any `ViewHolder` containing a `EditText` view that collects text data should use this class.
  */
-internal class QuestionnaireItemEditTextStringViewHolderDelegate(isSingleLine: Boolean) :
+internal class QuestionnaireItemEditTextStringViewHolderDelegate :
   QuestionnaireItemEditTextViewHolderDelegate(
-    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
-    isSingleLine
+    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
   ) {
   override fun getValue(
     text: String

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.View.FOCUS_DOWN
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import androidx.annotation.LayoutRes
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.localizedFlyoverSpanned
@@ -32,16 +33,15 @@ import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
-internal abstract class QuestionnaireItemEditTextViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_edit_text_view) {
+internal abstract class QuestionnaireItemEditTextViewHolderFactory(
+  @LayoutRes override val resId: Int
+) : QuestionnaireItemViewHolderFactory(resId) {
   abstract override fun getQuestionnaireItemViewHolderDelegate():
     QuestionnaireItemEditTextViewHolderDelegate
 }
 
-abstract class QuestionnaireItemEditTextViewHolderDelegate(
-  private val rawInputType: Int,
-  private val isSingleLine: Boolean
-) : QuestionnaireItemViewHolderDelegate {
+abstract class QuestionnaireItemEditTextViewHolderDelegate(private val rawInputType: Int) :
+  QuestionnaireItemViewHolderDelegate {
   private lateinit var header: QuestionnaireItemHeaderView
   private lateinit var textInputLayout: TextInputLayout
   private lateinit var textInputEditText: TextInputEditText
@@ -53,10 +53,6 @@ abstract class QuestionnaireItemEditTextViewHolderDelegate(
     textInputLayout = itemView.findViewById(R.id.text_input_layout)
     textInputEditText = itemView.findViewById(R.id.text_input_edit_text)
     textInputEditText.setRawInputType(rawInputType)
-    textInputEditText.isSingleLine = isSingleLine
-    if (!isSingleLine) {
-      textInputEditText.minLines = MULTI_LINE_TEXT_EDIT_MIN_LINE_NUM
-    }
     // Override `setOnEditorActionListener` to avoid crash with `IllegalStateException` if it's not
     // possible to move focus forward.
     // See
@@ -125,13 +121,4 @@ abstract class QuestionnaireItemEditTextViewHolderDelegate(
   abstract fun getText(
     answer: QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent?
   ): String
-
-  companion object {
-    /**
-     * The minimum number of lines to display for multi-line edit text widget. This gives the user
-     * the indication that the widget allows multi-line input. Without this, the widget will appear
-     * the same as a single-line edit text widget.
-     */
-    private const val MULTI_LINE_TEXT_EDIT_MIN_LINE_NUM = 3
-  }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextViewHolderFactory.kt
@@ -54,6 +54,9 @@ abstract class QuestionnaireItemEditTextViewHolderDelegate(
     textInputEditText = itemView.findViewById(R.id.text_input_edit_text)
     textInputEditText.setRawInputType(rawInputType)
     textInputEditText.isSingleLine = isSingleLine
+    if (!isSingleLine) {
+      textInputEditText.minLines = MULTI_LINE_TEXT_EDIT_MIN_LINE_NUM
+    }
     // Override `setOnEditorActionListener` to avoid crash with `IllegalStateException` if it's not
     // possible to move focus forward.
     // See
@@ -122,4 +125,13 @@ abstract class QuestionnaireItemEditTextViewHolderDelegate(
   abstract fun getText(
     answer: QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent?
   ): String
+
+  companion object {
+    /**
+     * The minimum number of lines to display for multi-line edit text widget. This gives the user
+     * the indication that the widget allows multi-line input. Without this, the widget will appear
+     * the same as a single-line edit text widget.
+     */
+    private const val MULTI_LINE_TEXT_EDIT_MIN_LINE_NUM = 3
+  }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
@@ -28,7 +28,7 @@ import com.google.android.fhir.datacapture.validation.ValidationResult
  *
  * @param resId the layout resource for the view
  */
-abstract class QuestionnaireItemViewHolderFactory(@LayoutRes val resId: Int) {
+abstract class QuestionnaireItemViewHolderFactory(@LayoutRes open val resId: Int) {
   fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
     return QuestionnaireItemViewHolder(
       LayoutInflater.from(parent.context).inflate(resId, parent, false),

--- a/datacapture/src/main/res/layout/questionnaire_item_edit_text_multi_line_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_edit_text_multi_line_view.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/item_margin_horizontal"
+    android:layout_marginTop="@dimen/padding_default"
+    android:orientation="vertical"
+>
+
+    <com.google.android.fhir.datacapture.views.QuestionnaireItemHeaderView
+        android:id="@+id/header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/padding_default"
+    />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/text_input_layout"
+        style="?attr/questionnaireTextInputLayoutStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+    >
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/text_input_edit_text"
+            style="?attr/questionnaireTextInputEditTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="top"
+            android:minLines="3"
+        />
+
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_edit_text_single_line_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_edit_text_single_line_view.xml
@@ -42,7 +42,7 @@
             style="?attr/questionnaireTextInputEditTextStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="top"
+            android:maxLines="1"
         />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_edit_text_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_edit_text_view.xml
@@ -31,17 +31,18 @@
     />
 
     <com.google.android.material.textfield.TextInputLayout
-        style="?attr/questionnaireTextInputLayoutStyle"
         android:id="@+id/text_input_layout"
+        style="?attr/questionnaireTextInputLayoutStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
     >
 
         <com.google.android.material.textfield.TextInputEditText
-            style="?attr/questionnaireTextInputEditTextStyle"
             android:id="@+id/text_input_edit_text"
+            style="?attr/questionnaireTextInputEditTextStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="top"
         />
 
     </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1197 

**Description**
Set a minimum number of lines for the multi-line edit text widget.

The widet will initially have 3 lines to indicate that the widget itself supports multi-line input. But as the user types the widget would expand vertically to accommodate more lines.

**Alternative(s) considered**
NA

**Type**
Bug fix

**Screenshots (if applicable)**

https://user-images.githubusercontent.com/28757340/181742578-fd3373ba-6774-4718-a24e-16ce501a0aaa.mp4

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
