### PR TITLE
Remove need for R4 package constant

### DIFF
--- a/buildSrc/src/main/kotlin/codegen/SearchParameterRepositoryGenerator.kt
+++ b/buildSrc/src/main/kotlin/codegen/SearchParameterRepositoryGenerator.kt
@@ -28,6 +28,7 @@ import kotlin.collections.HashMap
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.Enumerations
 import org.hl7.fhir.r4.model.Resource
+import org.hl7.fhir.r4.model.ResourceType
 import org.hl7.fhir.r4.model.SearchParameter
 
 /**
@@ -88,13 +89,13 @@ internal object SearchParameterRepositoryGenerator {
 
     val getSearchParamListFunction =
       FunSpec.builder("getSearchParamList")
-        .addParameter("resource", Resource::class)
+        .addParameter("resourceType", ResourceType::class)
         .returns(
           ClassName("kotlin.collections", "List").parameterizedBy(searchParamDefinitionClass)
         )
         .addModifiers(KModifier.INTERNAL)
         .addKdoc(generatedComment)
-        .beginControlFlow("return when (resource.fhirType())")
+        .beginControlFlow("return when (resourceType.name)")
 
     // Helper function used in SearchParameterRepositoryGeneratedTest
     val testHelperFunctionCodeBlock =
@@ -175,8 +176,7 @@ internal object SearchParameterRepositoryGenerator {
     return if (searchParam.base.size == 1) {
       mapOf(searchParam.base.single().valueAsString to searchParam.expression)
     } else {
-      searchParam
-        .expression
+      searchParam.expression
         .split("|")
         .groupBy { splitString -> splitString.split(".").first().trim().removePrefix("(") }
         .mapValues { it.value.joinToString(" | ") { join -> join.trim() } }

--- a/engine/src/main/java/com/google/android/fhir/MoreResources.kt
+++ b/engine/src/main/java/com/google/android/fhir/MoreResources.kt
@@ -20,9 +20,6 @@ import java.lang.reflect.InvocationTargetException
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
 
-/** The HAPI Fhir package prefix for R4 resources. */
-internal const val R4_RESOURCE_PACKAGE_PREFIX = "org.hl7.fhir.r4.model."
-
 /**
  * Returns the FHIR resource type.
  *
@@ -43,18 +40,18 @@ fun <R : Resource> getResourceType(clazz: Class<R>): ResourceType {
 }
 
 /** Returns the {@link Class} object for the resource type. */
-fun <R : Resource> getResourceClass(resourceType: ResourceType): Class<R> =
+inline fun <reified R : Resource> getResourceClass(resourceType: ResourceType): Class<R> =
   getResourceClass(resourceType.name)
 
 /** Returns the {@link Class} object for the resource type. */
-fun <R : Resource> getResourceClass(resourceType: String): Class<R> {
+inline fun <reified R : Resource> getResourceClass(resourceType: String): Class<R> {
   // Remove any curly brackets in the resource type string. This is to work around an issue with
   // JSON deserialization in the CQL engine on Android. The resource type string incorrectly
   // includes namespace prefix in curly brackets, e.g. "{http://hl7.org/fhir}Patient" instead of
   // "Patient".
   // TODO: remove this once a fix has been found for the CQL engine on Android.
   val className = resourceType.replace(Regex("\\{[^}]*\\}"), "")
-  return Class.forName(R4_RESOURCE_PACKAGE_PREFIX + className) as Class<R>
+  return Class.forName(R::class.java.`package`?.name + "." + className) as Class<R>
 }
 
 internal val Resource.versionId

--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -72,7 +72,7 @@ internal object ResourceIndexer {
 
   private fun <R : Resource> extractIndexValues(resource: R): ResourceIndices {
     val indexBuilder = ResourceIndices.Builder(resource.resourceType, resource.logicalId)
-    getSearchParamList(resource)
+    getSearchParamList(resource.resourceType)
       .map { it to fhirPathEngine.evaluate(resource, it.path) }
       .flatMap { pair -> pair.second.map { pair.first to it } }
       .forEach { pair ->

--- a/engine/src/main/java/com/google/android/fhir/search/query/XFhirQueryTranslator.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/query/XFhirQueryTranslator.kt
@@ -23,7 +23,6 @@ import ca.uhn.fhir.rest.gclient.ReferenceClientParam
 import ca.uhn.fhir.rest.gclient.StringClientParam
 import ca.uhn.fhir.rest.gclient.TokenClientParam
 import ca.uhn.fhir.rest.gclient.UriClientParam
-import com.google.android.fhir.getResourceClass
 import com.google.android.fhir.index.SearchParamDefinition
 import com.google.android.fhir.index.getSearchParamList
 import com.google.android.fhir.isValidDateOnly
@@ -36,7 +35,6 @@ import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.DateType
 import org.hl7.fhir.r4.model.Enumerations
 import org.hl7.fhir.r4.model.Quantity
-import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
 
 /**
@@ -174,9 +172,6 @@ object XFhirQueryTranslator {
         throw UnsupportedOperationException("${param.type} sort not supported in x-fhir-query")
     }
 
-  private val ResourceType.resourceSearchParameters
-    get() = getSearchParamList(getResourceClass<Resource>(this).newInstance())
-
   /** Parse string key-val map to SearchParamDefinition-Value map */
   private fun Map<String, String>.toSearchParamDefinitionValueMap(
     type: ResourceType
@@ -189,7 +184,7 @@ object XFhirQueryTranslator {
 
   /** Parse param to SearchParamDefinition for given resourceType */
   private fun String.toSearchParamDefinition(resourceType: ResourceType) =
-    resourceType.resourceSearchParameters.find { it.name == this }
+    getSearchParamList(resourceType).find { it.name == this }
       ?: throw IllegalArgumentException("$this not found in ${resourceType.name}")
 
   /**

--- a/engine/src/test/java/com/google/android/fhir/index/SearchParameterRepositoryGeneratedTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/SearchParameterRepositoryGeneratedTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,12 @@ import org.junit.runners.Parameterized
 class SearchParameterRepositoryGeneratedTest(private val resource: Resource) {
   @Test
   fun testResources() {
-    assertThat(getSearchParamList(resource))
+    assertThat(getSearchParamList(resource.resourceType))
       .containsExactlyElementsIn(getSearchParamListReflection(resource))
   }
 
   private fun getSearchParamListReflection(resource: Resource): MutableList<SearchParamDefinition> {
-    return resource
-      .javaClass
-      .fields
+    return resource.javaClass.fields
       .asSequence()
       .mapNotNull {
         it.getAnnotation(ca.uhn.fhir.model.api.annotation.SearchParamDefinition::class.java)


### PR DESCRIPTION

**Description**
Remove need for R4 package constant


**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | **Code health** | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
