### PR TITLE
Add db layer for storing metadata for Ig library

### DIFF
--- a/implementationguide/build.gradle.kts
+++ b/implementationguide/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id(Plugins.BuildPlugins.androidLib)
   id(Plugins.BuildPlugins.kotlinAndroid)
+  id(Plugins.BuildPlugins.kotlinKapt)
   id(Plugins.BuildPlugins.mavenPublish)
   jacoco
 }
@@ -51,6 +52,7 @@ android {
         "META-INF/NOTICE.md",
         "META-INF/notice.txt",
         "META-INF/LGPL-3.0.txt",
+        "META-INF/sun-jaxb.episode",
       )
     )
   }
@@ -60,6 +62,30 @@ android {
   configureJacocoTestOptions()
 }
 
-dependencies { coreLibraryDesugaring(Dependencies.desugarJdkLibs) }
+configurations {
+  all {
+    exclude(module = "xpp3")
+    exclude(module = "xpp3_min")
+  }
+}
+
+dependencies {
+  coreLibraryDesugaring(Dependencies.desugarJdkLibs)
+  kapt(Dependencies.Room.compiler)
+
+  androidTestImplementation(Dependencies.AndroidxTest.core)
+  androidTestImplementation(Dependencies.AndroidxTest.runner)
+  androidTestImplementation(Dependencies.AndroidxTest.extJunitKtx)
+  androidTestImplementation(Dependencies.Kotlin.kotlinCoroutinesTest)
+  androidTestImplementation(Dependencies.junit)
+  androidTestImplementation(Dependencies.truth)
+
+  api(Dependencies.HapiFhir.structuresR4) { exclude(module = "junit") }
+
+  implementation(Dependencies.Kotlin.stdlib)
+  implementation(Dependencies.Room.ktx)
+  implementation(Dependencies.Room.runtime)
+  implementation(Dependencies.timber)
+}
 
 configureDokka(Releases.ImplmentationGuide.artifactId, Releases.ImplmentationGuide.version)

--- a/implementationguide/src/androidTest/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabaseTest.kt
+++ b/implementationguide/src/androidTest/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabaseTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.implementationguide.db.impl
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
+import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.hl7.fhir.r4.model.ResourceType
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class ImplementationGuideDatabaseTest {
+
+  private val context: Context = ApplicationProvider.getApplicationContext()
+  private val igDb =
+    Room.inMemoryDatabaseBuilder(context, ImplementationGuideDatabase::class.java).build()
+  private val igDao = igDb.implementationGuideDao()
+
+  @After
+  fun tearDownDb() {
+    igDb.close()
+  }
+
+  @Test
+  fun igInserted(): Unit = runBlocking {
+    assertThat(igDao.insert(IG_ENTITY)).isGreaterThan(0)
+    assertThat(igDao.getImplementationGuides().map { it.name }).containsExactly(IG_NAME)
+  }
+
+  @Test
+  fun resourcesInserted() = runBlocking {
+    val igId = igDao.insert(IG_ENTITY)
+    val resourceEntity =
+      ResourceEntity(
+        0L,
+        ResourceType.ValueSet,
+        RES_ID_1,
+        "http://url.com/ValueSet/Name/1.0.0",
+        RES_NAME,
+        "1.0.0",
+        File("resId"),
+        igId
+      )
+
+    igDao.insert(resourceEntity)
+
+    assertThat(igDao.getResources(ResourceType.ValueSet, listOf(igId)).map { it.resourceId })
+      .containsExactly(RES_ID_1)
+    assertThat(igDao.getResources(ResourceType.Account, listOf(igId))).isEmpty()
+    assertThat(igDao.getResources(listOf(-1L))).isEmpty()
+  }
+
+  @Test
+  fun resourcesDeleted() = runBlocking {
+    val igId = igDao.insert(IG_ENTITY)
+    val resourceEntity =
+      ResourceEntity(
+        0L,
+        ResourceType.ValueSet,
+        RES_ID_1,
+        "http://url.com/ValueSet/Name/1.0.0",
+        RES_NAME,
+        "1.0.0",
+        File("resId"),
+        igId
+      )
+    igDao.insert(resourceEntity)
+
+    igDao.deleteImplementationGuide(IG_NAME, IG_VERSION)
+
+    assertThat(igDao.getImplementationGuides()).isEmpty()
+    assertThat(igDao.getResources(listOf(igId))).isEmpty()
+  }
+
+  private companion object {
+    const val IG_NAME = "test.ig"
+    const val IG_VERSION = "1.0.0"
+    const val RES_ID_1 = "res-id-1"
+    const val RES_NAME = "res-name-1"
+    val IG_ENTITY = ImplementationGuideEntity(0L, IG_NAME, IG_VERSION, File("test"))
+  }
+}

