### PR TITLE
Fix for radio button getting unchecked after scroll (view recycled) in recycler view

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
@@ -56,16 +56,13 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
 
         when (questionnaireItemViewItem.answers.singleOrNull()?.valueBooleanType?.value) {
           true -> {
-            yesRadioButton.isChecked = true
-            noRadioButton.isChecked = false
+            radioGroup.check(yesRadioButton.id)
           }
           false -> {
-            yesRadioButton.isChecked = false
-            noRadioButton.isChecked = true
+            radioGroup.check(noRadioButton.id)
           }
           null -> {
-            yesRadioButton.isChecked = false
-            noRadioButton.isChecked = false
+            radioGroup.clearCheck()
           }
         }
 


### PR DESCRIPTION

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1683 

**Description**
1. Confirmed that the selected answer is not lost / overriden.
2. Setting checked state on `RadioButton` in `RadioGroup` is sometimes causing the `RadioButton` to not show appropriate state.
3. Fixed by setting state using  `RadioGroup`'s `check` api instead.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**
_Before the fix:_

[boolean_answer.webm](https://user-images.githubusercontent.com/18224849/198580038-6a09d520-fd69-4feb-826d-915833162215.webm)

_After the fix:_

[boolean_answer_fixed.webm](https://user-images.githubusercontent.com/18224849/198580132-47a6d27d-953e-472a-a35c-888665ef64ae.webm)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
