### PR TITLE
Clearing the old state of date and date-time ViewHolders

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -41,6 +41,7 @@ import java.time.ZoneId
 import java.time.chrono.IsoChronology
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
+import java.util.Date
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.log10
@@ -173,8 +174,7 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       } catch (e: Exception) {
         null
       }
-    if (answer == null || inputDate == null) return true
-    return answer.localDate != inputDate
+    return answer?.localDate != inputDate
   }
 }
 
@@ -213,14 +213,17 @@ internal val DateType.localDate
 internal val LocalDate.dateType
   get() = DateType(year, monthValue - 1, dayOfMonth)
 
+internal val Date.localDate
+  get() = LocalDate.of(year + 1900, month + 1, date)
+
 internal fun parseDate(text: CharSequence?, context: Context): LocalDate {
-  val date =
+  val localDate =
     if (isAndroidIcuSupported()) {
-      DateFormat.getDateInstance(DateFormat.SHORT).parse(text.toString())
-    } else {
-      android.text.format.DateFormat.getDateFormat(context).parse(text.toString())
-    }
-  val localDate = LocalDate.of(date.year + 1900, date.month + 1, date.date)
+        DateFormat.getDateInstance(DateFormat.SHORT).parse(text.toString())
+      } else {
+        android.text.format.DateFormat.getDateFormat(context).parse(text.toString())
+      }
+      .localDate
   // date/localDate with year more than 4 digit throws data format exception if deep copy
   // operation get performed on QuestionnaireResponse,
   // QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent in org.hl7.fhir.r4.model

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -55,6 +55,7 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       private lateinit var textInputLayout: TextInputLayout
       private lateinit var textInputEditText: TextInputEditText
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
+      private var previousQuestionnaireItemViewItem: QuestionnaireItemViewItem? = null
       private var textWatcher: TextWatcher? = null
       // Medium and long format styles use alphabetical month names which are difficult for the user
       // to input. Use short format style which is always numerical.
@@ -102,6 +103,13 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
         header.bind(questionnaireItemViewItem.questionnaireItem)
         textInputLayout.hint = localePattern
         textInputEditText.removeTextChangedListener(textWatcher)
+        // Cleanup old state when the ViewHolder is now being used for a different questionnaireItem
+        if (previousQuestionnaireItemViewItem?.questionnaireItem !=
+            questionnaireItemViewItem.questionnaireItem
+        ) {
+          textInputEditText.text = null
+        }
+        previousQuestionnaireItemViewItem = questionnaireItemViewItem
 
         if (textInputEditText.text.isNullOrEmpty()) {
           textInputEditText.setText(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -61,6 +61,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       private lateinit var timeInputLayout: TextInputLayout
       private lateinit var timeInputEditText: TextInputEditText
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
+      private var previousQuestionnaireItemViewItem: QuestionnaireItemViewItem? = null
       private var localDate: LocalDate? = null
       private var localTime: LocalTime? = null
       private var textWatcher: TextWatcher? = null
@@ -142,7 +143,6 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
         clearPreviousState()
         header.bind(questionnaireItemViewItem.questionnaireItem)
         dateInputLayout.hint = localeDatePattern
-        dateInputEditText.removeTextChangedListener(textWatcher)
         val dateTime = questionnaireItemViewItem.answers.singleOrNull()?.valueDateTimeType
         updateDateTimeInput(
           dateTime?.let {
@@ -272,9 +272,18 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       }
 
       private fun clearPreviousState() {
-        localDate = null
-        localTime = null
         setReadOnlyInternal(isReadOnly = false)
+        dateInputEditText.removeTextChangedListener(textWatcher)
+        // Cleanup old state when the ViewHolder is now being used for a different questionnaireItem
+        if (previousQuestionnaireItemViewItem?.questionnaireItem !=
+            questionnaireItemViewItem.questionnaireItem
+        ) {
+          dateInputEditText.text = null
+          timeInputEditText.text = null
+          localDate = null
+          localTime = null
+        }
+        previousQuestionnaireItemViewItem = questionnaireItemViewItem
       }
 
       private fun enableOrDisableTimePicker(enableIt: Boolean) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -146,7 +146,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
         val dateTime = questionnaireItemViewItem.answers.singleOrNull()?.valueDateTimeType
         updateDateTimeInput(
           dateTime?.let {
-            LocalDateTime.of(it.year, it.month + 1, it.day, it.hour, it.minute, it.second)?.also {
+            it.localDateTime.also {
               localDate = it.toLocalDate()
               localTime = it.toLocalTime()
             }
@@ -320,6 +320,17 @@ internal val DateTimeType.localDate
 internal val DateTimeType.localTime
   get() =
     LocalTime.of(
+      hour,
+      minute,
+      second,
+    )
+
+internal val DateTimeType.localDateTime
+  get() =
+    LocalDateTime.of(
+      year,
+      month + 1,
+      day,
       hour,
       minute,
       second,

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
@@ -65,10 +65,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text.toString()
-      )
-      .isEqualTo("")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("")
   }
 
   @Test
@@ -86,10 +83,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     )
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text.toString()
-      )
-      .isEqualTo("11/19/20")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/20")
   }
 
   @Test
@@ -107,10 +101,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     )
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text.toString()
-      )
-      .isEqualTo("2020/11/19")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2020/11/19")
   }
 
   @Test
