### PR TITLE
Separate the parameterized tests for questionnaire view model

### DIFF
--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelParameterizedTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelParameterizedTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture
+
+import android.app.Application
+import android.net.Uri
+import android.os.Build
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.parser.IParser
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_ENABLE_REVIEW_PAGE
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_JSON_STRING
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_JSON_URI
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_SHOW_REVIEW_PAGE_FIRST
+import com.google.android.fhir.datacapture.testing.DataCaptureTestApplication
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import kotlin.test.assertFailsWith
+import org.hl7.fhir.instance.model.api.IBaseResource
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+
+/**
+ * Parameterized test for passing the questionnaire and the questionnaire response to the view
+ * model.
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], application = DataCaptureTestApplication::class)
+class QuestionnaireViewModelParameterizedTest(
+  private val questionnaireSource: QuestionnaireSource,
+  private val questionnaireResponseSource: QuestionnaireResponseSource,
+) {
+
+  private lateinit var state: SavedStateHandle
+  private val context = ApplicationProvider.getApplicationContext<Application>()
+
+  @Before
+  fun setUp() {
+    state = SavedStateHandle()
+    check(
+      ApplicationProvider.getApplicationContext<DataCaptureTestApplication>()
+        is DataCaptureConfig.Provider
+    ) { "Few tests require a custom application class that implements DataCaptureConfig.Provider" }
+    ReflectionHelpers.setStaticField(DataCapture::class.java, "configuration", null)
+  }
+
+  @Test
+  fun `init should throw an exception if no questionnaire is provided`() {
+    val errorMessage =
+      assertFailsWith<IllegalStateException> { QuestionnaireViewModel(context, state) }
+        .localizedMessage
+
+    assertThat(errorMessage)
+      .isEqualTo(
+        "Neither EXTRA_QUESTIONNAIRE_JSON_URI nor EXTRA_QUESTIONNAIRE_JSON_STRING is supplied."
+      )
+  }
+
+  @Test
+  fun `should copy questionnaire if no response is provided`() {
+    val questionnaire =
+      Questionnaire().apply {
+        url = "http://www.sample-org/FHIR/Resources/Questionnaire/a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "a-link-id"
+            text = "Yes or no?"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          }
+        )
+      }
+
+    val viewModel = createQuestionnaireViewModel(questionnaire)
+
+    assertResourceEquals(
+      viewModel.getQuestionnaireResponse(),
+      QuestionnaireResponse().apply {
+        this.questionnaire = "http://www.sample-org/FHIR/Resources/Questionnaire/a-questionnaire"
+        addItem(
+          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+            linkId = "a-link-id"
+            text = "Yes or no?"
+          }
+        )
+      }
+    )
+  }
+
+  @Test
+  fun `should copy questionnaire response if provided`() {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "a-link-id"
+            text = "Basic question"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          }
+        )
+      }
+    val questionnaireResponse =
+      QuestionnaireResponse().apply {
+        id = "a-questionnaire-response"
+        addItem(
+          QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+            linkId = "a-link-id"
+            text = "Basic question"
+            addAnswer(
+              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                value = BooleanType(true)
+              }
+            )
+          }
+        )
+      }
+
+    val viewModel = createQuestionnaireViewModel(questionnaire, questionnaireResponse)
+
+    assertResourceEquals(viewModel.getQuestionnaireResponse(), questionnaireResponse)
+  }
+
+  private fun createQuestionnaireViewModel(
+    questionnaire: Questionnaire,
+    questionnaireResponse: QuestionnaireResponse? = null,
+    enableReviewPage: Boolean = false,
+    showReviewPageFirst: Boolean = false,
+  ): QuestionnaireViewModel {
+    if (questionnaireSource == QuestionnaireSource.STRING) {
+      state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, printer.encodeResourceToString(questionnaire))
+    } else if (questionnaireSource == QuestionnaireSource.URI) {
+      val questionnaireFile = File(context.cacheDir, "test_questionnaire")
+      questionnaireFile.outputStream().bufferedWriter().use {
+        printer.encodeResourceToWriter(questionnaire, it)
+      }
+      val questionnaireUri = Uri.fromFile(questionnaireFile)
+      state.set(EXTRA_QUESTIONNAIRE_JSON_URI, questionnaireUri)
+      shadowOf(context.contentResolver)
+        .registerInputStream(questionnaireUri, questionnaireFile.inputStream())
+    }
+
+    questionnaireResponse?.let {
+      if (questionnaireResponseSource == QuestionnaireResponseSource.STRING) {
+        state.set(
+          EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING,
+          printer.encodeResourceToString(questionnaireResponse)
+        )
+      } else if (questionnaireResponseSource == QuestionnaireResponseSource.URI) {
+        val questionnaireResponseFile = File(context.cacheDir, "test_questionnaire_response")
+        questionnaireResponseFile.outputStream().bufferedWriter().use {
+          printer.encodeResourceToWriter(questionnaireResponse, it)
+        }
+        val questionnaireResponseUri = Uri.fromFile(questionnaireResponseFile)
+        state.set(EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI, questionnaireResponseUri)
+        shadowOf(context.contentResolver)
+          .registerInputStream(questionnaireResponseUri, questionnaireResponseFile.inputStream())
+      }
+    }
+    enableReviewPage.let { state.set(EXTRA_ENABLE_REVIEW_PAGE, it) }
+    showReviewPageFirst.let { state.set(EXTRA_SHOW_REVIEW_PAGE_FIRST, it) }
+    return QuestionnaireViewModel(context, state)
+  }
+
+  private companion object {
+    val printer: IParser = FhirContext.forR4().newJsonParser()
+
+    fun <T : IBaseResource> assertResourceEquals(actual: T, expected: T) {
+      assertThat(printer.encodeResourceToString(actual))
+        .isEqualTo(printer.encodeResourceToString(expected))
+    }
+
+    @JvmStatic
+    @Parameters
+    fun parameters() =
+      listOf(
+        arrayOf(QuestionnaireSource.URI, QuestionnaireResponseSource.URI),
+        arrayOf(QuestionnaireSource.URI, QuestionnaireResponseSource.STRING),
+        arrayOf(QuestionnaireSource.STRING, QuestionnaireResponseSource.URI),
+        arrayOf(QuestionnaireSource.STRING, QuestionnaireResponseSource.STRING)
+      )
+  }
+}
+
+/** The source of questionnaire. */
+enum class QuestionnaireSource {
+  STRING,
+  URI
+}
+
+/** The source of questionnaire-response. */
+enum class QuestionnaireResponseSource {
+  STRING,
+  URI
+}

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelParameterizedTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelParameterizedTest.kt
@@ -32,7 +32,6 @@ import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA
 import com.google.android.fhir.datacapture.testing.DataCaptureTestApplication
 import com.google.common.truth.Truth.assertThat
 import java.io.File
