### PR TITLE
Add version to output path for Dokka

### DIFF
--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -106,7 +106,7 @@ dependencies {
 }
 
 tasks.dokkaHtml.configure {
-  outputDirectory.set(file("../docs/${Releases.DataCapture.artifactId}"))
+  outputDirectory.set(file("../docs/${Releases.DataCapture.artifactId}/${Releases.DataCapture.version}"))
   suppressInheritedMembers.set(true)
   dokkaSourceSets {
     named("main") {

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -106,7 +106,9 @@ dependencies {
 }
 
 tasks.dokkaHtml.configure {
-  outputDirectory.set(file("../docs/${Releases.DataCapture.artifactId}/${Releases.DataCapture.version}"))
+  outputDirectory.set(
+    file("../docs/${Releases.DataCapture.artifactId}/${Releases.DataCapture.version}")
+  )
   suppressInheritedMembers.set(true)
   dokkaSourceSets {
     named("main") {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
 }
 
 tasks.dokkaHtml.configure {
-  outputDirectory.set(file("../docs/${Releases.Engine.artifactId}"))
+  outputDirectory.set(file("../docs/${Releases.Engine.artifactId}/${Releases.Engine.version}"))
   suppressInheritedMembers.set(true)
   dokkaSourceSets {
     named("main") {

--- a/implementationguide/build.gradle.kts
+++ b/implementationguide/build.gradle.kts
@@ -92,7 +92,9 @@ dependencies {
 }
 
 tasks.dokkaHtml.configure {
-  outputDirectory.set(file("../docs/${Releases.ImplmentationGuide.artifactId}/${Releases.ImplmentationGuide.version}"))
+  outputDirectory.set(
+    file("../docs/${Releases.ImplmentationGuide.artifactId}/${Releases.ImplmentationGuide.version}")
+  )
   suppressInheritedMembers.set(true)
   dokkaSourceSets {
     named("main") {

--- a/implementationguide/build.gradle.kts
+++ b/implementationguide/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
 }
 
 tasks.dokkaHtml.configure {
-  outputDirectory.set(file("../docs/${Releases.ImplmentationGuide.artifactId}"))
+  outputDirectory.set(file("../docs/${Releases.ImplmentationGuide.artifactId}/${Releases.ImplmentationGuide.version}"))
   suppressInheritedMembers.set(true)
   dokkaSourceSets {
     named("main") {

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -140,7 +140,7 @@ dependencies {
 }
 
 tasks.dokkaHtml.configure {
-  outputDirectory.set(file("../docs/${Releases.Workflow.artifactId}"))
+  outputDirectory.set(file("../docs/${Releases.Workflow.artifactId}/${Releases.Workflow.version}"))
   suppressInheritedMembers.set(true)
   dokkaSourceSets {
     named("main") {


### PR DESCRIPTION
**Description**
In order to facilitate building documentation during the release process, @jingtang10 wants to have versioned documentation. This PR adds an additional directory of the current version number.

**Alternative(s) considered**
Continuing to use unversioned docs. Less preferable as it complicates the order of operations during a release.

**Type**
Documentation

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
