### PR TITLE
Introduce new `QuestionnaireAdapterItem` type

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/contrib/views/QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest.kt
@@ -65,7 +65,11 @@ class QuestionnaireItemPhoneNumberViewHolderFactoryInstrumentedTest {
     val viewHolderFromAdapter =
       questionnaireItemEditAdapter.createViewHolder(
         parent,
-        QuestionnaireItemViewHolderType.PHONE_NUMBER.value
+        QuestionnaireItemEditAdapter.ViewType.from(
+            type = QuestionnaireItemEditAdapter.ViewType.Type.QUESTION,
+            subtype = QuestionnaireItemViewHolderType.PHONE_NUMBER.value,
+          )
+          .viewType,
       )
     assertThat(viewHolderFromAdapter).isInstanceOf(viewHolder::class.java)
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireAdapterItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireAdapterItem.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture
+
+import com.google.android.fhir.datacapture.views.QuestionnaireItemViewItem
+
+sealed interface QuestionnaireAdapterItem {
+  data class Question(val item: QuestionnaireItemViewItem) : QuestionnaireAdapterItem
+}

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireAdapterItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireAdapterItem.kt
@@ -18,6 +18,8 @@ package com.google.android.fhir.datacapture
 
 import com.google.android.fhir.datacapture.views.QuestionnaireItemViewItem
 
-sealed interface QuestionnaireAdapterItem {
+/** Various types of rows that can be used in a Questionnaire RecyclerView. */
+internal sealed interface QuestionnaireAdapterItem {
+  /** A row for a quesion in a Questionnaire RecyclerView. */
   data class Question(val item: QuestionnaireItemViewItem) : QuestionnaireAdapterItem
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -125,7 +125,9 @@ open class QuestionnaireFragment : Fragment() {
           is DisplayMode.ReviewMode -> {
             // Set items
             questionnaireEditRecyclerView.visibility = View.GONE
-            questionnaireItemReviewAdapter.submitList(state.items)
+            questionnaireItemReviewAdapter.submitList(
+              state.items.filterIsInstance<QuestionnaireAdapterItem.Question>()
+            )
             questionnaireReviewRecyclerView.visibility = View.VISIBLE
 
             // Set button visibility

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemEditAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemEditAdapter.kt
@@ -43,25 +43,35 @@ import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType
 internal class QuestionnaireItemEditAdapter(
   private val questionnaireItemViewHolderMatchers:
     List<QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatcher> =
-    emptyList()
-) : ListAdapter<QuestionnaireItemViewItem, QuestionnaireItemViewHolder>(DiffCallback) {
+    emptyList(),
+) : ListAdapter<QuestionnaireAdapterItem, QuestionnaireItemViewHolder>(DiffCallback) {
   /**
    * @param viewType the integer value of the [QuestionnaireItemViewHolderType] used to render the
    * [QuestionnaireItemViewItem].
    */
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuestionnaireItemViewHolder {
+    val typedViewType = ViewType.parse(viewType)
+    val subtype = typedViewType.subtype
+    return when (typedViewType.type) {
+      ViewType.Type.QUESTION -> onCreateViewHolderQuestion(parent = parent, subtype = subtype)
+    }
+  }
+  private fun onCreateViewHolderQuestion(
+    parent: ViewGroup,
+    subtype: Int
+  ): QuestionnaireItemViewHolder {
     val numOfCanonicalWidgets = QuestionnaireItemViewHolderType.values().size
-    check(viewType < numOfCanonicalWidgets + questionnaireItemViewHolderMatchers.size) {
+    check(subtype < numOfCanonicalWidgets + questionnaireItemViewHolderMatchers.size) {
       "Invalid widget type specified. Widget Int type cannot exceed the total number of supported custom and canonical widgets"
     }
 
     // Map custom widget viewTypes to their corresponding widget factories
-    if (viewType >= numOfCanonicalWidgets)
-      return questionnaireItemViewHolderMatchers[viewType - numOfCanonicalWidgets]
+    if (subtype >= numOfCanonicalWidgets)
+      return questionnaireItemViewHolderMatchers[subtype - numOfCanonicalWidgets]
         .factory.create(parent)
 
     val viewHolderFactory =
-      when (QuestionnaireItemViewHolderType.fromInt(viewType)) {
+      when (QuestionnaireItemViewHolderType.fromInt(subtype)) {
         QuestionnaireItemViewHolderType.GROUP -> QuestionnaireItemGroupViewHolderFactory
         QuestionnaireItemViewHolderType.BOOLEAN_TYPE_PICKER ->
           QuestionnaireItemBooleanTypePickerViewHolderFactory
@@ -95,7 +105,55 @@ internal class QuestionnaireItemEditAdapter(
   }
 
   override fun onBindViewHolder(holder: QuestionnaireItemViewHolder, position: Int) {
-    holder.bind(getItem(position))
+    when (val item = getItem(position)) {
+      is QuestionnaireAdapterItem.Question -> {
+        holder.bind(item.item)
+      }
+    }
+  }
+
+  override fun getItemViewType(position: Int): Int {
+    // Because we have multiple Item subtypes, we will pack two ints into the item view type.
+
+    // The first 8 bits will be represented by this type, which is unique for each Item subclass.
+    val type: ViewType.Type
+    // The last 24 bits will be represented by this subtype, which will further divide each Item
+    // subclass into more view types.
+    val subtype: Int
+    when (val item = getItem(position)) {
+      is QuestionnaireAdapterItem.Question -> {
+        type = ViewType.Type.QUESTION
+        subtype = getItemViewTypeForQuestion(item.item)
+      }
+    }
+    return ViewType.from(type = type, subtype = subtype).viewType
+  }
+
+  /**
+   * Utility to pack two types (a "type" and "subtype") into a single "viewType" int, for use with
+   * [getItemViewType].
+   *
+   * [type] is contained in the first 8 bits of the int, and should be unique for each type of
+   * [QuestionnaireAdapterItem].
+   *
+   * [subtype] is contained in the lower 24 bits of the int, and should be used to differentiate
+   * between different items within the same [QuestionnaireAdapterItem] type.
+   */
+  @JvmInline
+  internal value class ViewType(val viewType: Int) {
+    val subtype: Int
+      get() = viewType and 0xFFFFFF
+    val type: Type
+      get() = Type.values()[viewType shr 24]
+
+    companion object {
+      fun parse(viewType: Int): ViewType = ViewType(viewType)
+
+      fun from(type: Type, subtype: Int): ViewType = ViewType((type.ordinal shl 24) or subtype)
+    }
+    enum class Type {
+      QUESTION,
+    }
   }
 
   /**
@@ -105,11 +163,9 @@ internal class QuestionnaireItemEditAdapter(
    * (http://hl7.org/fhir/R4/valueset-questionnaire-item-control.html) used in the itemControl
    * extension (http://hl7.org/fhir/R4/extension-questionnaire-itemcontrol.html).
    */
-  override fun getItemViewType(position: Int): Int {
-    return getItemViewTypeMapping(getItem(position))
-  }
-
-  internal fun getItemViewTypeMapping(questionnaireItemViewItem: QuestionnaireItemViewItem): Int {
+  internal fun getItemViewTypeForQuestion(
+    questionnaireItemViewItem: QuestionnaireItemViewItem,
+  ): Int {
     val questionnaireItem = questionnaireItemViewItem.questionnaireItem
     // For custom widgets, generate an int value that's greater than any int assigned to the
     // canonical FHIR widgets
@@ -141,7 +197,7 @@ internal class QuestionnaireItemEditAdapter(
   }
 
   private fun getChoiceViewHolderType(
-    questionnaireItemViewItem: QuestionnaireItemViewItem
+    questionnaireItemViewItem: QuestionnaireItemViewItem,
   ): QuestionnaireItemViewHolderType {
     val questionnaireItem = questionnaireItemViewItem.questionnaireItem
 
@@ -169,7 +225,7 @@ internal class QuestionnaireItemEditAdapter(
   }
 
   private fun getIntegerViewHolderType(
-    questionnaireItemViewItem: QuestionnaireItemViewItem
+    questionnaireItemViewItem: QuestionnaireItemViewItem,
   ): QuestionnaireItemViewHolderType {
     val questionnaireItem = questionnaireItemViewItem.questionnaireItem
     // Use the view type that the client wants if they specified an itemControl
@@ -178,7 +234,7 @@ internal class QuestionnaireItemEditAdapter(
   }
 
   private fun getStringViewHolderType(
-    questionnaireItemViewItem: QuestionnaireItemViewItem
+    questionnaireItemViewItem: QuestionnaireItemViewItem,
   ): QuestionnaireItemViewHolderType {
     val questionnaireItem = questionnaireItemViewItem.questionnaireItem
     // Use the view type that the client wants if they specified an itemControl
@@ -195,7 +251,7 @@ internal class QuestionnaireItemEditAdapter(
   }
 }
 
-internal object DiffCallback : DiffUtil.ItemCallback<QuestionnaireItemViewItem>() {
+internal object DiffCallback : DiffUtil.ItemCallback<QuestionnaireAdapterItem>() {
   /**
    * [QuestionnaireItemViewItem] is a transient object for the UI only. Whenever the user makes any
    * change via the UI, a new list of [QuestionnaireItemViewItem]s will be created, each holding
@@ -205,16 +261,25 @@ internal object DiffCallback : DiffUtil.ItemCallback<QuestionnaireItemViewItem>(
    * underlying [QuestionnaireItem] and [QuestionnaireResponseItem].
    */
   override fun areItemsTheSame(
-    oldItem: QuestionnaireItemViewItem,
-    newItem: QuestionnaireItemViewItem
-  ) = oldItem.hasTheSameItem(newItem)
+    oldItem: QuestionnaireAdapterItem,
+    newItem: QuestionnaireAdapterItem,
+  ): Boolean =
+    when (oldItem) {
+      is QuestionnaireAdapterItem.Question -> {
+        newItem is QuestionnaireAdapterItem.Question && oldItem.item.hasTheSameItem(newItem.item)
+      }
+    }
 
   override fun areContentsTheSame(
-    oldItem: QuestionnaireItemViewItem,
-    newItem: QuestionnaireItemViewItem
-  ): Boolean {
-    return oldItem.hasTheSameItem(newItem) &&
-      oldItem.hasTheSameAnswer(newItem) &&
-      oldItem.hasTheSameValidationResult(newItem)
-  }
+    oldItem: QuestionnaireAdapterItem,
+    newItem: QuestionnaireAdapterItem,
+  ): Boolean =
+    when (oldItem) {
+      is QuestionnaireAdapterItem.Question -> {
+        newItem is QuestionnaireAdapterItem.Question &&
+          oldItem.item.hasTheSameItem(newItem.item) &&
+          oldItem.item.hasTheSameAnswer(newItem.item) &&
+          oldItem.item.hasTheSameValidationResult(newItem.item)
+      }
+    }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemReviewAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemReviewAdapter.kt
@@ -23,17 +23,14 @@ import com.google.android.fhir.datacapture.views.QuestionnaireItemViewHolder
 
 /** List Adapter used to bind answers to [QuestionnaireItemViewHolder] in review mode. */
 internal class QuestionnaireItemReviewAdapter :
-  ListAdapter<QuestionnaireAdapterItem, QuestionnaireItemViewHolder>(DiffCallback) {
+  ListAdapter<QuestionnaireAdapterItem.Question, QuestionnaireItemViewHolder>(
+    DiffCallbacks.QUESTIONS
+  ) {
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuestionnaireItemViewHolder {
     return QuestionnaireItemSimpleQuestionAnswerDisplayViewHolderFactory.create(parent)
   }
 
   override fun onBindViewHolder(holder: QuestionnaireItemViewHolder, position: Int) {
-    val item = getItem(position)
-    item as? QuestionnaireAdapterItem.Question
-      ?: error(
-        "QuestionnaireItemReviewAdapter only supports QuestionnaireAdapterItem.Questions, but was passed a ${item::class.java.name}"
-      )
-    holder.bind(item.item)
+    holder.bind(getItem(position).item)
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemReviewAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireItemReviewAdapter.kt
@@ -20,16 +20,20 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.google.android.fhir.datacapture.views.QuestionnaireItemSimpleQuestionAnswerDisplayViewHolderFactory
 import com.google.android.fhir.datacapture.views.QuestionnaireItemViewHolder
-import com.google.android.fhir.datacapture.views.QuestionnaireItemViewItem
 
 /** List Adapter used to bind answers to [QuestionnaireItemViewHolder] in review mode. */
 internal class QuestionnaireItemReviewAdapter :
-  ListAdapter<QuestionnaireItemViewItem, QuestionnaireItemViewHolder>(DiffCallback) {
+  ListAdapter<QuestionnaireAdapterItem, QuestionnaireItemViewHolder>(DiffCallback) {
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuestionnaireItemViewHolder {
     return QuestionnaireItemSimpleQuestionAnswerDisplayViewHolderFactory.create(parent)
   }
 
   override fun onBindViewHolder(holder: QuestionnaireItemViewHolder, position: Int) {
-    holder.bind(getItem(position))
+    val item = getItem(position)
+    item as? QuestionnaireAdapterItem.Question
+      ?: error(
+        "QuestionnaireItemReviewAdapter only supports QuestionnaireAdapterItem.Questions, but was passed a ${item::class.java.name}"
+      )
+    holder.bind(item.item)
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -700,7 +700,10 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
     }
   }
 
-  /** Gets a list of [QuestionnairePage]s for a paginated questionnaire. */
+  /**
+   * Gets a list of [QuestionnairePage]s for a paginated questionnaire, or `null` if the
+   * questionnaire is not paginated.
+   */
   private fun getQuestionnairePages(): List<QuestionnairePage>? =
     if (questionnaire.isPaginated) {
       questionnaire.item.zip(questionnaireResponse.item).mapIndexed {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -61,7 +61,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
 
   /** The current questionnaire as questions are being answered. */
   internal val questionnaire: Questionnaire
-  private lateinit var currentPageItems: List<QuestionnaireItemViewItem>
+  private lateinit var currentPageItems: List<QuestionnaireAdapterItem>
 
   init {
     questionnaire =
@@ -100,7 +100,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
    */
   private var isPaginationButtonPressed = false
 
-  /** Forces response validation each time [getQuestionnaireItemViewItems] is called. */
+  /** Forces response validation each time [getQuestionnaireAdapterItems] is called. */
   private var hasPressedSubmitButton = false
 
   init {
@@ -303,7 +303,11 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
           modificationCount.update { it + 1 }
         }
 
-        if (currentPageItems.all { it.validationResult is Valid }) {
+        val allCurrentPageItemsValid =
+          currentPageItems.filterIsInstance<QuestionnaireAdapterItem.Question>().all {
+            it.item.validationResult is Valid
+          }
+        if (allCurrentPageItemsValid) {
           isPaginationButtonPressed = false
           val nextPageIndex =
             pages!!.indexOfFirst {
@@ -484,12 +488,12 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         if (currentPageIndexFlow.value == null) {
           currentPageIndexFlow.value = pages!!.first { it.enabled && !it.hidden }.index
         }
-        getQuestionnaireItemViewItems(
+        getQuestionnaireAdapterItems(
           questionnaireItemList[currentPageIndexFlow.value!!],
           questionnaireResponseItemList[currentPageIndexFlow.value!!]
         )
       } else {
-        getQuestionnaireItemViewItems(questionnaireItemList, questionnaireResponseItemList)
+        getQuestionnaireAdapterItems(questionnaireItemList, questionnaireResponseItemList)
       }
 
     // Reviewing the questionnaire or the questionnaire is read-only
@@ -531,10 +535,10 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
    * Returns the list of [QuestionnaireItemViewItem]s generated for the questionnaire items and
    * questionnaire response items.
    */
-  private fun getQuestionnaireItemViewItems(
+  private fun getQuestionnaireAdapterItems(
     questionnaireItemList: List<Questionnaire.QuestionnaireItemComponent>,
     questionnaireResponseItemList: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
-  ): List<QuestionnaireItemViewItem> {
+  ): List<QuestionnaireAdapterItem> {
     var responseIndex = 0
     return questionnaireItemList
       .asSequence()
@@ -549,7 +553,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
           responseIndex += 1
         }
 
-        getQuestionnaireItemViewItems(questionnaireItem, questionnaireResponseItem)
+        getQuestionnaireAdapterItems(questionnaireItem, questionnaireResponseItem)
       }
       .toList()
   }
@@ -558,10 +562,10 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
    * Returns the list of [QuestionnaireItemViewItem]s generated for the questionnaire item and
    * questionnaire response item.
    */
-  private fun getQuestionnaireItemViewItems(
+  private fun getQuestionnaireAdapterItems(
     questionnaireItem: Questionnaire.QuestionnaireItemComponent,
     questionnaireResponseItem: QuestionnaireResponse.QuestionnaireResponseItemComponent,
-  ): List<QuestionnaireItemViewItem> {
+  ): List<QuestionnaireAdapterItem> {
     // Disabled/hidden questions should not get QuestionnaireItemViewItem instances
     val enabled =
       EnablementEvaluator(questionnaireResponse)
@@ -584,41 +588,44 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
       } else {
         NotValidated
       }
-    val items = buildList {
-      // Add an item for the question itself
-      add(
-        QuestionnaireItemViewItem(
-          questionnaireItem,
-          questionnaireResponseItem,
-          validationResult = validationResult,
-          answersChangedCallback = answersChangedCallback,
-          resolveAnswerValueSet = { resolveAnswerValueSet(it) },
-          resolveAnswerExpression = { resolveAnswerExpression(it) }
-        )
-      )
-      val nestedResponses: List<List<QuestionnaireResponse.QuestionnaireResponseItemComponent>> =
-        when {
-          // Repeated questions have one answer item per response instance, which we must display
-          // after the question.
-          questionnaireItem.repeats -> questionnaireResponseItem.answer.map { it.item }
-          // Non-repeated questions may have nested items, which we should display
-          else -> listOf(questionnaireResponseItem.item)
-        }
-      nestedResponses.forEach { nestedResponse ->
-        addAll(
-          getQuestionnaireItemViewItems(
-            // If nested display item is identified as instructions or flyover, then do not create
-            // questionnaire state for it.
-            questionnaireItemList =
-              questionnaireItem.item.filterNot {
-                it.type == Questionnaire.QuestionnaireItemType.DISPLAY &&
-                  (it.isInstructionsCode || it.isFlyoverCode || it.isHelpCode)
-              },
-            questionnaireResponseItemList = nestedResponse,
+    val items =
+      buildList<QuestionnaireAdapterItem> {
+        // Add an item for the question itself
+        add(
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = validationResult,
+              answersChangedCallback = answersChangedCallback,
+              resolveAnswerValueSet = { resolveAnswerValueSet(it) },
+              resolveAnswerExpression = { resolveAnswerExpression(it) }
+            )
           )
         )
+        val nestedResponses: List<List<QuestionnaireResponse.QuestionnaireResponseItemComponent>> =
+          when {
+            // Repeated questions have one answer item per response instance, which we must display
+            // after the question.
+            questionnaireItem.repeats -> questionnaireResponseItem.answer.map { it.item }
+            // Non-repeated questions may have nested items, which we should display
+            else -> listOf(questionnaireResponseItem.item)
+          }
+        nestedResponses.forEach { nestedResponse ->
+          addAll(
+            getQuestionnaireAdapterItems(
+              // If nested display item is identified as instructions or flyover, then do not create
+              // questionnaire state for it.
+              questionnaireItemList =
+                questionnaireItem.item.filterNot {
+                  it.type == Questionnaire.QuestionnaireItemType.DISPLAY &&
+                    (it.isInstructionsCode || it.isFlyoverCode || it.isHelpCode)
+                },
+              questionnaireResponseItemList = nestedResponse,
+            )
+          )
+        }
       }
-    }
     currentPageItems = items
     return items
   }
@@ -693,28 +700,13 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
     }
   }
 
-  /**
-   * Checks if this questionnaire uses pagination via the "page" extension.
-   *
-   * If any one group has a "page" extension, it is assumed that the whole questionnaire is a
-   * well-formed, paginated questionnaire (eg, each top-level group should be its own page).
-   *
-   * If this questionnaire uses pagination, returns the [QuestionnairePagination] that you would see
-   * when first opening this questionnaire. Otherwise, returns `null`.
-   */
-  private fun getInitialPageIndex(): Int? =
-    if (questionnaire.isPaginated) {
-      0 // Always begin with the first page
-    } else {
-      null
-    }
-
   /** Gets a list of [QuestionnairePage]s for a paginated questionnaire. */
   private fun getQuestionnairePages(): List<QuestionnairePage>? =
     if (questionnaire.isPaginated) {
       questionnaire.item.zip(questionnaireResponse.item).mapIndexed {
         index,
-        (questionnaireItem, questionnaireResponseItem) ->
+        (questionnaireItem, questionnaireResponseItem),
+        ->
         QuestionnairePage(
           index,
           EnablementEvaluator(questionnaireResponse)
@@ -735,7 +727,7 @@ typealias ItemToParentMap =
 
 /** Questionnaire state for the Fragment to consume. */
 internal data class QuestionnaireState(
-  val items: List<QuestionnaireItemViewItem>,
+  val items: List<QuestionnaireAdapterItem>,
   val displayMode: DisplayMode,
 )
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemEditAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemEditAdapterTest.kt
@@ -492,7 +492,7 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areItemsTheSame(
+        DiffCallbacks.ITEMS.areItemsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -520,7 +520,7 @@ class QuestionnaireItemEditAdapterTest {
     val otherQuestionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areItemsTheSame(
+        DiffCallbacks.ITEMS.areItemsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -547,7 +547,7 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areItemsTheSame(
+        DiffCallbacks.ITEMS.areItemsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -576,7 +576,7 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areContentsTheSame(
+        DiffCallbacks.ITEMS.areContentsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -604,7 +604,7 @@ class QuestionnaireItemEditAdapterTest {
     val otherQuestionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areContentsTheSame(
+        DiffCallbacks.ITEMS.areContentsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -631,7 +631,7 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areContentsTheSame(
+        DiffCallbacks.ITEMS.areContentsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -665,7 +665,7 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areContentsTheSame(
+        DiffCallbacks.ITEMS.areContentsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -692,7 +692,7 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areContentsTheSame(
+        DiffCallbacks.ITEMS.areContentsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,
@@ -719,7 +719,7 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireResponseItem = QuestionnaireResponse.QuestionnaireResponseItemComponent()
 
     assertThat(
-        DiffCallback.areContentsTheSame(
+        DiffCallbacks.ITEMS.areContentsTheSame(
           QuestionnaireAdapterItem.Question(
             QuestionnaireItemViewItem(
               questionnaireItem,

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemEditAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemEditAdapterTest.kt
@@ -47,12 +47,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.GROUP),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.GROUP),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -66,12 +68,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.BOOLEAN),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.BOOLEAN),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -85,12 +89,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.DATE),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.DATE),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -110,11 +116,13 @@ class QuestionnaireItemEditAdapterTest {
       }
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          questionnaireItemComponent,
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            questionnaireItemComponent,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -128,12 +136,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.DATETIME),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.DATETIME),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -147,12 +157,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.STRING),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.STRING),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -180,11 +192,13 @@ class QuestionnaireItemEditAdapterTest {
     )
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          questionnaireItem,
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            questionnaireItem,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -204,11 +218,13 @@ class QuestionnaireItemEditAdapterTest {
       }
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          questionnaireItemComponent,
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            questionnaireItemComponent,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -222,12 +238,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.TEXT),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.TEXT),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -241,12 +259,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.INTEGER),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.INTEGER),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -276,11 +296,13 @@ class QuestionnaireItemEditAdapterTest {
     )
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          questionnaireItem,
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            questionnaireItem,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -300,11 +322,13 @@ class QuestionnaireItemEditAdapterTest {
       }
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          questionnaireItemComponent,
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            questionnaireItemComponent,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -318,12 +342,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.DECIMAL),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.DECIMAL),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -337,12 +363,14 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.CHOICE),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.CHOICE),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -361,13 +389,15 @@ class QuestionnaireItemEditAdapterTest {
     val questionnaireItemEditAdapter = QuestionnaireItemEditAdapter()
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.CHOICE)
-            .setAnswerOption(answerOptions),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.CHOICE)
+              .setAnswerOption(answerOptions),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -403,11 +433,13 @@ class QuestionnaireItemEditAdapterTest {
     )
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          questionnaireItem,
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            questionnaireItem,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -436,11 +468,13 @@ class QuestionnaireItemEditAdapterTest {
     )
     questionnaireItemEditAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          questionnaireItem,
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = NotValidated,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            questionnaireItem,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -459,18 +493,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areItemsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            otherQuestionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              otherQuestionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isFalse()
@@ -483,18 +521,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areItemsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            otherQuestionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              otherQuestionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isFalse()
@@ -506,18 +548,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areItemsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isTrue()
@@ -531,18 +577,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areContentsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            otherQuestionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              otherQuestionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isFalse()
@@ -555,18 +605,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areContentsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            otherQuestionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              otherQuestionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isFalse()
@@ -578,25 +632,29 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areContentsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          ),
-          QuestionnaireItemViewItem(
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
               questionnaireItem,
               questionnaireResponseItem,
               validationResult = NotValidated,
               answersChangedCallback = { _, _, _ -> },
             )
-            .apply {
-              addAnswer(
-                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                  value = StringType("answer")
-                }
+          ),
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+                questionnaireItem,
+                questionnaireResponseItem,
+                validationResult = NotValidated,
+                answersChangedCallback = { _, _, _ -> },
               )
-            }
+              .apply {
+                addAnswer(
+                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                    value = StringType("answer")
+                  }
+                )
+              }
+          ),
         )
       )
       .isFalse()
@@ -608,18 +666,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areContentsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = Invalid(listOf()),
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = Invalid(listOf()),
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isFalse()
@@ -631,18 +693,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areContentsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isTrue()
@@ -654,18 +720,22 @@ class QuestionnaireItemEditAdapterTest {
 
     assertThat(
         DiffCallback.areContentsTheSame(
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
           ),
-          QuestionnaireItemViewItem(
-            questionnaireItem,
-            questionnaireResponseItem,
-            validationResult = NotValidated,
-            answersChangedCallback = { _, _, _ -> },
-          )
+          QuestionnaireAdapterItem.Question(
+            QuestionnaireItemViewItem(
+              questionnaireItem,
+              questionnaireResponseItem,
+              validationResult = NotValidated,
+              answersChangedCallback = { _, _, _ -> },
+            )
+          ),
         )
       )
       .isTrue()
@@ -713,7 +783,7 @@ class QuestionnaireItemEditAdapterTest {
     assertThat(expectedItemViewType)
       .isEqualTo(
         QuestionnaireItemEditAdapter(getQuestionnaireItemViewHolderFactoryMatchers())
-          .getItemViewTypeMapping(questionnaireItemViewItem)
+          .getItemViewTypeForQuestion(questionnaireItemViewItem)
       )
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemReviewAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireItemReviewAdapterTest.kt
@@ -43,12 +43,14 @@ class QuestionnaireItemReviewAdapterTest {
     val questionnaireItemReviewAdapter = QuestionnaireItemReviewAdapter()
     questionnaireItemReviewAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.GROUP),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = Valid,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.GROUP),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = Valid,
+            answersChangedCallback = { _, _, _ -> },
+          )
         )
       )
     )
@@ -61,20 +63,24 @@ class QuestionnaireItemReviewAdapterTest {
     val questionnaireItemReviewAdapter = QuestionnaireItemReviewAdapter()
     questionnaireItemReviewAdapter.submitList(
       listOf(
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.GROUP),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = Valid,
-          answersChangedCallback = { _, _, _ -> },
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.GROUP),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = Valid,
+            answersChangedCallback = { _, _, _ -> },
+          )
         ),
-        QuestionnaireItemViewItem(
-          Questionnaire.QuestionnaireItemComponent()
-            .setType(Questionnaire.QuestionnaireItemType.DISPLAY),
-          QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-          validationResult = Valid,
-          answersChangedCallback = { _, _, _ -> },
-        )
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireItemViewItem(
+            Questionnaire.QuestionnaireItemComponent()
+              .setType(Questionnaire.QuestionnaireItemType.DISPLAY),
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = Valid,
+            answersChangedCallback = { _, _, _ -> },
+          )
+        ),
       )
     )
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -1150,10 +1150,15 @@ class QuestionnaireViewModelTest {
         createQuestionnaireViewModel(questionnaire, questionnaireResponse)
 
       val questionnaireItemViewItem = questionnaireViewModel.questionnaireStateFlow.first()
-      assertThat(questionnaireItemViewItem.items.first().questionnaireItem.linkId)
+      assertThat(questionnaireItemViewItem.items.first().asQuestion().questionnaireItem.linkId)
         .isEqualTo(questionnaireResponseWithMissingItem.item.first().linkId)
       assertThat(
-          questionnaireItemViewItem.items.single().answers.single().valueBooleanType.booleanValue()
+          questionnaireItemViewItem.items
+            .single()
+            .asQuestion()
+            .answers
+            .single()
+            .valueBooleanType.booleanValue()
         )
         .isTrue()
     }
@@ -1211,19 +1216,19 @@ class QuestionnaireViewModelTest {
         questionnaireViewModel.questionnaireStateFlow.first().items
 
       // Answer to first question should be created from questionnaire
-      val questionnaireItemViewItem1 = questionnaireItemViewItemList[0]
+      val questionnaireItemViewItem1 = questionnaireItemViewItemList[0].asQuestion()
       assertThat(questionnaireItemViewItem1.questionnaireItem.linkId).isEqualTo("q1")
       assertThat(questionnaireItemViewItem1.answers.single().valueBooleanType.booleanValue())
         .isFalse()
 
       // Answer to second question should be copied from questionnaire response
-      val questionnaireItemViewItem2 = questionnaireItemViewItemList[1]
+      val questionnaireItemViewItem2 = questionnaireItemViewItemList[1].asQuestion()
       assertThat(questionnaireItemViewItem2.questionnaireItem.linkId).isEqualTo("q2")
       assertThat(questionnaireItemViewItem2.answers.single().valueBooleanType.booleanValue())
         .isTrue()
 
       // Answer to third quesiton should be created from questionnaire
-      val questionnaireItemViewItem3 = questionnaireItemViewItemList[2]
+      val questionnaireItemViewItem3 = questionnaireItemViewItemList[2].asQuestion()
       assertThat(questionnaireItemViewItem3.questionnaireItem.linkId).isEqualTo("q3")
       assertThat(questionnaireItemViewItem3.answers.single().valueBooleanType.booleanValue())
         .isFalse()
@@ -1255,12 +1260,12 @@ class QuestionnaireViewModelTest {
     val questionnaireItemViewItemList = viewModel.getQuestionnaireItemViewItemList()
     assertThat(questionnaireItemViewItemList).hasSize(2)
 
-    val firstQuestionnaireItem = questionnaireItemViewItemList[0].questionnaireItem
+    val firstQuestionnaireItem = questionnaireItemViewItemList[0].asQuestion().questionnaireItem
     assertThat(firstQuestionnaireItem.linkId).isEqualTo("a-link-id")
     assertThat(firstQuestionnaireItem.text).isEqualTo("Basic questions")
     assertThat(firstQuestionnaireItem.type).isEqualTo(Questionnaire.QuestionnaireItemType.GROUP)
 
-    val secondQuestionnaireItem = questionnaireItemViewItemList[1].questionnaireItem
+    val secondQuestionnaireItem = questionnaireItemViewItemList[1].asQuestion().questionnaireItem
     assertThat(secondQuestionnaireItem.linkId).isEqualTo("another-link-id")
     assertThat(secondQuestionnaireItem.text).isEqualTo("Name?")
     assertThat(secondQuestionnaireItem.type).isEqualTo(Questionnaire.QuestionnaireItemType.STRING)
@@ -1282,7 +1287,8 @@ class QuestionnaireViewModelTest {
       }
     val viewModel = createQuestionnaireViewModel(questionnaire)
     val questionnaireItemViewItemList = viewModel.getQuestionnaireItemViewItemList()
-    assertThat(questionnaireItemViewItemList.single().validationResult).isEqualTo(NotValidated)
+    assertThat(questionnaireItemViewItemList.single().asQuestion().validationResult)
+      .isEqualTo(NotValidated)
   }
 
   @Test
@@ -1303,8 +1309,9 @@ class QuestionnaireViewModelTest {
     val viewModel = createQuestionnaireViewModel(questionnaire)
 
     viewModel.runViewModelBlocking {
-      viewModel.getQuestionnaireItemViewItemList().single().clearAnswer()
-      assertThat(viewModel.getQuestionnaireItemViewItemList().single().validationResult)
+      val question = viewModel.getQuestionnaireItemViewItemList().single().asQuestion()
+      question.clearAnswer()
+      assertThat(question.validationResult)
         .isEqualTo(Invalid(listOf("Missing answer for required field.")))
     }
   }
@@ -1335,7 +1342,9 @@ class QuestionnaireViewModelTest {
       }
     val viewModel = createQuestionnaireViewModel(questionnaire)
 
-    assertThat(viewModel.getQuestionnaireItemViewItemList().single().questionnaireItem.linkId)
+    assertThat(
+        viewModel.getQuestionnaireItemViewItemList().single().asQuestion().questionnaireItem.linkId
+      )
       .isEqualTo("question-1")
   }
 
@@ -1368,8 +1377,10 @@ class QuestionnaireViewModelTest {
     val questionnaireItemViewItemList = viewModel.getQuestionnaireItemViewItemList()
 
     assertThat(questionnaireItemViewItemList).hasSize(2)
-    assertThat(questionnaireItemViewItemList[0].questionnaireItem.linkId).isEqualTo("question-1")
-    assertThat(questionnaireItemViewItemList[1].questionnaireItem.linkId).isEqualTo("question-2")
+    assertThat(questionnaireItemViewItemList[0].asQuestion().questionnaireItem.linkId)
+      .isEqualTo("question-1")
+    assertThat(questionnaireItemViewItemList[1].asQuestion().questionnaireItem.linkId)
+      .isEqualTo("question-2")
   }
 
   @Test
@@ -1417,7 +1428,9 @@ class QuestionnaireViewModelTest {
 
     val viewModel = QuestionnaireViewModel(context, state)
 
-    assertThat(viewModel.getQuestionnaireItemViewItemList().single().questionnaireItem.linkId)
+    assertThat(
+        viewModel.getQuestionnaireItemViewItemList().single().asQuestion().questionnaireItem.linkId
+      )
       .isEqualTo("a-boolean-item-1")
   }
 
@@ -1444,7 +1457,13 @@ class QuestionnaireViewModelTest {
 
       val viewModel = QuestionnaireViewModel(context, state)
 
-      assertThat(viewModel.getQuestionnaireItemViewItemList().single().questionnaireItem.linkId)
+      assertThat(
+          viewModel
+            .getQuestionnaireItemViewItemList()
+            .single()
+            .asQuestion()
+            .questionnaireItem.linkId
+        )
         .isEqualTo("a-boolean-item-1")
     }
 
@@ -1493,7 +1512,9 @@ class QuestionnaireViewModelTest {
     val viewModel = createQuestionnaireViewModel(questionnaire)
 
     viewModel
-      .getQuestionnaireItemViewItemList()[1].setAnswer(
+      .getQuestionnaireItemViewItemList()[1]
+      .asQuestion()
+      .setAnswer(
         QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
           this.value = valueBooleanType.setValue(false)
         }
@@ -1556,32 +1577,44 @@ class QuestionnaireViewModelTest {
 
     fun repeatedGroupA() =
       viewModel.getQuestionnaireItemViewItemList().single {
-        it.questionnaireItem.linkId == "repeated-group-a"
+        it.asQuestion().questionnaireItem.linkId == "repeated-group-a"
       }
 
     fun repeatedGroupB() =
       viewModel.getQuestionnaireItemViewItemList().single {
-        it.questionnaireItem.linkId == "repeated-group-b"
+        it.asQuestion().questionnaireItem.linkId == "repeated-group-b"
       }
     viewModel.runViewModelBlocking {
       // Calling addAnswer out of order should not result in the answers in the response being out
       // of order; all of the answers to repeated-group-a should come before repeated-group-b.
       repeat(times = 2) {
         repeatedGroupA()
+          .asQuestion()
           .addAnswer(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              item = repeatedGroupA().questionnaireItem.getNestedQuestionnaireResponseItems()
+              item =
+                repeatedGroupA()
+                  .asQuestion()
+                  .questionnaireItem.getNestedQuestionnaireResponseItems()
             }
           )
         repeatedGroupB()
+          .asQuestion()
           .addAnswer(
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-              item = repeatedGroupB().questionnaireItem.getNestedQuestionnaireResponseItems()
+              item =
+                repeatedGroupB()
+                  .asQuestion()
+                  .questionnaireItem.getNestedQuestionnaireResponseItems()
             }
           )
       }
 
-      assertThat(viewModel.getQuestionnaireItemViewItemList().map { it.questionnaireItem.linkId })
+      assertThat(
+          viewModel.getQuestionnaireItemViewItemList().map {
+            it.asQuestion().questionnaireItem.linkId
+          }
+        )
         .containsExactly(
           "repeated-group-a",
           "nested-item-a",
@@ -1726,13 +1759,17 @@ class QuestionnaireViewModelTest {
     val viewModel = createQuestionnaireViewModel(questionnaire)
 
     viewModel
-      .getQuestionnaireItemViewItemList()[0].setAnswer(
+      .getQuestionnaireItemViewItemList()[0]
+      .asQuestion()
+      .setAnswer(
         QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
           this.value = valueBooleanType.setValue(false)
         }
       )
     viewModel
-      .getQuestionnaireItemViewItemList()[1].setAnswer(
+      .getQuestionnaireItemViewItemList()[1]
+      .asQuestion()
+      .setAnswer(
         QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
           this.value = valueBooleanType.setValue(false)
         }
@@ -1793,11 +1830,11 @@ class QuestionnaireViewModelTest {
           )
         )
       assertThat(state.items).hasSize(2)
-      state.items[0].questionnaireItem.let { groupItem ->
+      state.items[0].asQuestion().questionnaireItem.let { groupItem ->
         assertThat(groupItem.type).isEqualTo(Questionnaire.QuestionnaireItemType.GROUP)
         assertThat(groupItem.linkId).isEqualTo("page1")
       }
-      state.items[1].questionnaireItem.let { questionItem ->
+      state.items[1].asQuestion().questionnaireItem.let { questionItem ->
         assertThat(questionItem.type).isEqualTo(Questionnaire.QuestionnaireItemType.BOOLEAN)
         assertThat(questionItem.linkId).isEqualTo("page1-1")
         assertThat(questionItem.text).isEqualTo("Question on page 1")
@@ -2742,7 +2779,9 @@ class QuestionnaireViewModelTest {
 
     val viewModel = QuestionnaireViewModel(context, state)
 
-    assertThat(viewModel.getQuestionnaireItemViewItemList().last().questionnaireItem.linkId)
+    assertThat(
+        viewModel.getQuestionnaireItemViewItemList().last().asQuestion().questionnaireItem.linkId
+      )
       .isEqualTo("nested-display-question")
   }
 
@@ -2789,7 +2828,9 @@ class QuestionnaireViewModelTest {
 
       val viewModel = QuestionnaireViewModel(context, state)
 
-      assertThat(viewModel.getQuestionnaireItemViewItemList().last().questionnaireItem.linkId)
+      assertThat(
+          viewModel.getQuestionnaireItemViewItemList().last().asQuestion().questionnaireItem.linkId
+        )
         .isEqualTo("parent-question")
     }
 
@@ -2836,7 +2877,9 @@ class QuestionnaireViewModelTest {
 
       val viewModel = QuestionnaireViewModel(context, state)
 
-      assertThat(viewModel.getQuestionnaireItemViewItemList().last().questionnaireItem.linkId)
+      assertThat(
+          viewModel.getQuestionnaireItemViewItemList().last().asQuestion().questionnaireItem.linkId
+        )
         .isEqualTo("parent-question")
     }
 
@@ -2883,7 +2926,9 @@ class QuestionnaireViewModelTest {
 
       val viewModel = QuestionnaireViewModel(context, state)
 
-      assertThat(viewModel.getQuestionnaireItemViewItemList().last().questionnaireItem.linkId)
+      assertThat(
+          viewModel.getQuestionnaireItemViewItemList().last().asQuestion().questionnaireItem.linkId
+        )
         .isEqualTo("parent-question")
     }
 
@@ -3494,15 +3539,17 @@ class QuestionnaireViewModelTest {
       val viewModel = createQuestionnaireViewModel(questionnaire)
 
       val birthdateItem =
-        viewModel.getQuestionnaireItemViewItemList().first {
-          it.questionnaireItem.linkId == "a-birthdate"
-        }
+        viewModel
+          .getQuestionnaireItemViewItemList()
+          .first { it.asQuestionOrNull()?.questionnaireItem?.linkId == "a-birthdate" }
+          .asQuestion()
 
       assertThat(birthdateItem.getQuestionnaireResponseItem().answer).isEmpty()
 
       viewModel
         .getQuestionnaireItemViewItemList()
-        .first { it.questionnaireItem.linkId == "a-age-years" }
+        .first { it.asQuestionOrNull()?.questionnaireItem?.linkId == "a-age-years" }
+        .asQuestion()
         .apply {
           this.answersChangedCallback(
             this.questionnaireItem,
@@ -3553,9 +3600,10 @@ class QuestionnaireViewModelTest {
 
       val viewModel = createQuestionnaireViewModel(questionnaire)
       val birthdateItem =
-        viewModel.getQuestionnaireItemViewItemList().first {
-          it.questionnaireItem.linkId == "a-birthdate"
-        }
+        viewModel
+          .getQuestionnaireItemViewItemList()
+          .first { it.asQuestionOrNull()?.questionnaireItem?.linkId == "a-birthdate" }
+          .asQuestion()
       val birthdateValue = DateType(Date())
       birthdateItem.apply {
         this.answersChangedCallback(
@@ -3576,7 +3624,8 @@ class QuestionnaireViewModelTest {
 
       viewModel
         .getQuestionnaireItemViewItemList()
-        .first { it.questionnaireItem.linkId == "a-age-years" }
+        .first { it.asQuestionOrNull()?.questionnaireItem?.linkId == "a-age-years" }
+        .asQuestion()
         .apply {
           this.answersChangedCallback(
             this.questionnaireItem,
@@ -3776,6 +3825,14 @@ class QuestionnaireViewModelTest {
     }
   }
 }
+
+private fun QuestionnaireAdapterItem.asQuestion(): QuestionnaireItemViewItem {
+  assertThat(this).isInstanceOf(QuestionnaireAdapterItem.Question::class.java)
+  return (this as QuestionnaireAdapterItem.Question).item
+}
+
+private fun QuestionnaireAdapterItem.asQuestionOrNull(): QuestionnaireItemViewItem? =
+  (this as? QuestionnaireAdapterItem.Question)?.item
 
 /**
  * Runs code that relies on the [QuestionnaireViewModel.viewModelScope]. Runs on [Dispatchers.Main],


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1766 

**Description**
This is a sealed class that currently only has one subtype, wrapping `QuestionnaireItemViewItem`.

More subtypes will be added in the future to support (for example) repeated group headers, allowing us to break from the current 1:1 mapping of question:row in our adapters.

`QuestionnaireItemEditAdapter` and `QuestionnaireItemReviewAdapter` were changed to use this new type.

**Alternative(s) considered**
Discussed in Eng Weekly, this is the best approach

**Type**
Code health

**Screenshots (if applicable)**

**Checklist**
- [X] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [X] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [X] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [X] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [X] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [X] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
