### PR TITLE
Stop updating answer in questionnaire item view item

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/utilities/EspressoUtilities.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/utilities/EspressoUtilities.kt
@@ -23,9 +23,9 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import com.google.android.fhir.datacapture.views.QuestionnaireItemViewItem
 import com.google.common.truth.Truth.assertThat
 import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 fun clickOnText(text: String) {
   onView(withText(text)).perform(click())
@@ -40,11 +40,10 @@ fun endIconClickInTextInputLayout(id: Int) {
 }
 
 fun assertQuestionnaireResponseAtIndex(
-  questionnaireItemViewItem: QuestionnaireItemViewItem,
+  answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>,
   vararg expectedStrings: String
 ) {
   for ((index, expectedString) in expectedStrings.withIndex()) {
-    assertThat((questionnaireItemViewItem.answers[index].value as Coding).display)
-      .isEqualTo(expectedString)
+    assertThat((answers[index].value as Coding).display).isEqualTo(expectedString)
   }
 }

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
@@ -23,9 +23,7 @@ import android.widget.TextView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.RootMatchers.isDialog
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -88,19 +86,18 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     }
 
     onView(withId(R.id.text_input_layout)).perform(clickIcon(true))
-    onView(allOf(withText("Nov 19, 2020")))
-      .inRoot(RootMatchers.isDialog())
-      .check(matches(ViewMatchers.isDisplayed()))
+    onView(allOf(withText("Nov 19, 2020"))).inRoot(isDialog()).check(matches(isDisplayed()))
   }
 
   @Test
   fun shouldSetDateInput() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemView =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     runOnUI { viewHolder.bind(questionnaireItemView) }
@@ -113,12 +110,12 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
 
     val today = DateTimeType.today().valueAsString
 
-    assertThat(questionnaireItemView.answers.singleOrNull()?.valueDateType?.valueAsString)
-      .isEqualTo(today)
+    assertThat(answerHolder!!.single().valueDateType?.valueAsString).isEqualTo(today)
   }
 
   @Test
   fun shouldSetDateInput_withinRange() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemView =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -135,7 +132,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     runOnUI { viewHolder.bind(questionnaireItemView) }
@@ -154,13 +151,13 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
         viewHolder.itemView.context
       )
 