@@ -128,10 +119,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     )
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text.toString()
-      )
-      .isEqualTo("11/19/20")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/20")
   }
 
   @Test
@@ -146,7 +134,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
       )
 
     viewHolder.bind(item)
-    viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text = "11/19/2020"
+    viewHolder.dateInputView.text = "11/19/2020"
 
     val answer = item.answers.singleOrNull()?.value as DateType
 
@@ -166,7 +154,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     viewHolder.bind(item)
-    viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text = "2020/11/19"
+    viewHolder.dateInputView.text = "2020/11/19"
     val answer = item.answers.singleOrNull()?.value as DateType
 
     assertThat(answer.day).isEqualTo(19)
@@ -190,7 +178,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
       )
     viewHolder.bind(questionnaireItem)
 
-    viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text = "11/19/"
+    viewHolder.dateInputView.text = "11/19/"
     val answer = questionnaireItem.answers.singleOrNull()?.value
     assertThat(answer).isNull()
   }
@@ -265,12 +253,59 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).isEnabled)
-      .isFalse()
+    assertThat(viewHolder.dateInputView.isEnabled).isFalse()
+  }
+
+  @Test
+  fun `bind multiple times with different QuestionnaireItemViewItem should show proper date`() {
+    setLocale(Locale.US)
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+          .addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+              .setValue(DateType(2020, 10, 19))
+          ),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/20")
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+          .addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+              .setValue(DateType(2021, 10, 19))
+          ),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/21")
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+    assertThat(viewHolder.dateInputView.text.toString()).isEmpty()
   }
 
   private fun setLocale(locale: Locale) {
     Locale.setDefault(locale)
     context.resources.configuration.setLocale(locale)
   }
+
+  private val QuestionnaireItemViewHolder.dateInputView: TextView
+    get() {
+      return itemView.findViewById(R.id.text_input_edit_text)
+    }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.fhir.datacapture.views
 
-import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.TextView
 import com.google.android.fhir.datacapture.R
@@ -75,14 +74,8 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text.toString()
-      )
-      .isEqualTo("")
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.time_input_edit_text).text.toString()
-      )
-      .isEqualTo("")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("")
+    assertThat(viewHolder.timeInputView.text.toString()).isEqualTo("")
   }
 
   @Test
@@ -100,14 +93,8 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text.toString()
-      )
-      .isEqualTo("2/5/20")
-    assertThat(
-        viewHolder.itemView.findViewById<TextView>(R.id.time_input_edit_text).text.toString()
-      )
-      .isEqualTo("1:30 AM")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2/5/20")
+    assertThat(viewHolder.timeInputView.text.toString()).isEqualTo("1:30 AM")
   }
 
   @Test
@@ -125,7 +112,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     viewHolder.bind(itemViewItem)
 
-    viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text = "11/19/2020"
+    viewHolder.dateInputView.text = "11/19/2020"
 
     val answer = itemViewItem.answers.singleOrNull()?.value as DateTimeType
     assertThat(answer.day).isEqualTo(19)
@@ -149,7 +136,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     viewHolder.bind(itemViewItem)
 
