### PR TITLE
prior-edit entry mode added in screener questionnaire

### DIFF
--- a/demo/src/main/assets/screener-questionnaire.json
+++ b/demo/src/main/assets/screener-questionnaire.json
@@ -15,7 +15,11 @@
         "expression": "Encounter",
         "name": "encounter"
       }
-    }
+    },
+      {
+        "url" : "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-entryMode",
+        "valueCode" : "prior-edit"
+      }
   ],
   "item": [
     {
@@ -292,7 +296,6 @@
         {
           "linkId": "2.1.0",
           "type": "group",
-          "required": true,
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -381,7 +384,6 @@
         {
           "linkId": "2.2.0",
           "type": "group",
-          "required": true,
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",
@@ -461,7 +463,6 @@
         {
           "linkId": "2.3.0",
           "type": "group",
-          "required": true,
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemExtractionContext",

--- a/demo/src/main/java/com/google/android/fhir/demo/EditPatientFragment.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/EditPatientFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class EditPatientFragment : Fragment(R.layout.add_patient_fragment) {
     }
     viewModel.isPatientSaved.observe(viewLifecycleOwner) {
       if (!it) {
-        Toast.makeText(requireContext(), R.string.message_input_missing, Toast.LENGTH_SHORT).show()
+        Toast.makeText(requireContext(), R.string.inputs_missing, Toast.LENGTH_SHORT).show()
         return@observe
       }
       Toast.makeText(requireContext(), R.string.message_patient_updated, Toast.LENGTH_SHORT).show()

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
   <string name="edit_patient">Edit Patient</string>
   <string name="submit">Submit</string>
   <string name="message_syncing">Syncing\u2026</string>
-  <string name="message_input_missing">Inputs are missing.</string>
+
   <string name="message_patient_updated">Patient is updated.</string>
   <string name="inputs_missing">Inputs are missing.</string>
   <string name="resources_saved">Resources are saved.</string>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1151

**Description**
1. prior-edit entry mode added in screener questionnaire to validate required fields
2. removed duplicate required = true field for a questionnaire item causing error message displayed twice on screen for that item
3. removed duplicate string from Demo app string.xml

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