-    assertThat(questionnaireItemView.answers.singleOrNull()?.valueDateType?.valueAsString)
-      .isEqualTo(today)
+    assertThat(answerHolder!!.single().valueDateType?.valueAsString).isEqualTo(today)
     assertThat(validationResult).isEqualTo(Valid)
   }
 
   @Test
   fun shouldNotSetDateInput_outsideMaxRange() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val maxDate = DateType(Date()).apply { add(Calendar.YEAR, -2) }
     val questionnaireItemView =
       QuestionnaireItemViewItem(
@@ -177,7 +174,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     runOnUI { viewHolder.bind(questionnaireItemView) }
@@ -192,7 +189,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     val validationResult =
       QuestionnaireResponseItemValidator.validate(
         questionnaireItemView.questionnaireItem,
-        questionnaireItemView.answers,
+        answerHolder!!,
         viewHolder.itemView.context
       )
 
@@ -202,6 +199,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
 
   @Test
   fun shouldNotSetDateInput_outsideMinRange() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val minDate = DateType(Date()).apply { add(Calendar.YEAR, 1) }
     val questionnaireItemView =
       QuestionnaireItemViewItem(
@@ -218,7 +216,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     runOnUI { viewHolder.bind(questionnaireItemView) }
@@ -233,7 +231,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     val validationResult =
       QuestionnaireResponseItemValidator.validate(
         questionnaireItemView.questionnaireItem,
-        questionnaireItemView.answers,
+        answerHolder!!,
         viewHolder.itemView.context
       )
 

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.content.Context
 import android.view.View
 import android.widget.FrameLayout
-import android.widget.TextView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -67,26 +66,6 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     activityScenarioRule.getScenario().onActivity { activity -> parent = FrameLayout(activity) }
     viewHolder = QuestionnaireItemDatePickerViewHolderFactory.create(parent)
     setTestLayout(viewHolder.itemView)
-  }
-
-  @Test
-  fun validDateTextInput_updateCalenderDialogView() {
-    activityScenarioRule.scenario.onActivity { activity -> setLocale(Locale.US, activity) }
-    val questionnaireItemView =
-      QuestionnaireItemViewItem(
-        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
-        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-        validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
-      )
-
-    runOnUI {
-      viewHolder.bind(questionnaireItemView)
-      viewHolder.itemView.findViewById<TextView>(R.id.text_input_edit_text).text = "11/19/20"
-    }
-
-    onView(withId(R.id.text_input_layout)).perform(clickIcon(true))
-    onView(allOf(withText("Nov 19, 2020"))).inRoot(isDialog()).check(matches(isDisplayed()))
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
@@ -61,12 +61,13 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
 
   @Test
   fun multipleChoice_selectMultiple_clickSave_shouldSaveMultipleOptions() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         answerOptions(true, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5"),
         responseOptions(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
@@ -78,12 +79,7 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     clickOnText("Save")
 
     assertDisplayedText().isEqualTo("Coding 1, Coding 3, Coding 5")
-    assertQuestionnaireResponseAtIndex(
-      questionnaireItemViewItem,
-      "Coding 1",
-      "Coding 3",
-      "Coding 5"
-    )
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding 1", "Coding 3", "Coding 5")
   }
 
   @Test
@@ -128,12 +124,13 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
 
   @Test
   fun shouldSelectSingleOptionOnChangeInOptionFromDropDown() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         answerOptions(false, "Coding 1", "Coding 2", "Coding 3"),
         responseOptions(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
@@ -144,17 +141,18 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     clickOnText("Save")
 
     assertDisplayedText().isEqualTo("Coding 1")
-    assertQuestionnaireResponseAtIndex(questionnaireItemViewItem, "Coding 1")
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding 1")
   }
 
   @Test
   fun singleOption_select_clickSave_shouldSaveSingleOption() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         answerOptions(false, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5"),
         responseOptions(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
@@ -164,7 +162,7 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     clickOnText("Save")
 
     assertDisplayedText().isEqualTo("Coding 2")
-    assertQuestionnaireResponseAtIndex(questionnaireItemViewItem, "Coding 2")
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding 2")
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDropDownViewHolderFactoryEspressoTest.kt
@@ -77,12 +77,13 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
 
   @Test
   fun shouldSetDropDownValueToAutoCompleteTextView() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         answerOptions("Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5"),
         responseOptions(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
 
@@ -93,18 +94,18 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
       .perform(click())
     assertThat(viewHolder.itemView.findViewById<TextView>(R.id.auto_complete).text.toString())
       .isEqualTo("Coding 3")
-    assertThat((questionnaireItemViewItem.answers.single().value as Coding).display)
-      .isEqualTo("Coding 3")
+    assertThat((answerHolder!!.single().value as Coding).display).isEqualTo("Coding 3")
   }
 
   @Test
   fun shouldSetDropDownValueStringToAutoCompleteTextView() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         answerOptionsValueString("Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5"),
         responseValueStringOptions(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
 
@@ -115,8 +116,7 @@ class QuestionnaireItemDropDownViewHolderFactoryEspressoTest {
       .perform(click())
     assertThat(viewHolder.itemView.findViewById<TextView>(R.id.auto_complete).text.toString())
       .isEqualTo("Coding 1")
-    assertThat((questionnaireItemViewItem.answers.single().value as StringType).valueAsString)
-      .isEqualTo("Coding 1")
+    assertThat((answerHolder!!.single().value as StringType).valueAsString).isEqualTo("Coding 1")
   }
 
   /** Method to run code snippet on UI/main thread */

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextQuantityViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemEditTextQuantityViewHolderFactoryEspressoTest.kt
@@ -55,6 +55,7 @@ class QuestionnaireItemEditTextQuantityViewHolderFactoryEspressoTest {
 
   @Test
   fun getValue_WithInitial_shouldReturn_Quantity_With_UnitAndSystem() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -70,7 +71,7 @@ class QuestionnaireItemEditTextQuantityViewHolderFactoryEspressoTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
 
@@ -81,7 +82,7 @@ class QuestionnaireItemEditTextQuantityViewHolderFactoryEspressoTest {
       )
       .isEqualTo("22")
 
-    val responseValue = questionnaireItemViewItem.answers.first().valueQuantity
+    val responseValue = answerHolder!!.first().valueQuantity
     assertThat(responseValue.code).isEqualTo("months")
     assertThat(responseValue.system).isEqualTo("http://unitofmeasure.com")
     assertThat(responseValue.value).isEqualTo(BigDecimal(22))
@@ -89,12 +90,13 @@ class QuestionnaireItemEditTextQuantityViewHolderFactoryEspressoTest {
 
   @Test
   fun getValue_WithoutInitial_shouldReturn_Quantity_Without_UnitAndSystem() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { required = true },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     runOnUI { viewHolder.bind(questionnaireItemViewItem) }
 
@@ -105,7 +107,7 @@ class QuestionnaireItemEditTextQuantityViewHolderFactoryEspressoTest {
       )
       .isEqualTo("22")
 
-    val responseValue = questionnaireItemViewItem.answers.first().valueQuantity
+    val responseValue = answerHolder!!.first().valueQuantity
     assertThat(responseValue.code).isNull()
     assertThat(responseValue.system).isNull()
     assertThat(responseValue.value).isEqualTo(BigDecimal(22))

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemMultiSelectHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemMultiSelectHolderFactoryInstrumentedTest.kt
@@ -151,6 +151,7 @@ class QuestionnaireItemMultiSelectHolderFactoryInstrumentedTest {
 private fun answerOptions(vararg options: String) =
   Questionnaire.QuestionnaireItemComponent().apply {
     linkId = "1"
+    repeats = true
     options.forEach { option ->
       addAnswerOption(
         Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
@@ -121,11 +121,12 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
             setOnClickListener {
               when (isChecked) {
                 true -> {
-                  questionnaireItemViewItem.addAnswer(
+                  val newAnswers = questionnaireItemViewItem.answers.toMutableList()
+                  newAnswers +=
                     QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                       value = answerOption.value
                     }
-                  )
+
                   if (answerOption.optionExclusive) {
                     // if this answer option has optionExclusive extension, then deselect other
                     // answer options.
@@ -135,11 +136,7 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
                         continue
                       }
                       (checkboxGroup.getChildAt(i + 1) as CheckBox).isChecked = false
-                      questionnaireItemViewItem.removeAnswer(
-                        QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                          value = questionnaireItemViewItem.answerOption[i].value
-                        }
-                      )
+                      newAnswers.removeIf { it.value.equalsDeep(questionnaireItemViewItem.answerOption[i].value) }
                     }
                   } else {
                     // deselect optionExclusive answer option.
@@ -148,13 +145,10 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
                         continue
                       }
                       (checkboxGroup.getChildAt(i + 1) as CheckBox).isChecked = false
-                      questionnaireItemViewItem.removeAnswer(
-                        QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                          value = questionnaireItemViewItem.answerOption[i].value
-                        }
-                      )
+                      newAnswers.removeIf { it.value.equalsDeep(questionnaireItemViewItem.answerOption[i].value) }
                     }
                   }
+                  questionnaireItemViewItem.setAnswer(*newAnswers.toTypedArray())
                 }
                 false -> {
                   questionnaireItemViewItem.removeAnswer(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
@@ -71,8 +71,7 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
             flow.setWrapMode(Flow.WRAP_NONE)
           }
         }
-        questionnaireItemViewItem
-          .answerOption
+        questionnaireItemViewItem.answerOption
           .map { answerOption -> View.generateViewId() to answerOption }
           .onEach { populateViewWithAnswerOption(it.first, it.second, choiceOrientation) }
           .map { it.first }
@@ -81,7 +80,8 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
 
       override fun displayValidationResult(validationResult: ValidationResult) {
         when (validationResult) {
-          is NotValidated, Valid -> error.visibility = View.GONE
+          is NotValidated,
+          Valid -> error.visibility = View.GONE
           is Invalid -> {
             error.text = validationResult.getSingleStringValidationMessage()
             error.visibility = View.VISIBLE
@@ -136,7 +136,9 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
                         continue
                       }
                       (checkboxGroup.getChildAt(i + 1) as CheckBox).isChecked = false
-                      newAnswers.removeIf { it.value.equalsDeep(questionnaireItemViewItem.answerOption[i].value) }
+                      newAnswers.removeIf {
+                        it.value.equalsDeep(questionnaireItemViewItem.answerOption[i].value)
+                      }
                     }
                   } else {
                     // deselect optionExclusive answer option.
@@ -145,7 +147,9 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
                         continue
                       }
                       (checkboxGroup.getChildAt(i + 1) as CheckBox).isChecked = false
-                      newAnswers.removeIf { it.value.equalsDeep(questionnaireItemViewItem.answerOption[i].value) }
+                      newAnswers.removeIf {
+                        it.value.equalsDeep(questionnaireItemViewItem.answerOption[i].value)
+                      }
                     }
                   }
                   questionnaireItemViewItem.setAnswer(*newAnswers.toTypedArray())

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDialogSelectViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDialogSelectViewHolderFactory.kt
@@ -127,30 +127,22 @@ internal object QuestionnaireItemDialogSelectViewHolderFactory :
 
       private fun updateAnswers(selectedOptions: SelectedOptions) {
         questionnaireItemViewItem.clearAnswer()
+        var answers = arrayOf<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>()
         selectedOptions.options
           .filter { it.selected }
           .map { option ->
-            val answer =
+            answers +=
               QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                 value = option.item.value
               }
-            if (questionnaireItemViewItem.questionnaireItem.repeats) {
-              questionnaireItemViewItem.addAnswer(answer)
-            } else {
-              questionnaireItemViewItem.setAnswer(answer)
-            }
           }
         selectedOptions.otherOptions.map { otherOption ->
-          val otherAnswer =
+          answers +=
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
               value = StringType(otherOption)
             }
-          if (questionnaireItemViewItem.questionnaireItem.repeats) {
-            questionnaireItemViewItem.addAnswer(otherAnswer)
-          } else {
-            questionnaireItemViewItem.setAnswer(otherAnswer)
-          }
         }
+        questionnaireItemViewItem.setAnswer(*answers)
       }
     }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewHolderFactory.kt
@@ -60,9 +60,7 @@ open class QuestionnaireItemViewHolder(
     delegate.questionnaireItemViewItem = questionnaireItemViewItem
     delegate.bind(questionnaireItemViewItem)
     delegate.setReadOnly(questionnaireItemViewItem.questionnaireItem.readOnly)
-    delegate.questionnaireItemViewItem.validationResult?.let {
-      delegate.displayValidationResult(it)
-    }
+    delegate.displayValidationResult(questionnaireItemViewItem.validationResult)
   }
 }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
@@ -93,6 +93,7 @@ data class QuestionnaireItemViewItem(
   val answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent> =
     questionnaireResponseItem.answer.map { it.copy() }
 
+  /** Updates the answers. This will override any existing answers. */
   fun setAnswer(
     vararg questionnaireResponseItemAnswerComponent:
       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
@@ -107,11 +108,7 @@ data class QuestionnaireItemViewItem(
     )
   }
 
-  internal fun answerString(context: Context): String {
-    if (!questionnaireResponseItem.hasAnswer()) return context.getString(R.string.not_answered)
-    return questionnaireResponseItem.answer.joinToString { it.displayString(context) }
-  }
-
+  /** Adds an answer to the existing answers. */
   internal fun addAnswer(
     questionnaireResponseItemAnswerComponent:
       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
@@ -126,6 +123,7 @@ data class QuestionnaireItemViewItem(
     )
   }
 
+  /** Removes an answer from the existing answers. */
   internal fun removeAnswer(
     questionnaireResponseItemAnswerComponent:
       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
@@ -142,8 +140,14 @@ data class QuestionnaireItemViewItem(
     )
   }
 
+  /** Clears existing answers. */
   fun clearAnswer() {
     answersChangedCallback(questionnaireItem, questionnaireResponseItem, listOf())
+  }
+
+  internal fun answerString(context: Context): String {
+    if (!questionnaireResponseItem.hasAnswer()) return context.getString(R.string.not_answered)
+    return questionnaireResponseItem.answer.joinToString { it.displayString(context) }
   }
 
   fun isAnswerOptionSelected(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
@@ -90,9 +90,8 @@ data class QuestionnaireItemViewItem(
    * [QuestionnaireResponse.QuestionnaireResponseItemComponent] so that proper comparisons can be
    * carried out for the [RecyclerView.Adapter] to decide which items need to be updated.
    */
-  var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent> =
+  val answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent> =
     questionnaireResponseItem.answer.map { it.copy() }
-    private set
 
   fun setAnswer(
     questionnaireResponseItemAnswerComponent:
@@ -101,8 +100,7 @@ data class QuestionnaireItemViewItem(
     check(!questionnaireItem.repeats) {
       "Questionnaire item with linkId ${questionnaireItem.linkId} has repeated answers. Use addAnswer instead."
     }
-    answers = listOf(questionnaireResponseItemAnswerComponent)
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers)
+    answersChangedCallback(questionnaireItem, questionnaireResponseItem, listOf(questionnaireResponseItemAnswerComponent))
   }
 
   internal fun answerString(context: Context): String {
@@ -117,8 +115,7 @@ data class QuestionnaireItemViewItem(
     check(questionnaireItem.repeats) {
       "Questionnaire item with linkId ${questionnaireItem.linkId} does not allow repeated answers"
     }
-    answers += questionnaireResponseItemAnswerComponent
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers)
+    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers + questionnaireResponseItemAnswerComponent)
   }
 
   internal fun removeAnswer(
@@ -128,16 +125,13 @@ data class QuestionnaireItemViewItem(
     check(questionnaireItem.repeats) {
       "Questionnaire item with linkId ${questionnaireItem.linkId} does not allow repeated answers"
     }
-    answers =
-      answers.toMutableList().apply {
-        removeIf { it.value.equalsDeep(questionnaireResponseItemAnswerComponent.value) }
-      }
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers)
+    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers.toMutableList().apply {
+      removeIf { it.value.equalsDeep(questionnaireResponseItemAnswerComponent.value) }
+    })
   }
 
   fun clearAnswer() {
-    answers = listOf()
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers)
+    answersChangedCallback(questionnaireItem, questionnaireResponseItem, listOf())
   }
 
   fun isAnswerOptionSelected(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
@@ -94,13 +94,17 @@ data class QuestionnaireItemViewItem(
     questionnaireResponseItem.answer.map { it.copy() }
 
   fun setAnswer(
-    questionnaireResponseItemAnswerComponent:
+    vararg questionnaireResponseItemAnswerComponent:
       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
   ) {
-    check(!questionnaireItem.repeats) {
-      "Questionnaire item with linkId ${questionnaireItem.linkId} has repeated answers. Use addAnswer instead."
+    check(questionnaireItem.repeats || questionnaireResponseItemAnswerComponent.size <= 1) {
+      "Questionnaire item with linkId ${questionnaireItem.linkId} has repeated answers."
     }
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, listOf(questionnaireResponseItemAnswerComponent))
+    answersChangedCallback(
+      questionnaireItem,
+      questionnaireResponseItem,
+      questionnaireResponseItemAnswerComponent.toList()
+    )
   }
 
   internal fun answerString(context: Context): String {
@@ -115,7 +119,11 @@ data class QuestionnaireItemViewItem(
     check(questionnaireItem.repeats) {
       "Questionnaire item with linkId ${questionnaireItem.linkId} does not allow repeated answers"
     }
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers + questionnaireResponseItemAnswerComponent)
+    answersChangedCallback(
+      questionnaireItem,
+      questionnaireResponseItem,
+      answers + questionnaireResponseItemAnswerComponent
+    )
   }
 
   internal fun removeAnswer(
@@ -125,9 +133,13 @@ data class QuestionnaireItemViewItem(
     check(questionnaireItem.repeats) {
       "Questionnaire item with linkId ${questionnaireItem.linkId} does not allow repeated answers"
     }
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, answers.toMutableList().apply {
-      removeIf { it.value.equalsDeep(questionnaireResponseItemAnswerComponent.value) }
-    })
+    answersChangedCallback(
+      questionnaireItem,
+      questionnaireResponseItem,
+      answers.toMutableList().apply {
+        removeIf { it.value.equalsDeep(questionnaireResponseItemAnswerComponent.value) }
+      }
+    )
   }
 
   fun clearAnswer() {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItem.kt
@@ -36,10 +36,10 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse
  * render the data item in the UI. The view SHOULD NOT mutate the data using these properties.
  *
  * The view should use the following answer APIs to update the answer(s):
- * - [setAnswer] (for single answer only)
+ * - [setAnswer] (for single and repeated answers)
+ * - [clearAnswer] (for single and repeated answers)
  * - [addAnswer] (for repeated answers only)
  * - [removeAnswer] (for repeated answers only)
- * - [clearAnswer] (for both single and repated answers)
  *
  * Updates to the answers using these APIs will invoke [answersChangedCallback] to notify the view
  * model that the answer(s) have been changed. This will trigger a re-render of the [RecyclerView]
@@ -108,6 +108,11 @@ data class QuestionnaireItemViewItem(
     )
   }
 
+  /** Clears existing answers. */
+  fun clearAnswer() {
+    answersChangedCallback(questionnaireItem, questionnaireResponseItem, listOf())
+  }
+
   /** Adds an answer to the existing answers. */
   internal fun addAnswer(
     questionnaireResponseItemAnswerComponent:
@@ -138,11 +143,6 @@ data class QuestionnaireItemViewItem(
         removeIf { it.value.equalsDeep(questionnaireResponseItemAnswerComponent.value) }
       }
     )
-  }
-
-  /** Clears existing answers. */
-  fun clearAnswer() {
-    answersChangedCallback(questionnaireItem, questionnaireResponseItem, listOf())
   }
 
   internal fun answerString(context: Context): String {

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemAutoCompleteViewHolderFactoryTest.kt
@@ -37,7 +37,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
-class QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest {
+class QuestionnaireItemAutoCompleteViewHolderFactoryTest {
   private val parent =
     FrameLayout(
       RuntimeEnvironment.getApplication().apply { setTheme(R.style.Theme_Material3_DayNight) }
@@ -61,30 +61,34 @@ class QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest {
 
   @Test
   fun shouldHaveSingleAnswerChip() {
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        repeats = false
+        addAnswerOption(
+          Questionnaire.QuestionnaireItemAnswerOptionComponent()
+            .setValue(Coding().setCode("test1-code").setDisplay("Test1 Code"))
+        )
+        addAnswerOption(
+          Questionnaire.QuestionnaireItemAnswerOptionComponent()
+            .setValue(Coding().setCode("test2-code").setDisplay("Test2 Code"))
+        )
+      }
     viewHolder.bind(
       QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent().apply {
-            repeats = false
-            addAnswerOption(
-              Questionnaire.QuestionnaireItemAnswerOptionComponent()
-                .setValue(Coding().setCode("test1-code").setDisplay("Test1 Code"))
-            )
-            addAnswerOption(
-              Questionnaire.QuestionnaireItemAnswerOptionComponent()
-                .setValue(Coding().setCode("test2-code").setDisplay("Test2 Code"))
-            )
-          },
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
-        )
-        .apply {
-          setAnswer(
+        questionnaireItem,
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          addAnswer(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              value = answerOption.first { it.displayString == "Test1 Code" }.valueCoding
+              value =
+                questionnaireItem.answerOption
+                  .first { it.displayString == "Test1 Code" }
+                  .valueCoding
             }
           )
-        }
+        },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
     )
 
     assertThat(viewHolder.itemView.findViewById<ChipGroup>(R.id.chipContainer).childCount)
@@ -93,41 +97,44 @@ class QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest {
 
   @Test
   fun shouldHaveTwoAnswerChipWithExternalValueSet() {
+    val answers =
+      listOf(
+        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+          .setValue(Coding().setCode("test1-code").setDisplay("Test1 Code")),
+        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+          .setValue(Coding().setCode("test2-code").setDisplay("Test2 Code"))
+      )
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        repeats = true
+        answerValueSet = "http://answwer-value-set-url"
+      }
     viewHolder.bind(
       QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent().apply {
-            repeats = true
-            answerValueSet = "http://answwer-value-set-url"
-          },
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          resolveAnswerValueSet = {
-            if (it == "http://answwer-value-set-url") {
-              listOf(
-                Questionnaire.QuestionnaireItemAnswerOptionComponent()
-                  .setValue(Coding().setCode("test1-code").setDisplay("Test1 Code")),
-                Questionnaire.QuestionnaireItemAnswerOptionComponent()
-                  .setValue(Coding().setCode("test2-code").setDisplay("Test2 Code"))
-              )
-            } else {
-              emptyList()
-            }
-          },
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
-        )
-        .apply {
+        questionnaireItem,
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
           addAnswer(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              value = answerOption.first { it.displayString == "Test1 Code" }.valueCoding
+              value = answers.first { it.displayString == "Test1 Code" }.valueCoding
             }
           )
 
           addAnswer(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              value = answerOption.first { it.displayString == "Test2 Code" }.valueCoding
+              value = answers.first { it.displayString == "Test2 Code" }.valueCoding
             }
           )
-        }
+        },
+        resolveAnswerValueSet = {
+          if (it == "http://answwer-value-set-url") {
+            answers
+          } else {
+            emptyList()
+          }
+        },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
     )
 
     assertThat(viewHolder.itemView.findViewById<ChipGroup>(R.id.chipContainer).childCount)
@@ -136,35 +143,36 @@ class QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest {
 
   @Test
   fun shouldHaveSingleAnswerChipWithContainedAnswerValueSet() {
+    val answers =
+      listOf(
+        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+          .setValue(Coding().setCode("test1-code").setDisplay("Test1 Code")),
+        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+          .setValue(Coding().setCode("test2-code").setDisplay("Test2 Code"))
+      )
     viewHolder.bind(
       QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent().apply {
-            repeats = false
-            answerValueSet = "#ContainedValueSet"
-          },
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          resolveAnswerValueSet = {
-            if (it == "#ContainedValueSet") {
-              listOf(
-                Questionnaire.QuestionnaireItemAnswerOptionComponent()
-                  .setValue(Coding().setCode("test1-code").setDisplay("Test1 Code")),
-                Questionnaire.QuestionnaireItemAnswerOptionComponent()
-                  .setValue(Coding().setCode("test2-code").setDisplay("Test2 Code"))
-              )
-            } else {
-              emptyList()
-            }
-          },
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
-        )
-        .apply {
-          setAnswer(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          repeats = false
+          answerValueSet = "#ContainedValueSet"
+        },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          addAnswer(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              value = answerOption.first { it.displayString == "Test1 Code" }.valueCoding
+              value = answers.first { it.displayString == "Test1 Code" }.valueCoding
             }
           )
-        }
+        },
+        resolveAnswerValueSet = {
+          if (it == "#ContainedValueSet") {
+            answers
+          } else {
+            emptyList()
+          }
+        },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
     )
 
     assertThat(viewHolder.itemView.findViewById<ChipGroup>(R.id.chipContainer).childCount)
@@ -222,27 +230,29 @@ class QuestionnaireItemAutoCompleteViewHolderFactoryInstrumentedTest {
 
   @Test
   fun bind_readOnly_shouldDisableView() {
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        readOnly = true
+        addAnswerOption(
+          Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "readOnly" }
+          }
+        )
+      }
     viewHolder.bind(
       QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent().apply {
-            readOnly = true
-            addAnswerOption(
-              Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-                value = Coding().apply { display = "readOnly" }
-              }
-            )
-          },
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
-        )
-        .apply {
-          setAnswer(
+        questionnaireItem,
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          addAnswer(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              value = answerOption.first { it.displayString == "readOnly" }.valueCoding
+              value =
+                questionnaireItem.answerOption.first { it.displayString == "readOnly" }.valueCoding
             }
           )
-        }
+        },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
     )
 
     assertThat(viewHolder.itemView.findViewById<ChipGroup>(R.id.chipContainer)[0].isEnabled)

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryTest.kt
@@ -173,36 +173,39 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
 
   @Test
   fun click_shouldSetAnswerTrue() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView.findViewById<RadioButton>(R.id.yes_radio_button).performClick()
 
