### PR TITLE
Fix logic to copy questionnaire response item by matching the ID

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -495,7 +495,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         // If there is an enabled questionnaire response available then we use that. Or else we
         // just use an empty questionnaireResponse Item
         if (responseIndex < questionnaireResponseItemList.size &&
-            questionnaireItem.linkId == questionnaireResponseItem.linkId
+            questionnaireItem.linkId == questionnaireResponseItemList[responseIndex].linkId
         ) {
           questionnaireResponseItem = questionnaireResponseItemList[responseIndex]
           responseIndex += 1

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -39,7 +39,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -449,17 +448,77 @@ class QuestionnaireViewModelTest(
     assertThat(questionnaireItemViewItem.items.first().questionnaireItem.linkId)
       .isEqualTo(questionnaireResponseWithMissingItem.item.first().linkId)
     assertThat(
-        questionnaireItemViewItem.items.first().answers.first().valueBooleanType.booleanValue()
+        questionnaireItemViewItem.items.single().answers.single().valueBooleanType.booleanValue()
       )
-      .isEqualTo(
-        questionnaireResponseWithMissingItem
-          .item
-          .first()
-          .answer
-          .first()
-          .valueBooleanType
-          .booleanValue()
-      )
+      .isTrue()
+  }
+
+  @Test
+  fun stateHasQuestionnaireResponse_lessItemsInQuestionnaireResponse_shouldCopyAnswer() =
+      runBlocking {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "q1"
+            text = "Basic question"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            initial = listOf(Questionnaire.QuestionnaireItemInitialComponent(BooleanType(false)))
+          }
+        )
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "q2"
+            text = "Another basic question"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            initial = listOf(Questionnaire.QuestionnaireItemInitialComponent(BooleanType(false)))
+          }
+        )
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "q3"
+            text = "Another basic question"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+            initial = listOf(Questionnaire.QuestionnaireItemInitialComponent(BooleanType(false)))
+          }
+        )
+      }
+    val questionnaireResponse =
+      QuestionnaireResponse().apply {
+        id = "a-questionnaire-response"
+        addItem(
+          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+            linkId = "q2"
+            answer =
+              listOf(
+                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                  value = BooleanType(true)
+                }
+              )
+          }
+        )
+      }
+
+    val questionnaireViewModel = createQuestionnaireViewModel(questionnaire, questionnaireResponse)
+    val questionnaireItemViewItemList = questionnaireViewModel.questionnaireStateFlow.first().items
+
+    // Answer to first question should be created from questionnaire
+    val questionnaireItemViewItem1 = questionnaireItemViewItemList[0]
+    assertThat(questionnaireItemViewItem1.questionnaireItem.linkId).isEqualTo("q1")
+    assertThat(questionnaireItemViewItem1.answers.single().valueBooleanType.booleanValue())
+      .isFalse()
+
+    // Answer to second question should be copied from questionnaire response
+    val questionnaireItemViewItem2 = questionnaireItemViewItemList[1]
+    assertThat(questionnaireItemViewItem2.questionnaireItem.linkId).isEqualTo("q2")
+    assertThat(questionnaireItemViewItem2.answers.single().valueBooleanType.booleanValue()).isTrue()
+
+    // Answer to third quesiton should be created from questionnaire
+    val questionnaireItemViewItem3 = questionnaireItemViewItemList[2]
+    assertThat(questionnaireItemViewItem3.questionnaireItem.linkId).isEqualTo("q3")
+    assertThat(questionnaireItemViewItem3.answers.single().valueBooleanType.booleanValue())
+      .isFalse()
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1633 

**Description**
Fix logic to copy questionnaire response item by matching the ID

**Alternative(s) considered**
NA

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
