### PR TITLE
Show an error at the top for boolean, single and multiple choice view.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactory.kt
@@ -19,7 +19,6 @@ package com.google.android.fhir.datacapture.views
 import android.view.View
 import android.widget.RadioButton
 import android.widget.RadioGroup
-import android.widget.TextView
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.NotValidated
@@ -36,7 +35,6 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
       private lateinit var radioGroup: RadioGroup
       private lateinit var yesRadioButton: RadioButton
       private lateinit var noRadioButton: RadioButton
-      private lateinit var error: TextView
 
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
@@ -45,7 +43,6 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
         radioGroup = itemView.findViewById(R.id.radio_group)
         yesRadioButton = itemView.findViewById(R.id.yes_radio_button)
         noRadioButton = itemView.findViewById(R.id.no_radio_button)
-        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
@@ -100,10 +97,9 @@ internal object QuestionnaireItemBooleanTypePickerViewHolderFactory :
       override fun displayValidationResult(validationResult: ValidationResult) {
         when (validationResult) {
           is NotValidated,
-          Valid -> error.visibility = View.GONE
+          Valid -> header.showErrorText(isErrorTextVisible = false)
           is Invalid -> {
-            error.text = validationResult.getSingleStringValidationMessage()
-            error.visibility = View.VISIBLE
+            header.showErrorText(errorText = validationResult.getSingleStringValidationMessage())
           }
         }
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactory.kt
@@ -20,7 +20,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
-import android.widget.TextView
 import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.google.android.fhir.datacapture.ChoiceOrientationTypes
@@ -42,14 +41,12 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
       private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var checkboxGroup: ConstraintLayout
       private lateinit var flow: Flow
-      private lateinit var error: TextView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
         checkboxGroup = itemView.findViewById(R.id.checkbox_group)
         flow = itemView.findViewById(R.id.checkbox_flow)
-        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
@@ -81,10 +78,9 @@ internal object QuestionnaireItemCheckBoxGroupViewHolderFactory :
       override fun displayValidationResult(validationResult: ValidationResult) {
         when (validationResult) {
           is NotValidated,
-          Valid -> error.visibility = View.GONE
+          Valid -> header.showErrorText(isErrorTextVisible = false)
           is Invalid -> {
-            error.text = validationResult.getSingleStringValidationMessage()
-            error.visibility = View.VISIBLE
+            header.showErrorText(errorText = validationResult.getSingleStringValidationMessage())
           }
         }
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderView.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderView.kt
@@ -52,7 +52,12 @@ internal class QuestionnaireItemHeaderView(context: Context, attrs: AttributeSet
   private var prefix: TextView = findViewById(R.id.prefix)
   private var question: TextView = findViewById(R.id.question)
   private var hint: TextView = findViewById(R.id.hint)
+  private var errorTextView: TextView = findViewById(R.id.error_text_at_header)
 
+  /**
+   * Shows error in the header,and widgets could either use this, or use another view (i.e.
+   * TextInputLayout's error field) to display error.
+   */
   fun bind(questionnaireItem: Questionnaire.QuestionnaireItemComponent) {
     prefix.updateTextAndVisibility(questionnaireItem.localizedPrefixSpanned)
     updateQuestionText(question, questionnaireItem)
@@ -61,6 +66,19 @@ internal class QuestionnaireItemHeaderView(context: Context, attrs: AttributeSet
     //   Make the entire view GONE if there is nothing to show. This is to avoid an empty row in the
     // questionnaire.
     visibility = getViewGroupVisibility(prefix, question, hint)
+  }
+
+  fun showErrorText(errorText: String? = null, isErrorTextVisible: Boolean = true) {
+    errorTextView.visibility =
+      when (isErrorTextVisible) {
+        true -> {
+          VISIBLE
+        }
+        false -> {
+          GONE
+        }
+      }
+    errorTextView.text = errorText
   }
 }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactory.kt
@@ -20,7 +20,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioButton
-import android.widget.TextView
 import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.children
@@ -42,14 +41,12 @@ internal object QuestionnaireItemRadioGroupViewHolderFactory :
       private lateinit var header: QuestionnaireItemHeaderView
       private lateinit var radioGroup: ConstraintLayout
       private lateinit var flow: Flow
-      private lateinit var error: TextView
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
         radioGroup = itemView.findViewById(R.id.radio_group)
         flow = itemView.findViewById(R.id.flow)
-        error = itemView.findViewById(R.id.error)
       }
 
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
@@ -79,10 +76,9 @@ internal object QuestionnaireItemRadioGroupViewHolderFactory :
       override fun displayValidationResult(validationResult: ValidationResult) {
         when (validationResult) {
           is NotValidated,
-          Valid -> error.visibility = View.GONE
+          Valid -> header.showErrorText(isErrorTextVisible = false)
           is Invalid -> {
-            error.text = validationResult.getSingleStringValidationMessage()
-            error.visibility = View.VISIBLE
+            header.showErrorText(errorText = validationResult.getSingleStringValidationMessage())
           }
         }
       }

--- a/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_boolean_type_picker_view.xml
@@ -54,6 +54,4 @@
         />
     </RadioGroup>
 
-    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
-
 </LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_checkbox_group_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_checkbox_group_view.xml
@@ -52,6 +52,5 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
 
 </LinearLayout>

--- a/datacapture/src/main/res/layout/questionnaire_item_header.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_header.xml
@@ -38,7 +38,7 @@
         app:layout_constraintStart_toStartOf="parent"
     >
 
-    <TextView
+        <TextView
             android:id="@+id/hint"
             style="?attr/questionnaireSubtitleTextStyle"
             android:layout_width="wrap_content"
@@ -58,6 +58,17 @@
             app:icon="@drawable/ic_help_48px"
         />
     </LinearLayout>
+    <TextView
+        android:id="@+id/error_text_at_header"
+        style="?attr/questionnaireErrorTextStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/instructions_top_margin"
+        android:layout_gravity="center_vertical"
+        app:layout_constraintTop_toBottomOf="@id/helpContainer"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="Sample error text"
+    />
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/helpCardView"
@@ -75,7 +86,7 @@
             android:background="?attr/colorSurfaceVariant"
             android:orientation="vertical"
         >
-        <TextView
+            <TextView
                 style="?attr/questionnaireHelpHeaderStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/datacapture/src/main/res/layout/questionnaire_item_radio_group_view.xml
+++ b/datacapture/src/main/res/layout/questionnaire_item_radio_group_view.xml
@@ -52,6 +52,5 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <include android:id="@+id/error" layout="@layout/input_error_text_view" />
 
 </LinearLayout>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemBooleanTypePickerViewHolderFactoryTest.kt
@@ -306,7 +306,7 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_at_header).text)
       .isEqualTo("Missing answer for required field.")
   }
 