-    assertThat(questionnaireItemViewItem.answers.single().valueBooleanType.value).isTrue()
+    assertThat(answerHolder!!.single().valueBooleanType.value).isTrue()
   }
 
   @Test
   fun click_shouldSetAnswerFalse() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView.findViewById<RadioButton>(R.id.no_radio_button).performClick()
 
-    assertThat(questionnaireItemViewItem.answers.single().valueBooleanType.value).isFalse()
+    assertThat(answerHolder!!.single().valueBooleanType.value).isFalse()
   }
 
   @Test
   fun yesSelected_clickYes_shouldClearAnswer() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -214,12 +217,12 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
           )
         },
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView.findViewById<RadioButton>(R.id.yes_radio_button).performClick()
 
-    assertThat(questionnaireItemViewItem.answers).isEmpty()
+    assertThat(answerHolder).isEmpty()
   }
 
   @Test
@@ -248,6 +251,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
 
   @Test
   fun noSelected_clickNo_shouldClearAnswer() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -259,12 +263,12 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
           )
         },
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView.findViewById<RadioButton>(R.id.no_radio_button).performClick()
 
-    assertThat(questionnaireItemViewItem.answers).isEmpty()
+    assertThat(answerHolder).isEmpty()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryTest.kt
@@ -173,7 +173,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
 
   @Test
   fun click_shouldSetAnswerTrue() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -189,7 +189,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
 
   @Test
   fun click_shouldSetAnswerFalse() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -205,7 +205,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
 
   @Test
   fun yesSelected_clickYes_shouldClearAnswer() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -251,7 +251,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
 
   @Test
   fun noSelected_clickNo_shouldClearAnswer() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryTest.kt