-import kotlin.test.assertFailsWith
 import org.hl7.fhir.instance.model.api.IBaseResource
 import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Questionnaire
@@ -68,18 +67,6 @@ class QuestionnaireViewModelParameterizedTest(
         is DataCaptureConfig.Provider
     ) { "Few tests require a custom application class that implements DataCaptureConfig.Provider" }
     ReflectionHelpers.setStaticField(DataCapture::class.java, "configuration", null)
-  }
-
-  @Test
-  fun `init should throw an exception if no questionnaire is provided`() {
-    val errorMessage =
-      assertFailsWith<IllegalStateException> { QuestionnaireViewModel(context, state) }
-        .localizedMessage
-
-    assertThat(errorMessage)
-      .isEqualTo(
-        "Neither EXTRA_QUESTIONNAIRE_JSON_URI nor EXTRA_QUESTIONNAIRE_JSON_STRING is supplied."
-      )
   }
 
   @Test

--- a/demo/src/main/java/com/google/android/fhir/demo/AddPatientViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/AddPatientViewModel.kt
@@ -43,8 +43,8 @@ class AddPatientViewModel(application: Application, private val state: SavedStat
 
   private val questionnaireResource: Questionnaire
     get() =
-      FhirContext.forCached(FhirVersionEnum.R4).newJsonParser().parseResource(questionnaire) as
-        Questionnaire
+      FhirContext.forCached(FhirVersionEnum.R4).newJsonParser().parseResource(questionnaire)
+        as Questionnaire
   private var fhirEngine: FhirEngine = FhirApplication.fhirEngine(application.applicationContext)
   private var questionnaireJson: String? = null
 
@@ -81,7 +81,7 @@ class AddPatientViewModel(application: Application, private val state: SavedStat
 
   private fun getQuestionnaireJson(): String {
     questionnaireJson?.let {
-      return it!!
+      return it
     }
     questionnaireJson = readFileFromAssets(state[AddPatientFragment.QUESTIONNAIRE_FILE_PATH_KEY]!!)
     return questionnaireJson!!

--- a/demo/src/main/java/com/google/android/fhir/demo/MainActivity.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/MainActivity.kt
@@ -79,7 +79,7 @@ class MainActivity : AppCompatActivity() {
     when (item.itemId) {
       R.id.menu_sync -> {
         viewModel.triggerOneTimeSync()
-        true
+        return true
       }
     }
     binding.drawer.closeDrawer(GravityCompat.START)

--- a/demo/src/main/java/com/google/android/fhir/demo/PatientDetailsFragment.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/PatientDetailsFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ class PatientDetailsFragment : Fragment() {
     patientDetailsViewModel.livePatientData.observe(viewLifecycleOwner) {
       adapter.submitList(it)
       if (!it.isNullOrEmpty()) {
-        editMenuItem?.setEnabled(true)
+        editMenuItem?.isEnabled = true
       }
     }
     patientDetailsViewModel.getPatientDetailData()

--- a/demo/src/main/java/com/google/android/fhir/demo/PatientDetailsViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/PatientDetailsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,36 +93,41 @@ class PatientDetailsViewModel(
     val observations = getPatientObservations()
     val conditions = getPatientConditions()
 
-    patient.let {
-      data.add(PatientDetailOverview(it, firstInGroup = true))
+    patient.let { patientItem ->
+      data.add(PatientDetailOverview(patientItem, firstInGroup = true))
       data.add(
         PatientDetailProperty(
-          PatientProperty(getString(R.string.patient_property_mobile), it.phone)
+          PatientProperty(getString(R.string.patient_property_mobile), patientItem.phone)
         )
       )
       data.add(
         PatientDetailProperty(
-          PatientProperty(getString(R.string.patient_property_id), it.resourceId)
+          PatientProperty(getString(R.string.patient_property_id), patientItem.resourceId)
         )
       )
       data.add(
         PatientDetailProperty(
           PatientProperty(
             getString(R.string.patient_property_address),
-            "${it.city}, ${it.country} "
+            "${patientItem.city}, ${patientItem.country} "
           )
         )
       )
       data.add(
         PatientDetailProperty(
-          PatientProperty(getString(R.string.patient_property_dob), it.dob?.localizedString ?: "")
+          PatientProperty(
+            getString(R.string.patient_property_dob),
+            patientItem.dob?.localizedString ?: ""
+          )
         )
       )
       data.add(
         PatientDetailProperty(
           PatientProperty(
             getString(R.string.patient_property_gender),
-            it.gender.capitalize(Locale.ROOT)
+            patientItem.gender.replaceFirstChar {
+              if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+            }
           ),
           lastInGroup = true
         )

--- a/demo/src/main/java/com/google/android/fhir/demo/PatientListFragment.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/PatientListFragment.kt
@@ -94,9 +94,9 @@ class PatientListFragment : Fragment() {
       adapter.submitList(it)
     }
 
-    patientListViewModel.patientCount.observe(
-      viewLifecycleOwner
-    ) { binding.patientListContainer.patientCount.text = "$it Patient(s)" }
+    patientListViewModel.patientCount.observe(viewLifecycleOwner) {
+      binding.patientListContainer.patientCount.text = "$it Patient(s)"
+    }
 
     searchView = binding.search
     topBanner = binding.syncStatusContainer.linearLayoutSyncStatus

--- a/demo/src/main/java/com/google/android/fhir/demo/PatientListFragment.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/PatientListFragment.kt
@@ -95,9 +95,9 @@ class PatientListFragment : Fragment() {
     }
 
     patientListViewModel.patientCount.observe(
-      viewLifecycleOwner,
-      { binding.patientListContainer.patientCount.text = "$it Patient(s)" }
-    )
+      viewLifecycleOwner
+    ) { binding.patientListContainer.patientCount.text = "$it Patient(s)" }
+
     searchView = binding.search
     topBanner = binding.syncStatusContainer.linearLayoutSyncStatus
     syncStatus = binding.syncStatusContainer.tvSyncingStatus


### PR DESCRIPTION
**Description**
At the moment all test cases in `QuestionnaireViewModel.kt` are being run 4 times with the permutations of providing the questionnaire and the questionnaire response using string or URL.

This is highly inefficient and unnecessary. In fact, we only need to have a few test cases to check the mechanism to load the questionnaire and questionnaire response is working with both string and URL. The test cases regarding other parts of the view model logic shouldn't need to be run 4 times each.

**Alternative(s) considered**
NA

**Type**
Testing

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