--- a/implementationguide/src/androidTest/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabaseTest.kt
+++ b/implementationguide/src/androidTest/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabaseTest.kt
@@ -21,7 +21,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
-import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
+import com.google.android.fhir.implementationguide.db.impl.entities.ResourceMetadataEntity
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlinx.coroutines.runBlocking
@@ -52,8 +52,8 @@ internal class ImplementationGuideDatabaseTest {
   @Test
   fun resourcesInserted() = runBlocking {
     val igId = igDao.insert(IG_ENTITY)
-    val resourceEntity =
-      ResourceEntity(
+    val resource =
+      ResourceMetadataEntity(
         0L,
         ResourceType.ValueSet,
         RES_ID_1,
@@ -64,7 +64,7 @@ internal class ImplementationGuideDatabaseTest {
         igId
       )
 
-    igDao.insert(resourceEntity)
+    igDao.insert(resource)
 
     assertThat(igDao.getResources(ResourceType.ValueSet, listOf(igId)).map { it.resourceId })
       .containsExactly(RES_ID_1)
@@ -75,8 +75,8 @@ internal class ImplementationGuideDatabaseTest {
   @Test
   fun resourcesDeleted() = runBlocking {
     val igId = igDao.insert(IG_ENTITY)
-    val resourceEntity =
-      ResourceEntity(
+    val resource =
+      ResourceMetadataEntity(
         0L,
         ResourceType.ValueSet,
         RES_ID_1,
@@ -86,7 +86,7 @@ internal class ImplementationGuideDatabaseTest {
         File("resId"),
         igId
       )
-    igDao.insert(resourceEntity)
+    igDao.insert(resource)
 
     igDao.deleteImplementationGuide(IG_NAME, IG_VERSION)
 

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/DbTypeConverters.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/DbTypeConverters.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.implementationguide.db.impl
+
+import androidx.room.TypeConverter
+import java.io.File
+
+internal object DbTypeConverters {
+
+  @JvmStatic @TypeConverter fun filePathToFile(filePath: String) = File(filePath)
+
+  @JvmStatic @TypeConverter fun fileToFilePath(file: File): String = file.path
+}

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabase.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.implementationguide.db.impl
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.google.android.fhir.implementationguide.db.impl.dao.ImplementationGuideDao
+import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
+import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
+
+@Database(
+  entities = [ImplementationGuideEntity::class, ResourceEntity::class],
+  version = 1,
+  exportSchema = false
+)
+@TypeConverters(DbTypeConverters::class)
+abstract class ImplementationGuideDatabase : RoomDatabase() {
+  abstract fun implementationGuideDao(): ImplementationGuideDao
+}

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabase.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabase.kt
@@ -21,11 +21,11 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.google.android.fhir.implementationguide.db.impl.dao.ImplementationGuideDao
 import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
-import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
+import com.google.android.fhir.implementationguide.db.impl.entities.ResourceMetadataEntity
 
 /** Holds metadata for implementation guides and their containing FHIR Resources. */
 @Database(
-  entities = [ImplementationGuideEntity::class, ResourceEntity::class],
+  entities = [ImplementationGuideEntity::class, ResourceMetadataEntity::class],
   version = 1,
   exportSchema = false
 )

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabase.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/ImplementationGuideDatabase.kt
@@ -23,6 +23,7 @@ import com.google.android.fhir.implementationguide.db.impl.dao.ImplementationGui
 import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
 import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
 
+/** Holds metadata for implementation guides and their containing FHIR Resources. */
 @Database(
   entities = [ImplementationGuideEntity::class, ResourceEntity::class],
   version = 1,

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/dao/ImplementationGuideDao.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/dao/ImplementationGuideDao.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.implementationguide.db.impl.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
+import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
+import org.hl7.fhir.r4.model.ResourceType
+
+@Dao
+abstract class ImplementationGuideDao {
+
+  @Query("SELECT * from ImplementationGuideEntity")
+  internal abstract suspend fun getImplementationGuides(): List<ImplementationGuideEntity>
+
+  @Query("SELECT * from ImplementationGuideEntity WHERE name = :name AND version = :version")
+  internal abstract suspend fun getImplementationGuide(
+    name: String,
+    version: String,
+  ): ImplementationGuideEntity
+
+  @Query("SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId)")
+  internal abstract suspend fun getResources(
+    igId: List<Long>,
+  ): List<ResourceEntity>
+
+  @Query(
+    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType"
+  )
+  internal abstract suspend fun getResources(
+    resourceType: ResourceType,
+    igId: List<Long>,
+  ): List<ResourceEntity>
+
+  @Query(
+    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND resourceId = :resourceId"
+  )
+  internal abstract suspend fun getResourcesWithResourceId(
+    resourceType: ResourceType,
+    resourceId: String,
+    igId: List<Long>,
+  ): List<ResourceEntity>
+
+  @Query(
+    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND url = :url"
+  )
+  internal abstract suspend fun getResourcesWithUrl(
+    resourceType: ResourceType,
+    url: String,
+    igId: List<Long>,
+  ): List<ResourceEntity>
+
+  @Query(
+    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND name = :name"
+  )
+  internal abstract suspend fun getResourcesWithName(
+    resourceType: ResourceType,
+    name: String,
+    igId: List<Long>,
+  ): List<ResourceEntity>
+
+  @Query(
+    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND name = :name AND version = :version"
+  )
+  internal abstract suspend fun getResourcesWithNameAndVersion(
+    resourceType: ResourceType,
+    name: String,
+    version: String,
+    igId: List<Long>,
+  ): List<ResourceEntity>
+
+  @Delete
+  internal abstract suspend fun deleteImplementationGuide(igEntity: ImplementationGuideEntity)
+
+  @Query("DELETE FROM ResourceEntity WHERE  implementationGuideId = :igId")
+  internal abstract suspend fun deleteResources(igId: Long)
+
+  @Transaction
+  open suspend fun deleteImplementationGuide(name: String, version: String) {
+    val igEntity = getImplementationGuide(name, version)
+    deleteResources(igEntity.id)
+    deleteImplementationGuide(igEntity)
+  }
+
+  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  abstract suspend fun insert(resourceEntity: ResourceEntity): Long
+
+  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  abstract suspend fun insert(ig: ImplementationGuideEntity): Long
+}

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/dao/ImplementationGuideDao.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/dao/ImplementationGuideDao.kt
@@ -21,7 +21,6 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Transaction
 import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
 import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
 import org.hl7.fhir.r4.model.ResourceType
@@ -94,16 +93,14 @@ abstract class ImplementationGuideDao {
   @Query("DELETE FROM ResourceEntity WHERE  implementationGuideId = :igId")
   internal abstract suspend fun deleteResources(igId: Long)
 
-  @Transaction
   open suspend fun deleteImplementationGuide(name: String, version: String) {
     val igEntity = getImplementationGuide(name, version)
-    deleteResources(igEntity.id)
     deleteImplementationGuide(igEntity)
   }
 
   @Insert(onConflict = OnConflictStrategy.IGNORE)
-  abstract suspend fun insert(resourceEntity: ResourceEntity): Long
+  internal abstract suspend fun insert(resourceEntity: ResourceEntity): Long
 
   @Insert(onConflict = OnConflictStrategy.IGNORE)
-  abstract suspend fun insert(ig: ImplementationGuideEntity): Long
+  internal abstract suspend fun insert(ig: ImplementationGuideEntity): Long
 }

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/dao/ImplementationGuideDao.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/dao/ImplementationGuideDao.kt
@@ -22,7 +22,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.google.android.fhir.implementationguide.db.impl.entities.ImplementationGuideEntity
-import com.google.android.fhir.implementationguide.db.impl.entities.ResourceEntity
+import com.google.android.fhir.implementationguide.db.impl.entities.ResourceMetadataEntity
 import org.hl7.fhir.r4.model.ResourceType
 
 @Dao
@@ -37,60 +37,60 @@ abstract class ImplementationGuideDao {
     version: String,
   ): ImplementationGuideEntity
 
-  @Query("SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId)")
+  @Query("SELECT * from ResourceMetadataEntity WHERE implementationGuideId IN (:igId)")
   internal abstract suspend fun getResources(
     igId: List<Long>,
-  ): List<ResourceEntity>
+  ): List<ResourceMetadataEntity>
 
   @Query(
-    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType"
+    "SELECT * from ResourceMetadataEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType"
   )
   internal abstract suspend fun getResources(
     resourceType: ResourceType,
     igId: List<Long>,
-  ): List<ResourceEntity>
+  ): List<ResourceMetadataEntity>
 
   @Query(
-    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND resourceId = :resourceId"
+    "SELECT * from ResourceMetadataEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND resourceId = :resourceId"
   )
   internal abstract suspend fun getResourcesWithResourceId(
     resourceType: ResourceType,
     resourceId: String,
     igId: List<Long>,
-  ): List<ResourceEntity>
+  ): List<ResourceMetadataEntity>
 
   @Query(
-    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND url = :url"
+    "SELECT * from ResourceMetadataEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND url = :url"
   )
   internal abstract suspend fun getResourcesWithUrl(
     resourceType: ResourceType,
     url: String,
     igId: List<Long>,
-  ): List<ResourceEntity>
+  ): List<ResourceMetadataEntity>
 
   @Query(
-    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND name = :name"
+    "SELECT * from ResourceMetadataEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND name = :name"
   )
   internal abstract suspend fun getResourcesWithName(
     resourceType: ResourceType,
     name: String,
     igId: List<Long>,
-  ): List<ResourceEntity>
+  ): List<ResourceMetadataEntity>
 
   @Query(
-    "SELECT * from ResourceEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND name = :name AND version = :version"
+    "SELECT * from ResourceMetadataEntity WHERE implementationGuideId IN (:igId) AND resourceType = :resourceType AND name = :name AND version = :version"
   )
   internal abstract suspend fun getResourcesWithNameAndVersion(
     resourceType: ResourceType,
     name: String,
     version: String,
     igId: List<Long>,
-  ): List<ResourceEntity>
+  ): List<ResourceMetadataEntity>
 
   @Delete
   internal abstract suspend fun deleteImplementationGuide(igEntity: ImplementationGuideEntity)
 
-  @Query("DELETE FROM ResourceEntity WHERE  implementationGuideId = :igId")
+  @Query("DELETE FROM ResourceMetadataEntity WHERE  implementationGuideId = :igId")
   internal abstract suspend fun deleteResources(igId: Long)
 
   open suspend fun deleteImplementationGuide(name: String, version: String) {
@@ -99,7 +99,7 @@ abstract class ImplementationGuideDao {
   }
 
   @Insert(onConflict = OnConflictStrategy.IGNORE)
-  internal abstract suspend fun insert(resourceEntity: ResourceEntity): Long
+  internal abstract suspend fun insert(resource: ResourceMetadataEntity): Long
 
   @Insert(onConflict = OnConflictStrategy.IGNORE)
   internal abstract suspend fun insert(ig: ImplementationGuideEntity): Long

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ImplementationGuideEntity.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ImplementationGuideEntity.kt
@@ -21,8 +21,9 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import java.io.File
 
+
 @Entity(indices = [Index(value = ["name", "version"], unique = true)])
-data class ImplementationGuideEntity(
+internal data class ImplementationGuideEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
   val name: String,
   val version: String,

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ImplementationGuideEntity.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ImplementationGuideEntity.kt
@@ -21,7 +21,6 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import java.io.File
 
-
 @Entity(indices = [Index(value = ["name", "version"], unique = true)])
 internal data class ImplementationGuideEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ImplementationGuideEntity.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ImplementationGuideEntity.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.implementationguide.db.impl.entities
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.io.File
+
+@Entity(indices = [Index(value = ["name", "version"], unique = true)])
+data class ImplementationGuideEntity(
+  @PrimaryKey(autoGenerate = true) val id: Long,
+  val name: String,
+  val version: String,
+  val rootDirectory: File
+)

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ResourceEntity.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ResourceEntity.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.implementationguide.db.impl.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.io.File
+import org.hl7.fhir.r4.model.ResourceType
+
+@Entity(
+  indices =
+    [
+      Index(value = ["implementationGuideId"], unique = false),
+      Index(value = ["resourceType", "resourceId", "implementationGuideId"], unique = true)
+    ],
+  foreignKeys =
+    [
+      ForeignKey(
+        entity = ImplementationGuideEntity::class,
+        parentColumns = ["id"],
+        childColumns = ["implementationGuideId"]
+      )
+    ]
+)
+data class ResourceEntity(
+  @PrimaryKey(autoGenerate = true) val id: Long,
+  val resourceType: ResourceType,
+  val resourceId: String,
+  val url: String?,
+  val name: String?,
+  val version: String?,
+  val fileUri: File,
+  val implementationGuideId: Long,
+)

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ResourceEntity.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ResourceEntity.kt
@@ -18,11 +18,13 @@ package com.google.android.fhir.implementationguide.db.impl.entities
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.ForeignKey.CASCADE
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import java.io.File
 import org.hl7.fhir.r4.model.ResourceType
 
+/** A DB entity holding the FHIR Resource metadata for `implementationguide` module. */
 @Entity(
   indices =
     [
@@ -34,11 +36,12 @@ import org.hl7.fhir.r4.model.ResourceType
       ForeignKey(
         entity = ImplementationGuideEntity::class,
         parentColumns = ["id"],
-        childColumns = ["implementationGuideId"]
+        childColumns = ["implementationGuideId"],
+        onDelete = CASCADE
       )
     ]
 )
-data class ResourceEntity(
+internal data class ResourceEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
   val resourceType: ResourceType,
   val resourceId: String,

--- a/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ResourceMetadataEntity.kt
+++ b/implementationguide/src/main/java/com/google/android/fhir/implementationguide/db/impl/entities/ResourceMetadataEntity.kt
@@ -41,7 +41,7 @@ import org.hl7.fhir.r4.model.ResourceType
       )
     ]
 )
-internal data class ResourceEntity(
+internal data class ResourceMetadataEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
   val resourceType: ResourceType,
   val resourceId: String,


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Issue https://github.com/google/android-fhir/issues/1729

**Description**
Add a DB to store metadata for 

**Alternative(s) considered**
For the first iteration, complex structure of indices (like in `FHIREngine` is not necessary - most of the resources we are interested in for now are Libraries and ValueSets that are looked up by id, name or uri. 

**Type**
Feature

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
