### PR TITLE
Update material3 chip style.

### DIFF
--- a/datacapture/src/main/res/values/styles.xml
+++ b/datacapture/src/main/res/values/styles.xml
@@ -76,7 +76,7 @@
         >@style/TextAppearance.Material3.BodyLarge</item>
         <item
             name="questionnaireChipStyle"
-        >@style/Widget.MaterialComponents.Chip.Entry</item>
+        >@style/Widget.Material3.Chip.Input</item>
         <item name="questionnaireButtonStyle">@style/Widget.Material3.Button
         </item>
         <item name="questionnaireErrorTextStyle">


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1592

**Description**
Material3 style is applied to the chip in autocomplete view.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
