### PR TITLE
Cleanup the state of SliderViewHolder when item is recycled.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactory.kt
@@ -57,13 +57,14 @@ internal object QuestionnaireItemSliderViewHolderFactory :
         }
 
         with(slider) {
+          clearOnChangeListeners()
           valueFrom = minValue
           valueTo = maxValue
           stepSize =
-            (questionnaireItemViewItem.questionnaireItem?.sliderStepValue
+            (questionnaireItemViewItem.questionnaireItem.sliderStepValue
                 ?: SLIDER_DEFAULT_STEP_SIZE)
               .toFloat()
-          value = answer?.valueIntegerType?.value?.toFloat() ?: slider.valueFrom
+          value = answer?.valueIntegerType?.value?.toFloat() ?: valueFrom
 
           addOnChangeListener { _, newValue, _ ->
             // Responds to when slider's value is changed

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemSliderViewHolderFactoryTest.kt
@@ -327,4 +327,57 @@ class QuestionnaireItemSliderViewHolderFactoryTest {
 
     assertThat(viewHolder.itemView.findViewById<Slider>(R.id.slider).isEnabled).isFalse()
   }
+
+  @Test
+  fun `bind multiple times with different QuestionnaireItemViewItem should show proper slider value`() {
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+              value = IntegerType(10)
+            }
+          )
+        },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+
+    assertThat(viewHolder.itemView.findViewById<Slider>(R.id.slider).value).isEqualTo(10)
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+              value = IntegerType(12)
+            }
+          )
+        },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+
+    assertThat(viewHolder.itemView.findViewById<Slider>(R.id.slider).value).isEqualTo(12)
+
+    viewHolder.bind(
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          addExtension().apply {
+            url = "http://hl7.org/fhir/StructureDefinition/minValue"
+            setValue(IntegerType("50"))
+          }
+        },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    )
+
+    assertThat(viewHolder.itemView.findViewById<Slider>(R.id.slider).value).isEqualTo(50)
+  }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1818 

**Description**
1. Remove any previous changes listener so that the initialisation doesn't cause a side effect.
2. Added appropriate unit tests.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
No
**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
