### PR TITLE
appropriate error messages added for date and datetime picker

### DIFF
--- a/datacapture/src/main/res/values/strings.xml
+++ b/datacapture/src/main/res/values/strings.xml
@@ -13,6 +13,11 @@
     <string
         name="max_value_validation_error_msg"
     >Maximum value allowed is:<xliff:g id="max_value">%1$s</xliff:g> </string>
+    <string
+        name="date_format_validation_error_msg"
+    >Date format needs to be <xliff:g
+            id="locale_format"
+        >%1$s</xliff:g> </string>
     <string name="submit_button_text">Submit</string>
     <string name="button_pagination_next">Next</string>
     <string name="button_pagination_previous">Previous</string>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1589

**Description**
1. Displaying appropriate error messages for date picker for format validation and required=true/false
2. Displaying appropriate error messages for date time picker for format validation and required=true/false


**Alternative(s) considered**
yes , BY By implementing date formatter, which validates answer is set then its valid format because in UI after successful parsing of date in required format its set to Questionnaire answer

**Type**
Choose one: Bug fix 

**Screenshots (if applicable)** : Video is attached for all 4 scenarios

[date_picker_required_false.webm](https://user-images.githubusercontent.com/13957417/191939298-417a06ce-de79-46fe-9588-eb5e616b4651.webm)
[date_picker_required_true.webm](https://user-images.githubusercontent.com/13957417/191939378-e51c89ba-6386-4516-8dcc-e79ff11d30e3.webm)
[Uploading date_time_picker_re
[date_time_picker_required_true.webm](https://user-images.githubusercontent.com/13957417/191939424-3c8a552e-3c7c-4dc0-8c1b-2f85a943ebc1.webm)
quired_false.webm…]()



**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