@@ -327,7 +327,8 @@ class QuestionnaireItemBooleanTypePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text).isEqualTo("")
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_at_header).text)
+      .isEqualTo("")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemCheckBoxGroupViewHolderFactoryTest.kt
@@ -368,7 +368,7 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_at_header).text)
       .isEqualTo("Missing answer for required field.")
   }
 
@@ -397,7 +397,8 @@ class QuestionnaireItemCheckBoxGroupViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.isEmpty()).isTrue()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_at_header).text.isEmpty())
+      .isTrue()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderViewTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemHeaderViewTest.kt
@@ -272,6 +272,22 @@ class QuestionnaireItemHeaderViewTest {
       .isEqualTo(view.context.applicationContext.resources.getString(R.string.space_asterisk))
   }
 
+  @Test
+  fun `shows error text`() {
+    view.showErrorText("missing answer for required field")
+    assertThat(view.findViewById<TextView>(R.id.error_text_at_header).text.toString())
+      .isEqualTo("missing answer for required field")
+    assertThat(view.findViewById<TextView>(R.id.error_text_at_header).visibility)
+      .isEqualTo(View.VISIBLE)
+  }
+
+  @Test
+  fun `hides error text`() {
+    view.showErrorText(isErrorTextVisible = false)
+    assertThat(view.findViewById<TextView>(R.id.error_text_at_header).visibility)
+      .isEqualTo(View.GONE)
+  }
+
   private val displayCategoryExtensionWithInstructionsCode =
     Extension().apply {
       url = EXTENSION_DISPLAY_CATEGORY_URL

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemRadioGroupViewHolderFactoryTest.kt
@@ -379,7 +379,7 @@ class QuestionnaireItemRadioGroupViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text)
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_at_header).text)
       .isEqualTo("Missing answer for required field.")
   }
 
@@ -407,7 +407,8 @@ class QuestionnaireItemRadioGroupViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error).text.isEmpty()).isTrue()
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_at_header).text.isEmpty())
+      .isTrue()
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1586

**Description**
Show an error text at the top for view Single choice, Boolean choice, Multiple choice.


**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).