### PR TITLE
Add compound Fhir Evaluator Api to let FhirOperator support multiple sources

### DIFF
--- a/workflow/src/androidTest/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateTest.kt
+++ b/workflow/src/androidTest/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ class FhirOperatorLibraryEvaluateTest {
 
   private lateinit var fhirEngine: FhirEngine
   private lateinit var fhirOperator: FhirOperator
+  private lateinit var fhirEngineApiProvider: FhirEngineApiProvider
 
   private val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
   private val jsonParser = fhirContext.newJsonParser()
@@ -55,7 +56,8 @@ class FhirOperatorLibraryEvaluateTest {
   @Before
   fun setUp() = runBlocking {
     fhirEngine = FhirEngineProvider.getInstance(ApplicationProvider.getApplicationContext())
-    fhirOperator = FhirOperator(fhirContext, fhirEngine)
+    fhirEngineApiProvider = FhirEngineApiProvider(fhirContext, fhirEngine)
+    fhirOperator = FhirOperator(fhirContext, fhirEngineApiProvider)
   }
 
   /**
@@ -101,7 +103,7 @@ class FhirOperatorLibraryEvaluateTest {
     }
 
     // Load Library that checks if Patient has taken a vaccine
-    fhirOperator.loadLibs(load("/immunity-check/ImmunityCheck.json"))
+    fhirEngineApiProvider.loadLibs(load("/immunity-check/ImmunityCheck.json"))
 
     // Evaluates a specific Patient
     val results =
@@ -109,8 +111,7 @@ class FhirOperatorLibraryEvaluateTest {
         "http://localhost/Library/ImmunityCheck|1.0.0",
         "d4d35004-24f8-40e4-8084-1ad75924514f",
         setOf("CompletedImmunization")
-      ) as
-        Parameters
+      ) as Parameters
 
     assertThat(results.getParameterBool("CompletedImmunization")).isTrue()
   }

--- a/workflow/src/main/java/com/google/android/fhir/workflow/CompoundFhirDal.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/CompoundFhirDal.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.workflow
+
+import org.hl7.fhir.instance.model.api.IBaseResource
+import org.hl7.fhir.instance.model.api.IIdType
+import org.opencds.cqf.cql.evaluator.fhir.dal.FhirDal
+
+class CompoundFhirDal(private val providers: List<FhirDal>) : FhirDal {
+  override fun read(id: IIdType): IBaseResource? = providers.firstNotNullOfOrNull { it.read(id) }
+
+  // TODO: inserting to the first provider. Is it correct?
+  override fun create(resource: IBaseResource) = providers.first().create(resource)
+
+  override fun update(resource: IBaseResource) = providers.first().update(resource)
+
+  override fun delete(id: IIdType) = providers.first().delete(id)
+
+  override fun search(resourceType: String): Iterable<IBaseResource> =
+    providers.flatMap { it.search(resourceType) }
+
+  override fun searchByUrl(resourceType: String, url: String): Iterable<IBaseResource> =
+    providers.flatMap { it.searchByUrl(resourceType, url) }
+}

--- a/workflow/src/main/java/com/google/android/fhir/workflow/CompoundLibraryContentProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/CompoundLibraryContentProvider.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.workflow
+
+import java.io.InputStream
+import org.cqframework.cql.cql2elm.LibrarySourceProvider
+import org.hl7.elm.r1.VersionedIdentifier
+
+class CompoundLibraryContentProvider(private val providers: List<LibrarySourceProvider>) :
+  LibrarySourceProvider {
+
+  override fun getLibrarySource(libraryIdentifier: VersionedIdentifier): InputStream? =
+    providers.firstNotNullOfOrNull { it.getLibrarySource(libraryIdentifier) }
+}

--- a/workflow/src/main/java/com/google/android/fhir/workflow/CompoundRetrieveProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/CompoundRetrieveProvider.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.workflow
+
+import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider
+import org.opencds.cqf.cql.engine.runtime.Code
+import org.opencds.cqf.cql.engine.runtime.Interval
+
+class CompoundRetrieveProvider(private val providers: List<RetrieveProvider>) : RetrieveProvider {
+  override fun retrieve(
+    context: String?,
+    contextPath: String?,
+    contextValue: Any?,
+    dataType: String?,
+    templateId: String?,
+    codePath: String?,
+    codes: MutableIterable<Code>?,
+    valueSet: String?,
+    datePath: String?,
+    dateLowPath: String?,
+    dateHighPath: String?,
+    dateRange: Interval?,
+  ): Iterable<Any> =
+    providers.flatMap {
+      it.retrieve(
+        context,
+        contextPath,
+        contextValue,
+        dataType,
+        templateId,
+        codePath,
+        codes,
+        valueSet,
+        datePath,
+        dateLowPath,
+        dateHighPath,
+        dateRange
+      )
+    }
+}

--- a/workflow/src/main/java/com/google/android/fhir/workflow/CompoundTerminologyProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/CompoundTerminologyProvider.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.workflow
+
+import org.opencds.cqf.cql.engine.exception.TerminologyProviderException
+import org.opencds.cqf.cql.engine.runtime.Code
+import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo
+
+class CompoundTerminologyProvider(private val providers: List<TerminologyProvider>) :
+  TerminologyProvider {
+
+  // TODO: should the `in` be isolated?
+  override fun `in`(code: Code, valueSet: ValueSetInfo): Boolean {
+    try {
+      return expand(valueSet).any { it.code == code.code && it.system == code.system }
+    } catch (e: Exception) {
+      throw TerminologyProviderException(
+        "Error performing membership check of Code: $code in ValueSet: ${valueSet.id}",
+        e
+      )
+    }
+  }
+
+  override fun expand(valueSet: ValueSetInfo): Iterable<Code> =
+    providers.flatMap { it.expand(valueSet) }
+
+  override fun lookup(code: Code, codeSystem: CodeSystemInfo): Code =
+    providers.firstNotNullOf {
+      try {
+        it.lookup(code, codeSystem)
+      } catch (e: TerminologyProviderException) {
+        null
+      }
+    }
+}

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineApiProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineApiProvider.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.workflow
+
+import ca.uhn.fhir.context.FhirContext
+import com.google.android.fhir.FhirEngine
+import org.cqframework.cql.cql2elm.LibrarySourceProvider
+import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.Library
+import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider
+import org.opencds.cqf.cql.evaluator.fhir.adapter.r4.AdapterFactory
+import org.opencds.cqf.cql.evaluator.fhir.dal.FhirDal
+
+class FhirEngineApiProvider(fhirContext: FhirContext, fhirEngine: FhirEngine) :
+  WorkflowApiProvider {
+
+  private val fhirEngineTerminologyProvider = FhirEngineTerminologyProvider(fhirContext, fhirEngine)
+  private val libraryContentProvider = FhirEngineLibraryContentProvider(AdapterFactory())
+  private val fhirEngineRetrieveProvider =
+    FhirEngineRetrieveProvider(fhirEngine).apply {
+      terminologyProvider = fhirEngineTerminologyProvider
+      isExpandValueSets = true
+    }
+
+  private val fhirEngineDal = FhirEngineDal(fhirEngine)
+
+  override fun fhirDal(): FhirDal = fhirEngineDal
+
+  override fun terminologyProvider(): TerminologyProvider = fhirEngineTerminologyProvider
+
+  override fun libraryContentProvider(): LibrarySourceProvider = libraryContentProvider
+
+  override fun retrieveProvider(): RetrieveProvider = fhirEngineRetrieveProvider
+
+  fun loadLib(lib: Library) {
+    if (lib.url != null) {
+      fhirEngineDal.libs[lib.url] = lib
+    }
+    if (lib.name != null) {
+      libraryContentProvider.libs[lib.name] = lib
+    }
+  }
+
+  fun loadLibs(libBundle: Bundle) {
+    for (entry in libBundle.entry) {
+      loadLib(entry.resource as Library)
+    }
+  }
+}

--- a/workflow/src/main/java/com/google/android/fhir/workflow/WorkflowApiProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/WorkflowApiProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.workflow
+
+import org.cqframework.cql.cql2elm.LibrarySourceProvider
+import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider
+import org.opencds.cqf.cql.evaluator.fhir.dal.FhirDal
+
+interface WorkflowApiProvider {
+  fun fhirDal(): FhirDal
+  fun terminologyProvider(): TerminologyProvider
+  fun libraryContentProvider(): LibrarySourceProvider
+  fun retrieveProvider(): RetrieveProvider
+}

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateJavaTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateJavaTest.kt
@@ -40,6 +40,7 @@ class FhirOperatorLibraryEvaluateJavaTest {
 
   private lateinit var fhirEngine: FhirEngine
   private lateinit var fhirOperator: FhirOperator
+  private lateinit var fhirEngineApiProvider: FhirEngineApiProvider
 
   private val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
   private val jsonParser = fhirContext.newJsonParser()
@@ -55,7 +56,8 @@ class FhirOperatorLibraryEvaluateJavaTest {
   @Before
   fun setUp() = runBlocking {
     fhirEngine = FhirEngineProvider.getInstance(ApplicationProvider.getApplicationContext())
-    fhirOperator = FhirOperator(fhirContext, fhirEngine)
+    fhirEngineApiProvider = FhirEngineApiProvider(fhirContext, fhirEngine)
+    fhirOperator = FhirOperator(fhirContext, fhirEngineApiProvider)
   }
 
   /**
@@ -101,7 +103,7 @@ class FhirOperatorLibraryEvaluateJavaTest {
     }
 
     // Load Library that checks if Patient has taken a vaccine
-    fhirOperator.loadLibs(load("/immunity-check/ImmunityCheck.json"))
+    fhirEngineApiProvider.loadLibs(load("/immunity-check/ImmunityCheck.json"))
 
     // Evaluates a specific Patient
     val results =

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
@@ -46,6 +46,7 @@ class FhirOperatorTest {
 
   private lateinit var fhirEngine: FhirEngine
   private lateinit var fhirOperator: FhirOperator
+  private lateinit var fhirEngineApiProvider: FhirEngineApiProvider
 
   companion object {
     private val libraryBundle: Bundle by lazy { parseJson("/ANCIND01-bundle.json") }
@@ -66,7 +67,9 @@ class FhirOperatorTest {
   @Before
   fun setUp() = runBlocking {
     fhirEngine = FhirEngineProvider.getInstance(ApplicationProvider.getApplicationContext())
-    fhirOperator = FhirOperator(fhirContext, fhirEngine)
+    fhirEngineApiProvider = FhirEngineApiProvider(fhirContext, fhirEngine)
+    fhirOperator = FhirOperator(fhirContext, fhirEngineApiProvider)
+
     TimeZone.setDefault(TimeZone.getTimeZone("GMT"))
   }
 
@@ -202,7 +205,7 @@ class FhirOperatorTest {
   private suspend fun loadBundle(bundle: Bundle) {
     for (entry in bundle.entry) {
       when (entry.resource.resourceType) {
-        ResourceType.Library -> fhirOperator.loadLib(entry.resource as Library)
+        ResourceType.Library -> fhirEngineApiProvider.loadLib(entry.resource as Library)
         ResourceType.Bundle -> Unit
         else -> fhirEngine.create(entry.resource)
       }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Issue #1729

**Description**
Prework for integrating implementation guide module to the workflow module. Introduce FHIR Engine API implementation that allow to add multiple data sources to the FHIR Operator. In the future, the ImplementationGuide  module will become a second source for libraries and value sets. 

**Alternative(s) considered**


**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