-    viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text = "2020/11/19"
+    viewHolder.dateInputView.text = "2020/11/19"
 
     val answer = itemViewItem.answers.singleOrNull()?.value as DateTimeType
     assertThat(answer.day).isEqualTo(19)
@@ -171,7 +158,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     viewHolder.bind(itemViewItem)
-    viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text = "2020/11/"
+    viewHolder.dateInputView.text = "2020/11/"
 
     assertThat(itemViewItem.answers.singleOrNull()).isNull()
   }
@@ -187,7 +174,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
 
     viewHolder.bind(itemViewItem)
-    viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text = "11/19/"
+    viewHolder.dateInputView.text = "11/19/"
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.time_input_layout).isEnabled)
       .isFalse()
@@ -204,7 +191,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
 
     viewHolder.bind(itemViewItem)
-    viewHolder.itemView.findViewById<TextView>(R.id.date_input_edit_text).text = "11/19/2020"
+    viewHolder.dateInputView.text = "11/19/2020"
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.time_input_layout).isEnabled)
       .isTrue()
@@ -267,9 +254,65 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<EditText>(R.id.date_input_edit_text).isEnabled)
-      .isFalse()
-    assertThat(viewHolder.itemView.findViewById<EditText>(R.id.time_input_edit_text).isEnabled)
-      .isFalse()
+    assertThat(viewHolder.dateInputView.isEnabled).isFalse()
+    assertThat(viewHolder.timeInputView.isEnabled).isFalse()
   }
+
+  @Test
+  fun `bind multiple times with separate QuestionnaireItemViewItem should show proper date and time`() {
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+          .addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+              .setValue(DateTimeType(Date(2020 - 1900, 1, 5, 1, 30, 0)))
+          ),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2/5/20")
+    assertThat(viewHolder.timeInputView.text.toString()).isEqualTo("1:30 AM")
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+          .addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+              .setValue(DateTimeType(Date(2021 - 1900, 1, 5, 2, 30, 0)))
+          ),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2/5/21")
+    assertThat(viewHolder.timeInputView.text.toString()).isEqualTo("2:30 AM")
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+
+    assertThat(viewHolder.dateInputView.text.toString()).isEmpty()
+    assertThat(viewHolder.timeInputView.text.toString()).isEmpty()
+  }
+
+  private val QuestionnaireItemViewHolder.dateInputView: TextView
+    get() {
+      return itemView.findViewById(R.id.date_input_edit_text)
+    }
+
+  private val QuestionnaireItemViewHolder.timeInputView: TextView
+    get() {
+      return itemView.findViewById(R.id.time_input_edit_text)
+    }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1580 

**Description**

**Cause:** 
The date and date time view holders only set text to the TextInput if it was empty before. This logic is required when answer update causes an update in the adapter and subsequent bindView on the ViewHolder.
 But, this causes issue when the ViewHolder is recycled for a new QuestionnaireItem and the ViewHolder retains the old text (date).

**Fix:**
Cleanup up the the ViewHolder state when bind is called for a different QuestionnaireItem.
**UPDATE**
As per discussion with @jingtang10 , instead of cleaning state using a hack, `isTextUpdateRequired` is added to the particular `QuestionnaireItemViewHolderDelegate`s to check if textview has to be update or not based on current text and the `QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent` .

**Alternative(s) considered**
1. [RecyclerView.Adapter#onViewRecycled](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView.Adapter#onViewRecycled(VH)) could be used to forward a callback to the individual `QuestionnaireItemViewHolderDelegate` to do cleanup.
2. Have a way for `QuestionnaireItemViewHolderDelegate` to know that the bind is called as an update for the same item user is updating or is a regular bind.

Both of these require refactoring in all the `QuestionnaireItemViewHolderDelegate` and can be taken as a separate PR if required.

**Type**
Choose one: Bug fix
**Screenshots (if applicable)**
[Date Picker](https://user-images.githubusercontent.com/18224849/188478128-ecdb8c37-1b0f-4563-878d-eff548b143a1.webm)
[Date Time Picker](https://user-images.githubusercontent.com/18224849/188478268-009d7201-44e2-44be-86a7-3dbd0e889372.webm)



**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
