### PR TITLE
Append build id to artifact version when built via GH Actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,23 +37,3 @@ subprojects {
     }
   }
 }
-
-// Create a CI repository and also change versions to include the build number
-afterEvaluate {
-  val buildNumber = System.getenv("GITHUB_RUN_ID")
-  if (buildNumber != null) {
-    subprojects {
-      apply(plugin = Plugins.BuildPlugins.mavenPublish)
-      configure<PublishingExtension> {
-        repositories {
-          maven {
-            name = "CI"
-            url = uri("file://${rootProject.buildDir}/ci-repo")
-          }
-        }
-        // update version to have suffix of build id
-        project.version = "${project.version}-build_$buildNumber"
-      }
-    }
-  }
-}

--- a/buildSrc/src/main/kotlin/Releases.kt
+++ b/buildSrc/src/main/kotlin/Releases.kt
@@ -15,6 +15,7 @@
  */
 
 import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.configure
@@ -88,7 +89,7 @@ object Releases {
 
 fun Project.publishArtifact(artifact: LibraryArtifact) {
   afterEvaluate {
-    configure<org.gradle.api.publish.PublishingExtension> {
+    configure<PublishingExtension> {
       publications {
         register("release", MavenPublication::class) {
           from(components["release"])
@@ -112,6 +113,19 @@ fun Project.publishArtifact(artifact: LibraryArtifact) {
                 name.set("The Apache License, Version 2.0")
                 url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
               }
+            }
+          }
+          repositories {
+            maven {
+              name = "CI"
+              url = uri("file://${rootProject.buildDir}/ci-repo")
+              version =
+                if (project.providers.environmentVariable("GITHUB_ACTIONS").isPresent) {
+                  val buildNumber = System.getenv("GITHUB_RUN_ID")
+                  "${artifact.version}-build_$buildNumber"
+                } else {
+                  artifact.version
+                }
             }
           }
         }

--- a/buildSrc/src/main/kotlin/Releases.kt
+++ b/buildSrc/src/main/kotlin/Releases.kt
@@ -121,8 +121,7 @@ fun Project.publishArtifact(artifact: LibraryArtifact) {
               url = uri("file://${rootProject.buildDir}/ci-repo")
               version =
                 if (project.providers.environmentVariable("GITHUB_ACTIONS").isPresent) {
-                  val buildNumber = System.getenv("GITHUB_RUN_ID")
-                  "${artifact.version}-build_$buildNumber"
+                  "${artifact.version}-build_${System.getenv("GITHUB_RUN_ID")}"
                 } else {
                   artifact.version
                 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1701 

**Description**
Remove the need for two `afterEvaluate` blocks as one was giving precedence over another, stopping the appending of the build id to the artifacts.

This fix allows developers to follow:
https://github.com/google/android-fhir/wiki/Contributing#use-unreleased-github-build-for-developmenttesting-only

es? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (**Bug fix** | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
