### PR TITLE
NullPointerException inside LibraryContentProvider breaks the compiler's workflow

### DIFF
--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineLibraryContentProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineLibraryContentProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineLibraryContentProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineLibraryContentProvider.kt
@@ -26,7 +26,7 @@ class FhirEngineLibraryContentProvider(adapterFactory: AdapterFactory) :
   BaseFhirLibraryContentProvider(adapterFactory) {
   val libs = mutableMapOf<String, Library>()
 
-  override fun getLibrary(libraryIdentifier: VersionedIdentifier): IBaseResource {
-    return libs[libraryIdentifier.id]!!
+  override fun getLibrary(libraryIdentifier: VersionedIdentifier): IBaseResource? {
+    return libs[libraryIdentifier.id]
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1566

**Description**
This PR fixes obscure NullPointerException when loading and compiling dependent libraries of a library. The Workflow's LibraryContentProvider must return `null` if the library isn't found (as opposed to triggering an NPE) to allow the next providers to continue the process. 

Any exception inside the compilation workflow returns an internal error. 

**Alternative(s) considered**
No

**Type**
Bug Fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