@@ -202,7 +202,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
 
   @Test
   fun click_shouldAddQuestionnaireResponseItemAnswer() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -231,7 +231,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
 
   @Test
   fun optionExclusiveAnswerOption_click_deselectsOtherAnswerOptions() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -270,7 +270,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
 
   @Test
   fun answerOption_click_deselectsOptionExclusiveAnswerOption() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -310,7 +310,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
 
   @Test
   fun click_shouldRemoveQuestionnaireResponseItemAnswer() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryTest.kt
@@ -202,6 +202,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
 
   @Test
   fun click_shouldAddQuestionnaireResponseItemAnswer() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -218,18 +219,19 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     val checkBoxGroup = viewHolder.itemView.findViewById<ConstraintLayout>(R.id.checkbox_group)
     val checkBox = checkBoxGroup.getChildAt(1) as CheckBox
     checkBox.performClick()
 
-    assertThat(questionnaireItemViewItem.answers.single().valueCoding.display).isEqualTo("Coding 1")
+    assertThat(answerHolder!!.single().valueCoding.display).isEqualTo("Coding 1")
   }
 
   @Test
   fun optionExclusiveAnswerOption_click_deselectsOtherAnswerOptions() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -256,19 +258,19 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     val checkBoxGroup = viewHolder.itemView.findViewById<ConstraintLayout>(R.id.checkbox_group)
     (checkBoxGroup.getChildAt(2) as CheckBox).performClick()
     (checkBoxGroup.getChildAt(1) as CheckBox).performClick()
 
