### PR TITLE
Update HAPI structures lib version to 6.0.1

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -177,7 +177,7 @@ object Dependencies {
     const val desugarJdkLibs = "1.1.5"
     const val fhirUcum = "1.0.3"
     const val guava = "28.2-android"
-    const val hapiFhir = "5.4.0"
+    const val hapiFhir = "6.0.1"
     const val http = "4.9.1"
     // TODO: The next release of HAPI FHIR will hopefully have
     // https://github.com/hapifhir/hapi-fhir/pull/3043 merged in. If it does, when we update, we

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -207,7 +207,7 @@ object Dependencies {
 
     const val espresso = "3.4.0"
     const val jacoco = "0.8.7"
-    const val junit = "4.12"
+    const val junit = "4.13.2"
     const val mockitoKotlin = "3.2.0"
     const val mockitoInline = "4.0.0"
     const val robolectric = "4.7.3"

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
   androidTestImplementation(Dependencies.AndroidxTest.extJunitKtx)
   androidTestImplementation(Dependencies.AndroidxTest.rules)
   androidTestImplementation(Dependencies.AndroidxTest.runner)
+  androidTestImplementation(Dependencies.junit)
   androidTestImplementation(Dependencies.truth)
 
   api(Dependencies.HapiFhir.structuresR4)


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Update HAPI structures lib version to 6.0.1

**Alternative(s) considered**
NA

**Type**
Builds

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
