### PR TITLE
drop down item with valueString answer options selection crash fixed

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -36,6 +36,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.StringType
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -96,6 +97,28 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
       .isEqualTo("Coding 3")
   }
 
+  @Test
+  fun shouldSetDropDownValueStringToAutoCompleteTextView() {
+    val questionnaireItemViewItem =
+      QuestionnaireItemViewItem(
+        answerOptionsValueString("Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5"),
+        responseValueStringOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    runOnUI { viewHolder.bind(questionnaireItemViewItem) }
+
+    onView(withId(R.id.auto_complete)).perform(showDropDown())
+    onView(withText("Coding 1"))
+      .inRoot(isPlatformPopup())
+      .check(matches(isDisplayed()))
+      .perform(click())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.auto_complete).text.toString())
+      .isEqualTo("Coding 1")
+    assertThat((questionnaireItemViewItem.answers.single().value as StringType).valueAsString)
+      .isEqualTo("Coding 1")
+  }
+
   /** Method to run code snippet on UI/main thread */
   private fun runOnUI(action: () -> Unit) {
     activityScenarioRule.scenario.onActivity { action() }
@@ -128,6 +151,28 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
         addAnswer(
           QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
             value = Coding().apply { display = response }
+          }
+        )
+      }
+    }
+
+  private fun answerOptionsValueString(vararg options: String) =
+    Questionnaire.QuestionnaireItemComponent().apply {
+      options.forEach { option ->
+        addAnswerOption(
+          Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = StringType().apply { valueAsString = option }
+          }
+        )
+      }
+    }
+
+  private fun responseValueStringOptions(vararg responses: String) =
+    QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+      responses.forEach { response ->
+        addAnswer(
+          QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+            value = StringType().apply { valueAsString = response }
           }
         )
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreAnswerOptions.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreAnswerOptions.kt
@@ -22,6 +22,7 @@ import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.DateType
 import org.hl7.fhir.r4.model.IntegerType
 import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 import org.hl7.fhir.r4.model.TimeType
 
@@ -33,6 +34,27 @@ internal const val EXTENSION_OPTION_EXCLUSIVE_URL =
  * option is [IntegerType] or [StringType] or [Coding] type.
  */
 internal val Questionnaire.QuestionnaireItemAnswerOptionComponent.displayString: String
+  get() {
+    return when (value) {
+      is IntegerType, is DateType, is TimeType -> value.primitiveValue()
+      is StringType -> (value as StringType).getLocalizedText() ?: value.toString()
+      is Coding -> {
+        val display = valueCoding.displayElement.getLocalizedText() ?: valueCoding.display
+        if (display.isNullOrEmpty()) {
+          valueCoding.code
+        } else {
+          display
+        }
+      }
+      else -> throw IllegalArgumentException("$value is not supported.")
+    }
+  }
+
+/**
+ * Text value for response item answer option [QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent] if answer
+ * option is [IntegerType] or [StringType] or [Coding] type.
+ */
+internal val QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent.displayString: String
   get() {
     return when (value) {
       is IntegerType, is DateType, is TimeType -> value.primitiveValue()

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreAnswerOptions.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/MoreAnswerOptions.kt
@@ -51,8 +51,9 @@ internal val Questionnaire.QuestionnaireItemAnswerOptionComponent.displayString:
   }
 
 /**
- * Text value for response item answer option [QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent] if answer
- * option is [IntegerType] or [StringType] or [Coding] type.
+ * Text value for response item answer option
+ * [QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent] if answer option is
+ * [IntegerType] or [StringType] or [Coding] type.
  */
 internal val QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent.displayString: String
   get() {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
@@ -276,7 +276,7 @@ object QuestionnaireResponseValidator {
           "Mismatching question type $questionnaireItemType and answer type $answerType for $linkId"
         }
       Questionnaire.QuestionnaireItemType.CHOICE ->
-        require(answerType == "Coding") {
+        require(answerType == "Coding" || answerType == "string") {
           "Mismatching question type $questionnaireItemType and answer type $answerType for $linkId"
         }
       Questionnaire.QuestionnaireItemType.OPENCHOICE ->

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
@@ -275,11 +275,7 @@ object QuestionnaireResponseValidator {
         require(answerType == "url") {
           "Mismatching question type $questionnaireItemType and answer type $answerType for $linkId"
         }
-      Questionnaire.QuestionnaireItemType.CHOICE ->
-        require(answerType == "Coding" || answerType == "string") {
-          "Mismatching question type $questionnaireItemType and answer type $answerType for $linkId"
-        }
-      Questionnaire.QuestionnaireItemType.OPENCHOICE ->
+      Questionnaire.QuestionnaireItemType.CHOICE, Questionnaire.QuestionnaireItemType.OPENCHOICE ->
         require(answerType == "Coding" || answerType == "string") {
           "Mismatching question type $questionnaireItemType and answer type $answerType for $linkId"
         }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactory.kt
@@ -58,7 +58,7 @@ internal object QuestionnaireItemDropDownViewHolderFactory :
         val adapter =
           ArrayAdapter(context, R.layout.questionnaire_item_drop_down_list, answerOptionString)
         autoCompleteTextView.setText(
-          questionnaireItemViewItem.answers.singleOrNull()?.value?.toString() ?: ""
+          questionnaireItemViewItem.answers.singleOrNull()?.displayString ?: ""
         )
         autoCompleteTextView.setAdapter(adapter)
         autoCompleteTextView.onItemClickListener =

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactory.kt
@@ -57,7 +57,7 @@ internal object QuestionnaireItemDropDownViewHolderFactory :
         val adapter =
           ArrayAdapter(context, R.layout.questionnaire_item_drop_down_list, answerOptionString)
         autoCompleteTextView.setText(
-          questionnaireItemViewItem.answers.singleOrNull()?.valueCoding?.display ?: ""
+          questionnaireItemViewItem.answers.singleOrNull()?.value?.toString() ?: ""
         )
         autoCompleteTextView.setAdapter(adapter)
         autoCompleteTextView.onItemClickListener =


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1542 

**Description**
1. App crash on drop down item re-selection with valueString as Answer option
2. 2. test cases added for same

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