-    assertThat(questionnaireItemViewItem.answers.single().valueCoding.display)
-      .isEqualTo("display-1")
+    assertThat(answerHolder!!.single().valueCoding.display).isEqualTo("display-1")
   }
 
   @Test
   fun answerOption_click_deselectsOptionExclusiveAnswerOption() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -295,7 +297,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     viewHolder.bind(questionnaireItemViewItem)
@@ -303,12 +305,12 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
     (checkBoxGroup.getChildAt(1) as CheckBox).performClick()
     (checkBoxGroup.getChildAt(2) as CheckBox).performClick()
 
-    assertThat(questionnaireItemViewItem.answers.single().valueCoding.display)
-      .isEqualTo("display-2")
+    assertThat(answerHolder!!.single().valueCoding.display).isEqualTo("display-2")
   }
 
   @Test
   fun click_shouldRemoveQuestionnaireResponseItemAnswer() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -342,14 +344,14 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
           }
         },
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     val checkBoxGroup = viewHolder.itemView.findViewById<ConstraintLayout>(R.id.checkbox_group)
     val checkBox = checkBoxGroup.getChildAt(1) as CheckBox
     checkBox.performClick()
 
-    assertThat(questionnaireItemViewItem.answers).isEmpty()
+    assertThat(answerHolder).isEmpty()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
@@ -145,18 +145,19 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
   @Test
   fun `parse date text input in US locale`() {
     setLocale(Locale.US)
+    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val item =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
 
     viewHolder.bind(item)
     viewHolder.dateInputView.text = "11/19/2020"
 
-    val answer = item.answers.singleOrNull()?.value as DateType
+    val answer = answers!!.single().value as DateType
 
     assertThat(answer.day).isEqualTo(19)
     assertThat(answer.month).isEqualTo(10)
@@ -166,16 +167,17 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
   @Test
   fun `parse date text input in Japan locale`() {
     setLocale(Locale.JAPAN)
+    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val item =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
     viewHolder.bind(item)
     viewHolder.dateInputView.text = "2020/11/19"
-    val answer = item.answers.singleOrNull()?.value as DateType
+    val answer = answers!!.single()?.value as DateType
 
     assertThat(answer.day).isEqualTo(19)
     assertThat(answer.month).isEqualTo(10)
@@ -185,6 +187,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
   @Test
   fun `clear the answer if date input is invalid`() {
     setLocale(Locale.US)
+    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),
@@ -194,13 +197,12 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
               .setValue(DateType(2020, 10, 19))
           ),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
     viewHolder.bind(questionnaireItem)
 
     viewHolder.dateInputView.text = "11/19/"
-    val answer = questionnaireItem.answers.singleOrNull()?.value
-    assertThat(answer).isNull()
+    assertThat(answers!!).isEmpty()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
@@ -145,7 +145,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
   @Test
   fun `parse date text input in US locale`() {
     setLocale(Locale.US)
-    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val item =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),
@@ -167,7 +167,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
   @Test
   fun `parse date text input in Japan locale`() {
     setLocale(Locale.JAPAN)
-    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val item =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),
@@ -187,7 +187,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
   @Test
   fun `clear the answer if date input is invalid`() {
     setLocale(Locale.US)
-    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
@@ -99,7 +99,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
 
   @Test
   fun `parse date text input in US locale`() {
-    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val itemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -124,7 +124,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
   @Test
   fun `parse date text input in Japan locale`() {
     Locale.setDefault(Locale.JAPAN)
-    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val itemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -148,7 +148,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
 
   @Test
   fun `if date input is invalid then clear the answer`() {
-    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val itemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
@@ -99,6 +99,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
 
   @Test
   fun `parse date text input in US locale`() {
+    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val itemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -108,13 +109,13 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
               .setValue(DateTimeType(Date(2020 - 1900, 1, 5, 1, 30, 0)))
           ),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
     viewHolder.bind(itemViewItem)
 
     viewHolder.dateInputView.text = "11/19/2020"
 
-    val answer = itemViewItem.answers.singleOrNull()?.value as DateTimeType
+    val answer = answers!!.single().value as DateTimeType
     assertThat(answer.day).isEqualTo(19)
     assertThat(answer.month).isEqualTo(10)
     assertThat(answer.year).isEqualTo(2020)
@@ -123,6 +124,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
   @Test
   fun `parse date text input in Japan locale`() {
     Locale.setDefault(Locale.JAPAN)
+    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val itemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -132,13 +134,13 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
               .setValue(DateTimeType(Date(2020 - 1900, 1, 5, 1, 30, 0)))
           ),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
     viewHolder.bind(itemViewItem)
 
     viewHolder.dateInputView.text = "2020/11/19"
 
-    val answer = itemViewItem.answers.singleOrNull()?.value as DateTimeType
+    val answer = answers!!.single().value as DateTimeType
     assertThat(answer.day).isEqualTo(19)
     assertThat(answer.month).isEqualTo(10)
     assertThat(answer.year).isEqualTo(2020)
@@ -146,6 +148,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
 
   @Test
   fun `if date input is invalid then clear the answer`() {
+    var answers : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val itemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -155,12 +158,12 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
               .setValue(DateTimeType(Date(2020 - 1900, 1, 5, 1, 30, 0)))
           ),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
     viewHolder.bind(itemViewItem)
     viewHolder.dateInputView.text = "2020/11/"
 
-    assertThat(itemViewItem.answers.singleOrNull()).isNull()
+    assertThat(answers!!).isEmpty()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryTest.kt
@@ -199,6 +199,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryTest {
 
   @Test
   fun click_shouldSetQuestionnaireResponseItemAnswer() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -210,7 +211,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryTest {
         },
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView
@@ -218,7 +219,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryTest {
       .getChildAt(1)
       .performClick()
 
-    assertThat(questionnaireItemViewItem.answers.single().valueCoding.display).isEqualTo("Coding 1")
+    assertThat(answerHolder!!.single().valueCoding.display).isEqualTo("Coding 1")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryTest.kt
@@ -199,7 +199,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryTest {
 
   @Test
   fun click_shouldSetQuestionnaireResponseItemAnswer() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryTest.kt
@@ -108,7 +108,7 @@ class QuestionnaireItemSliderViewHolderFactoryTest {
 
   @Test
   fun shouldSetQuestionnaireResponseSliderAnswer() {
-    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryTest.kt
@@ -108,18 +108,19 @@ class QuestionnaireItemSliderViewHolderFactoryTest {
 
   @Test
   fun shouldSetQuestionnaireResponseSliderAnswer() {
+    var answerHolder : List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, answers -> answerHolder = answers },
       )
 
     viewHolder.bind(questionnaireItemViewItem)
     viewHolder.itemView.findViewById<Slider>(R.id.slider).value = 10.0F
 
-    assertThat(questionnaireItemViewItem.answers.single().valueIntegerType.value).isEqualTo(10)
+    assertThat(answerHolder!!.single().valueIntegerType.value).isEqualTo(10)
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItemTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemViewItemTest.kt
@@ -41,7 +41,7 @@ class QuestionnaireItemViewItemTest {
   private val context = ApplicationProvider.getApplicationContext<Application>()
 
   @Test
-  fun addAnswer_questionnaireItemDoesNotRepeat_shouldThrowIllegalArgument() {
+  fun `addAnswer() should throw exception if question does not allow repeated answers`() {
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { linkId = "a-question" },
@@ -69,7 +69,8 @@ class QuestionnaireItemViewItemTest {
   }
 
   @Test
-  fun addAnswer_questionnaireItemRepeats_shouldAddQuestionnaireResponseItemAnswerComponent() {
+  fun `addAnswer() should add answer to QuestionnaireResponseItem`() {
+    var answers = listOf<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>()
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -83,18 +84,18 @@ class QuestionnaireItemViewItemTest {
           )
         },
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
 
     questionnaireItemViewItem.addAnswer(
       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().setValue(BooleanType(true))
     )
 
-    assertThat(questionnaireItemViewItem.answers).hasSize(2)
+    assertThat(answers).hasSize(2)
   }
 
   @Test
-  fun removeAnswer_questionnaireItemDoesNotRepeat_shouldThrowIllegalArgument() {
+  fun `removeAnswer() should throw exception if question does not allow repeated answers`() {
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { linkId = "a-question" },
@@ -126,7 +127,8 @@ class QuestionnaireItemViewItemTest {
   }
 
   @Test
-  fun removeAnswer_questionnaireItemRepeats_shouldRemoveQuestionnaireResponseItemAnswerComponent() {
+  fun `removeAnswer() should remove answer from QuestionnaireResponseItem`() {
+    var answers = listOf<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>()
     val questionnaireItemViewItem =
       QuestionnaireItemViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -148,14 +150,14 @@ class QuestionnaireItemViewItemTest {
           )
         },
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _ -> },
+        answersChangedCallback = { _, _, result -> answers = result },
       )
 
     questionnaireItemViewItem.removeAnswer(
       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().setValue(BooleanType(false))
     )
 
-    assertThat(questionnaireItemViewItem.answers).hasSize(1)
+    assertThat(answers).hasSize(1)
   }
 
   @Test
@@ -298,17 +300,16 @@ class QuestionnaireItemViewItemTest {
     assertThat(
         QuestionnaireItemViewItem(
             Questionnaire.QuestionnaireItemComponent(),
-            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+              addAnswer(
+                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                  value = BooleanType(true)
+                }
+              )
+            },
             validationResult = NotValidated,
             answersChangedCallback = { _, _, _ -> }
           )
-          .apply {
-            setAnswer(
-              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                value = BooleanType(true)
-              }
-            )
-          }
           .hasTheSameAnswer(
             QuestionnaireItemViewItem(
               Questionnaire.QuestionnaireItemComponent(),
@@ -347,31 +348,29 @@ class QuestionnaireItemViewItemTest {
     assertThat(
         QuestionnaireItemViewItem(
             Questionnaire.QuestionnaireItemComponent(),
-            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+              addAnswer(
+                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                  value = BooleanType(true)
+                }
+              )
+            },
             validationResult = NotValidated,
             answersChangedCallback = { _, _, _ -> }
           )
-          .apply {
-            setAnswer(
-              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                value = BooleanType(true)
-              }
-            )
-          }
           .hasTheSameAnswer(
             QuestionnaireItemViewItem(
-                Questionnaire.QuestionnaireItemComponent(),
-                QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-                validationResult = NotValidated,
-                answersChangedCallback = { _, _, _ -> }
-              )
-              .apply {
-                setAnswer(
+              Questionnaire.QuestionnaireItemComponent(),
+              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+                addAnswer(
                   QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                     value = BooleanType(false)
                   }
                 )
-              }
+              },
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> }
+            )
           )
       )
       .isFalse()
@@ -389,18 +388,17 @@ class QuestionnaireItemViewItemTest {
           .apply { setAnswer(QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()) }
           .hasTheSameAnswer(
             QuestionnaireItemViewItem(
-                Questionnaire.QuestionnaireItemComponent(),
-                QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-                validationResult = NotValidated,
-                answersChangedCallback = { _, _, _ -> }
-              )
-              .apply {
-                setAnswer(
+              Questionnaire.QuestionnaireItemComponent(),
+              QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+                addAnswer(
                   QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                     value = BooleanType(false)
                   }
                 )
-              }
+              },
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> }
+            )
           )
       )
       .isFalse()
@@ -411,17 +409,16 @@ class QuestionnaireItemViewItemTest {
     assertThat(
         QuestionnaireItemViewItem(
             Questionnaire.QuestionnaireItemComponent(),
-            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+              addAnswer(
+                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                  value = BooleanType(true)
+                }
+              )
+            },
             validationResult = NotValidated,
             answersChangedCallback = { _, _, _ -> }
           )
-          .apply {
-            setAnswer(
-              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                value = BooleanType(true)
-              }
-            )
-          }
           .hasTheSameAnswer(
             QuestionnaireItemViewItem(
                 Questionnaire.QuestionnaireItemComponent(),


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1640 

**Description**
We should not be updating the answers in the questionnaire item view item. The questionnaire item view item should be a read-only model of what the UI should display. Update of the questionnaire item view item should be solely handled by the view model.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
