### PR TITLE
Automatically add date separator between day month year

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
@@ -151,7 +151,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("40/0/-9992"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
+      .isEqualTo("Date format needs to be MM/dd/yyyy (e.g. 01/01/2023)")
   }
 
   @Test
@@ -170,7 +170,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("1/100/2"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
+      .isEqualTo("Date format needs to be MM/dd/yyyy (e.g. 01/01/2023)")
   }
 
   @Test
@@ -189,7 +189,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("40/1/2"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
+      .isEqualTo("Date format needs to be MM/dd/yyyy (e.g. 01/01/2023)")
   }
 
   @Test
@@ -208,7 +208,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("1/1/22222"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
+      .isEqualTo("Date format needs to be MM/dd/yyyy (e.g. 01/01/2023)")
   }
   @Test
   fun shouldNotSetDateInput_outsideMaxRange() {

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryEspressoTest.kt
@@ -151,7 +151,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("40/0/-9992"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be M/d/yy")
+      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
   }
 
   @Test
@@ -170,7 +170,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("1/100/2"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be M/d/yy")
+      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
   }
 
   @Test
@@ -189,7 +189,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("40/1/2"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be M/d/yy")
+      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
   }
 
   @Test
@@ -208,7 +208,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryEspressoTest {
     onView(withId(R.id.text_input_edit_text)).perform(ViewActions.typeText("1/1/22222"))
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
-      .isEqualTo("Date format needs to be M/d/yy")
+      .isEqualTo("Date format needs to be MM/dd/yyyy\n" + "Example: 01/01/2023")
   }
   @Test
   fun shouldNotSetDateInput_outsideMaxRange() {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/common/datatype/MoreTypes.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/common/datatype/MoreTypes.kt
@@ -18,7 +18,7 @@ package com.google.android.fhir.datacapture.common.datatype
 
 import android.content.Context
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.utilities.localizedString
+import com.google.android.fhir.datacapture.utilities.format
 import com.google.android.fhir.datacapture.utilities.toLocalizedString
 import com.google.android.fhir.datacapture.views.localDate
 import com.google.android.fhir.datacapture.views.localTime
@@ -72,9 +72,8 @@ fun Type.displayString(context: Context): String =
         this.code ?: context.getString(R.string.not_answered)
       } else display
     }
-    is DateType -> this.localDate?.localizedString ?: context.getString(R.string.not_answered)
-    is DateTimeType ->
-      "${this.localDate.localizedString} ${this.localTime.toLocalizedString(context)}"
+    is DateType -> this.localDate?.format() ?: context.getString(R.string.not_answered)
+    is DateTimeType -> "${this.localDate.format()} ${this.localTime.toLocalizedString(context)}"
     is DecimalType,
     is IntegerType -> (this as PrimitiveType<*>).valueAsString
         ?: context.getString(R.string.not_answered)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimes.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.time.ZoneId
 import java.util.Date
 
 internal val LocalDateTime.localizedDateString: String
-  get() = toLocalDate().localizedString
+  get() = toLocalDate().format()
 
 // ICU on Android does not observe the user's 24h/12h time format setting (obtained from
 // DateFormat.is24HourFormat()). In order to observe the setting, we are using DateFormat as

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimes.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimes.kt
@@ -22,9 +22,6 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
 
-internal val LocalDateTime.localizedDateString: String
-  get() = toLocalDate().format()
-
 // ICU on Android does not observe the user's 24h/12h time format setting (obtained from
 // DateFormat.is24HourFormat()). In order to observe the setting, we are using DateFormat as
 // suggested in the docs. See

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -80,6 +80,12 @@ internal fun parseDate(text: CharSequence?, acceptableDateFormat: String?): Loca
           .parse(text.toString())
       }
       .localDate
+
+  // date/localDate with year less than 4 digit throws ParseException which force user to enter year
+  // with digit 4 from >=1000
+  if (localDate.year.length() < 4) {
+    throw ParseException("Year has lesss than 4 digits.", -4)
+  }
   // date/localDate with year more than 4 digit throws data format exception if deep copy
   // operation get performed on QuestionnaireResponse,
   // QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent in org.hl7.fhir.r4.model

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -20,18 +20,33 @@ import android.icu.text.DateFormat
 import android.icu.text.SimpleDateFormat
 import com.google.android.fhir.datacapture.views.length
 import com.google.android.fhir.datacapture.views.localDate
-import com.google.android.fhir.datacapture.views.localeDatePattern
 import java.lang.StringBuilder
 import java.text.ParseException
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.FormatStyle
 import java.util.Date
+import java.util.Locale
 
 internal val LocalDate.localizedString: String
   get() {
     val date = Date.from(atStartOfDay(ZoneId.systemDefault())?.toInstant())
     return DateFormat.getDateInstance(DateFormat.SHORT).format(date)
   }
+
+/**
+ * Medium and long format styles use alphabetical month names which are difficult for the user to
+ * input. Use short format style which is always numerical.
+ */
+internal val localeDatePattern =
+  DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+    FormatStyle.SHORT,
+    null,
+    IsoChronology.INSTANCE,
+    Locale.getDefault()
+  )
 
 /** Special character used in date format */
 internal val dateFormatSpecialChar =
@@ -54,8 +69,8 @@ internal fun generateAcceptableDateFormat(
           newDateFormat.append("dd")
         }
       } else if (it == 'm') {
-        if (!newDateFormat.contains("mm")) {
-          newDateFormat.append("mm")
+        if (!newDateFormat.contains("MM")) {
+          newDateFormat.append("MM")
         }
       } else if (it == 'y') {
         if (!newDateFormat.contains("yyyy")) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -42,7 +42,7 @@ internal fun getDateSeparator(localeDatePattern: String): Char =
 
 /**
  * Converts date pattern to acceptable date pattern where 2 digits are expected for day(dd) and
- * month(MM) and 4 digits are expected for year(yyyy). e.g. dd/mm/yyyy is returned for d/M/yy"
+ * month(MM) and 4 digits are expected for year(yyyy), e.g., dd/mm/yyyy is returned for d/M/yy"
  */
 internal fun generateAcceptableDateFormat(localDatePattern: String): String {
   val dateFormatSeparator = getDateSeparator(localDatePattern)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -37,13 +37,10 @@ internal fun getDateSeparator(localeDatePattern: String): Char =
   localeDatePattern.lowercase().replace("m", "").replace("d", "").replace("y", "").first()
 
 /**
- * Convert date pattern to acceptable date pattern where 2 digits are expected for day and month, 4
- * digits are expected for year.
+ * Convert date pattern to acceptable date pattern where 2 digits are expected for day(dd) and
+ * month(MM), 4 digits are expected for year(yyyy).
  */
-internal fun generateAcceptableDateFormat(
-  datePattern: String,
-  dateFormatSpecialChar: Char
-): String {
+internal fun generateAcceptableDateFormat(datePattern: String, dateFormatSeparator: Char): String {
   var newDateFormat = StringBuilder()
   datePattern
     .lowercase()
@@ -60,15 +57,15 @@ internal fun generateAcceptableDateFormat(
         if (!newDateFormat.contains("yyyy")) {
           newDateFormat.append("yyyy")
         }
-      } else if (it == dateFormatSpecialChar) {
-        newDateFormat.append(dateFormatSpecialChar)
+      } else if (it == dateFormatSeparator) {
+        newDateFormat.append(dateFormatSeparator)
       }
     }
     .toString()
   return newDateFormat.toString()
 }
 
-/** Parse date string into given given format. */
+/** Parse date string into given date format. */
 internal fun parseDate(text: CharSequence?, acceptableDateFormat: String?): LocalDate {
   val localDate =
     if (!acceptableDateFormat.isNullOrEmpty()) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -20,7 +20,7 @@ import android.icu.text.DateFormat
 import android.icu.text.SimpleDateFormat
 import com.google.android.fhir.datacapture.views.length
 import com.google.android.fhir.datacapture.views.localDate
-import java.lang.Character.isLetterOrDigit
+import java.lang.Character.isLetter
 import java.lang.StringBuilder
 import java.text.ParseException
 import java.time.LocalDate
@@ -35,7 +35,7 @@ internal val LocalDate.localizedString: String
 
 /** Special character used in date format */
 internal fun getDateSeparator(localeDatePattern: String): Char =
-  localeDatePattern.filterNot { isLetterOrDigit(it) }.first()
+  localeDatePattern.filterNot { isLetter(it) }.first()
 
 /**
  * Convert date pattern to acceptable date pattern where 2 digits are expected for day(dd) and
@@ -43,26 +43,29 @@ internal fun getDateSeparator(localeDatePattern: String): Char =
  */
 internal fun generateAcceptableDateFormat(datePattern: String, dateFormatSeparator: Char): String {
   var newDateFormat = StringBuilder()
-  datePattern
-    .lowercase()
-    .forEach {
-      if (it == 'd') {
+  datePattern.lowercase().forEach {
+    when (it) {
+      'd' -> {
         if (!newDateFormat.contains("dd")) {
           newDateFormat.append("dd")
         }
-      } else if (it == 'm') {
+      }
+      'm' -> {
         if (!newDateFormat.contains("MM")) {
           newDateFormat.append("MM")
         }
-      } else if (it == 'y') {
+      }
+      'y' -> {
         if (!newDateFormat.contains("yyyy")) {
           newDateFormat.append("yyyy")
         }
-      } else if (it == dateFormatSeparator) {
+      }
+      dateFormatSeparator -> {
         newDateFormat.append(dateFormatSeparator)
       }
+      else -> {}
     }
-    .toString()
+  }
   return newDateFormat.toString()
 }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -24,11 +24,7 @@ import java.lang.StringBuilder
 import java.text.ParseException
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.chrono.IsoChronology
-import java.time.format.DateTimeFormatterBuilder
-import java.time.format.FormatStyle
 import java.util.Date
-import java.util.Locale
 
 internal val LocalDate.localizedString: String
   get() {
@@ -36,20 +32,8 @@ internal val LocalDate.localizedString: String
     return DateFormat.getDateInstance(DateFormat.SHORT).format(date)
   }
 
-/**
- * Medium and long format styles use alphabetical month names which are difficult for the user to
- * input. Use short format style which is always numerical.
- */
-internal val localeDatePattern =
-  DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-    FormatStyle.SHORT,
-    null,
-    IsoChronology.INSTANCE,
-    Locale.getDefault()
-  )
-
 /** Special character used in date format */
-internal val dateFormatSpecialChar =
+internal fun getDateSeparator(localeDatePattern: String): Char =
   localeDatePattern.lowercase().replace("m", "").replace("d", "").replace("y", "").first()
 
 /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -17,22 +17,76 @@
 package com.google.android.fhir.datacapture.utilities
 
 import android.icu.text.DateFormat
-import android.os.Build
-import java.text.SimpleDateFormat
+import android.icu.text.SimpleDateFormat
+import com.google.android.fhir.datacapture.views.length
+import com.google.android.fhir.datacapture.views.localDate
+import com.google.android.fhir.datacapture.views.localeDatePattern
+import java.lang.StringBuilder
+import java.text.ParseException
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
-import java.util.Locale
 
 internal val LocalDate.localizedString: String
   get() {
     val date = Date.from(atStartOfDay(ZoneId.systemDefault())?.toInstant())
-    return if (isAndroidIcuSupported()) {
-      DateFormat.getDateInstance(DateFormat.SHORT).format(date)
-    } else {
-      SimpleDateFormat.getDateInstance(java.text.DateFormat.SHORT, Locale.getDefault()).format(date)
-    }
+    return DateFormat.getDateInstance(DateFormat.SHORT).format(date)
   }
 
-// Android ICU is supported API level 24 onwards.
-internal fun isAndroidIcuSupported() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+/** Special character used in date format */
+internal val dateFormatSpecialChar =
+  localeDatePattern.lowercase().replace("m", "").replace("d", "").replace("y", "").first()
+
+/**
+ * Convert date pattern to acceptable date pattern where 2 digits are expected for day and month, 4
+ * digits are expected for year.
+ */
+internal fun generateAcceptableDateFormat(
+  datePattern: String,
+  dateFormatSpecialChar: Char
+): String {
+  var newDateFormat = StringBuilder()
+  datePattern
+    .lowercase()
+    .forEach {
+      if (it == 'd') {
+        if (!newDateFormat.contains("dd")) {
+          newDateFormat.append("dd")
+        }
+      } else if (it == 'm') {
+        if (!newDateFormat.contains("mm")) {
+          newDateFormat.append("mm")
+        }
+      } else if (it == 'y') {
+        if (!newDateFormat.contains("yyyy")) {
+          newDateFormat.append("yyyy")
+        }
+      } else if (it == dateFormatSpecialChar) {
+        newDateFormat.append(dateFormatSpecialChar)
+      }
+    }
+    .toString()
+  return newDateFormat.toString()
+}
+
+/** Parse date string into given given format. */
+internal fun parseDate(text: CharSequence?, acceptableDateFormat: String?): LocalDate {
+  val localDate =
+    if (!acceptableDateFormat.isNullOrEmpty()) {
+        SimpleDateFormat(acceptableDateFormat).apply { isLenient = false }.parse(text.toString())
+      } else {
+        DateFormat.getDateInstance(DateFormat.SHORT)
+          .apply { isLenient = false }
+          .parse(text.toString())
+      }
+      .localDate
+  // date/localDate with year more than 4 digit throws data format exception if deep copy
+  // operation get performed on QuestionnaireResponse,
+  // QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent in org.hl7.fhir.r4.model
+  // e.g ca.uhn.fhir.parser.DataFormatException: Invalid date/time format: "19843-12-21":
+  // Expected character '-' at index 4 but found 3
+  if (localDate.year.length() > 4) {
+    throw ParseException("Year has more than 4 digits.", 4)
+  }
+  return localDate
+}

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -28,12 +28,6 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
 
-internal val LocalDate.localizedString: String
-  get() {
-    val date = Date.from(atStartOfDay(ZoneId.systemDefault())?.toInstant())
-    return DateFormat.getDateInstance(DateFormat.SHORT).format(date)
-  }
-
 /**
  * Returns the first character that is not a letter in the given date pattern string (e.g. "/" for
  * "dd/mm/yyyy").
@@ -105,13 +99,14 @@ internal fun parseDate(text: String, canonicalizedDatePattern: String): LocalDat
 }
 
 /**
- * Returns formatted local date using canonicalizedDatePattern date pattern otherwise localized
- * String
+ * Returns the local date string using the provided date format, or the default date format for the
+ * system locale if no date format is provided.
  */
-internal fun LocalDate.format(canonicalizedDatePattern: String): String {
-  return if (canonicalizedDatePattern.isEmpty()) {
-    this.localizedString
+internal fun LocalDate.format(format: String? = null): String {
+  return if (format.isNullOrEmpty()) {
+    val date = Date.from(atStartOfDay(ZoneId.systemDefault())?.toInstant())
+    return DateFormat.getDateInstance(DateFormat.SHORT).format(date)
   } else {
-    DateTimeFormatter.ofPattern(canonicalizedDatePattern).format(this)
+    DateTimeFormatter.ofPattern(format).format(this)
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -80,7 +80,7 @@ internal fun canonicalizeDateFormat(datePattern: String): String {
   return newDateFormat.toString()
 }
 
-/** Parses a date string using the given date format. */
+/** Parses a date string using the given date format, or the default date format for the locale. */
 internal fun parseDate(text: String, canonicalizedDatePattern: String): LocalDate {
   val dateFormat =
     if (!canonicalizedDatePattern.isEmpty()) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -44,23 +44,30 @@ internal fun getDateSeparator(localeDatePattern: String): Char =
  * Converts date pattern to acceptable date pattern where 2 digits are expected for day(dd) and
  * month(MM) and 4 digits are expected for year(yyyy). e.g. dd/mm/yyyy is returned for d/M/yy"
  */
-internal fun generateAcceptableDateFormat(datePattern: String, dateFormatSeparator: Char): String {
+internal fun generateAcceptableDateFormat(localDatePattern: String): String {
+  val dateFormatSeparator = getDateSeparator(localDatePattern)
+  var hasDay = false
+  var hasMonth = false
+  var hasYear = false
   var newDateFormat = StringBuilder()
-  datePattern.lowercase().forEach {
+  localDatePattern.lowercase().forEach {
     when (it) {
       'd' -> {
-        if (!newDateFormat.contains("dd")) {
+        if (!hasDay) {
           newDateFormat.append("dd")
+          hasDay = true
         }
       }
       'm' -> {
-        if (!newDateFormat.contains("MM")) {
+        if (!hasMonth) {
           newDateFormat.append("MM")
+          hasMonth = true
         }
       }
       'y' -> {
-        if (!newDateFormat.contains("yyyy")) {
+        if (!hasYear) {
           newDateFormat.append("yyyy")
+          hasYear = true
         }
       }
       dateFormatSeparator -> {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -20,6 +20,7 @@ import android.icu.text.DateFormat
 import android.icu.text.SimpleDateFormat
 import com.google.android.fhir.datacapture.views.length
 import com.google.android.fhir.datacapture.views.localDate
+import java.lang.Character.isLetterOrDigit
 import java.lang.StringBuilder
 import java.text.ParseException
 import java.time.LocalDate
@@ -34,7 +35,7 @@ internal val LocalDate.localizedString: String
 
 /** Special character used in date format */
 internal fun getDateSeparator(localeDatePattern: String): Char =
-  localeDatePattern.lowercase().replace("m", "").replace("d", "").replace("y", "").first()
+  localeDatePattern.filterNot { isLetterOrDigit(it) }.first()
 
 /**
  * Convert date pattern to acceptable date pattern where 2 digits are expected for day(dd) and

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/utilities/MoreLocalDates.kt
@@ -39,50 +39,53 @@ internal fun getDateSeparator(localeDatePattern: String): Char =
  * Converts date pattern to acceptable date pattern where 2 digits are expected for day(dd) and
  * month(MM) and 4 digits are expected for year(yyyy), e.g., dd/mm/yyyy is returned for d/M/yy"
  */
-internal fun canonicalizeDateFormat(datePattern: String): String {
-  val dateFormatSeparator = getDateSeparator(datePattern)
+internal fun canonicalizeDatePattern(datePattern: String): String {
+  val datePatternSeparator = getDateSeparator(datePattern)
   var hasDay = false
   var hasMonth = false
   var hasYear = false
-  val newDateFormat = StringBuilder()
+  val newDatePattern = StringBuilder()
   datePattern.lowercase().forEach {
     when (it) {
       'd' -> {
         if (!hasDay) {
-          newDateFormat.append("dd")
+          newDatePattern.append("dd")
           hasDay = true
         }
       }
       'm' -> {
         if (!hasMonth) {
-          newDateFormat.append("MM")
+          newDatePattern.append("MM")
           hasMonth = true
         }
       }
       'y' -> {
         if (!hasYear) {
-          newDateFormat.append("yyyy")
+          newDatePattern.append("yyyy")
           hasYear = true
         }
       }
-      dateFormatSeparator -> {
-        newDateFormat.append(dateFormatSeparator)
+      datePatternSeparator -> {
+        newDatePattern.append(datePatternSeparator)
       }
       else -> {}
     }
   }
-  return newDateFormat.toString()
+  return newDatePattern.toString()
 }
 
-/** Parses a date string using the given date format, or the default date format for the locale. */
-internal fun parseDate(text: String, canonicalizedDatePattern: String): LocalDate {
+/**
+ * Parses a date string using the given date pattern, or the default date pattern for the device
+ * locale.
+ */
+internal fun parseDate(text: String, datePattern: String): LocalDate {
   val dateFormat =
-    if (!canonicalizedDatePattern.isEmpty()) {
-      SimpleDateFormat(canonicalizedDatePattern)
+    if (datePattern.isNotEmpty()) {
+      SimpleDateFormat(datePattern)
     } else {
       DateFormat.getDateInstance(DateFormat.SHORT)
     }
-  val localDate = dateFormat.apply { isLenient = false }.parse(text.toString()).localDate
+  val localDate = dateFormat.apply { isLenient = false }.parse(text).localDate
   // Throw ParseException if year is less than 4 digits.
   if (localDate.year.length() < 4) {
     throw ParseException("Year has less than 4 digits.", text.indexOf('y'))
@@ -99,14 +102,14 @@ internal fun parseDate(text: String, canonicalizedDatePattern: String): LocalDat
 }
 
 /**
- * Returns the local date string using the provided date format, or the default date format for the
- * system locale if no date format is provided.
+ * Returns the local date string using the provided date pattern, or the default date pattern for
+ * the system locale if no date pattern is provided.
  */
-internal fun LocalDate.format(format: String? = null): String {
-  return if (format.isNullOrEmpty()) {
+internal fun LocalDate.format(pattern: String? = null): String {
+  return if (pattern.isNullOrEmpty()) {
     val date = Date.from(atStartOfDay(ZoneId.systemDefault())?.toInstant())
     return DateFormat.getDateInstance(DateFormat.SHORT).format(date)
   } else {
-    DateTimeFormatter.ofPattern(format).format(this)
+    DateTimeFormatter.ofPattern(pattern).format(this)
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -285,10 +285,7 @@ internal fun handleDateFormatAfterTextChange(
   }
   // handle delete text and separator
   if (editableLength < acceptableDateFormat.length) {
-    if (acceptableDateFormat[editableLength] != dateFormatSeparator) {
-      // appends date digits as it is
-      editable.append(acceptableDateFormat[editableLength])
-    } else if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator) {
+    if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator) {
       // 02 is entered with dd/MM/yyyy so appending / to editable 02/
       editable.append(acceptableDateFormat[editableLength])
     }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -293,7 +293,7 @@ internal fun handleDateFormatAfterTextChange(
   }
   // handle delete text and separator
   if (editableLength < acceptableDateFormat.length) {
-    // if user is deleting separator then don't add it again. So check is added if its not deleting.
+    // Do not add the separator again if the user has just deleted it.
     if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator) {
       // 02 is entered with dd/MM/yyyy so appending / to editable 02/
       editable.append(dateFormatSeparator)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -66,7 +66,7 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       private lateinit var textInputEditText: TextInputEditText
       override lateinit var questionnaireItemViewItem: QuestionnaireItemViewItem
       private lateinit var acceptableDateFormat: String
-      private var dateFormatSpecialChar: Char? = null
+      private var dateFormatSeparator: Char? = null
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
@@ -112,10 +112,10 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
             Locale.getDefault()
           )
         // Special character used in date format
-        dateFormatSpecialChar = getDateSeparator(localeDatePattern)
-        dateFormatSpecialChar?.let {
+        dateFormatSeparator = getDateSeparator(localeDatePattern)
+        dateFormatSeparator?.let {
           acceptableDateFormat =
-            generateAcceptableDateFormat(localeDatePattern, dateFormatSpecialChar!!)
+            generateAcceptableDateFormat(localeDatePattern, dateFormatSeparator!!)
         }
         textInputLayout.hint = acceptableDateFormat
         textInputEditText.removeTextChangedListener(textWatcher)
@@ -251,17 +251,16 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
               return
             }
             if (editableLength < acceptableDateFormat.length) {
-              if (acceptableDateFormat[editableLength] != dateFormatSpecialChar) {
+              if (acceptableDateFormat[editableLength] != dateFormatSeparator) {
                 editable.append(acceptableDateFormat[editableLength])
-              } else if (!isDeleting &&
-                  acceptableDateFormat[editableLength] == dateFormatSpecialChar
+              } else if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator
               ) {
                 editable.append(acceptableDateFormat[editableLength])
               }
-              if (acceptableDateFormat[editableLength - 1] == dateFormatSpecialChar &&
-                  editable[editableLength - 1] != dateFormatSpecialChar
+              if (acceptableDateFormat[editableLength - 1] == dateFormatSeparator &&
+                  editable[editableLength - 1] != dateFormatSeparator
               ) {
-                editable.insert(editableLength - 1, dateFormatSpecialChar.toString())
+                editable.insert(editableLength - 1, dateFormatSeparator.toString())
               }
             }
             updateAnswer(editable.toString())

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -85,7 +85,7 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
                   Instant.ofEpochMilli(epochMilli)
                     .atZone(ZONE_ID_UTC)
                     .toLocalDate()
-                    ?.format(canonicalizedDatePattern)
+                    .format(canonicalizedDatePattern)
                 textInputEditText.setText(formattedDate)
                 questionnaireItemViewItem.setAnswer(
                   QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -301,8 +301,7 @@ internal fun handleDateFormatAfterTextChange(
     if (acceptableDateFormat[editable.lastIndex] == dateFormatSeparator &&
         editable[editable.lastIndex] != dateFormatSeparator
     ) {
-      // this case to handle when user deletes separator from "12/" to "12" and enter digit again
-      // like "123" then it should convert to "12/3" as per format
+      // Add separator to break different date components, e.g. converting "123" to "12/3"
       editable.insert(editable.lastIndex, dateFormatSeparator.toString())
     }
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -224,9 +224,8 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
         }
       }
 
-      inner class DateTextWatcher(dateFormatSeparator: Char) : TextWatcher {
+      inner class DateTextWatcher(private val dateFormatSeparator: Char) : TextWatcher {
         private var isDeleting = false
-        private val dateFormatSeparator = dateFormatSeparator
 
         override fun beforeTextChanged(
           charSequence: CharSequence,
@@ -286,6 +285,10 @@ internal fun formatDate(localDate: LocalDate?, acceptableDateFormat: String?): S
   return ""
 }
 
+/**
+ * Format entered date to acceptable date format where 2 digits for day and month, 4 digits for
+ * year.
+ */
 internal fun handleDateFormatAfterTextChange(
   editable: Editable,
   acceptableDateFormat: String,
@@ -307,12 +310,12 @@ internal fun handleDateFormatAfterTextChange(
       // 02 is entered with dd/MM/yyyy so appending / to editable 02/
       editable.append(acceptableDateFormat[editableLength])
     }
-    if (acceptableDateFormat[editableLength - 1] == dateFormatSeparator &&
-        editable[editableLength - 1] != dateFormatSeparator
+    if (acceptableDateFormat[editable.lastIndex] == dateFormatSeparator &&
+        editable[editable.lastIndex] != dateFormatSeparator
     ) {
       // this case to handle when user deletes separator from "12/" to "12" and enter digit again
       // like "123" then it should convert to "12/3" as per format
-      editable.insert(editableLength - 1, dateFormatSeparator.toString())
+      editable.insert(editable.lastIndex, dateFormatSeparator.toString())
     }
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -24,7 +24,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.utilities.canonicalizeDateFormat
+import com.google.android.fhir.datacapture.utilities.canonicalizeDatePattern
 import com.google.android.fhir.datacapture.utilities.format
 import com.google.android.fhir.datacapture.utilities.getDateSeparator
 import com.google.android.fhir.datacapture.utilities.parseDate
@@ -106,10 +106,10 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         header.bind(questionnaireItemViewItem.questionnaireItem)
         val localeDatePattern = getLocalizedDateTimePattern()
-        // Special character used in date format
-        val dateFormatSeparator = getDateSeparator(localeDatePattern)
-        textWatcher = DatePatternTextWatcher(dateFormatSeparator)
-        canonicalizedDatePattern = canonicalizeDateFormat(localeDatePattern)
+        // Special character used in date pattern
+        val datePatternSeparator = getDateSeparator(localeDatePattern)
+        textWatcher = DatePatternTextWatcher(datePatternSeparator)
+        canonicalizedDatePattern = canonicalizeDatePattern(localeDatePattern)
         textInputLayout.hint = canonicalizedDatePattern
         textInputEditText.removeTextChangedListener(textWatcher)
         if (isTextUpdateRequired(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -106,19 +106,11 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         header.bind(questionnaireItemViewItem.questionnaireItem)
-        // Medium and long format styles use alphabetical month names which are difficult for the
-        // user to input. Use short format style which is always numerical.
-        val localeDatePattern =
-          DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-            FormatStyle.SHORT,
-            null,
-            IsoChronology.INSTANCE,
-            Locale.getDefault()
-          )
+        val localeDatePattern = getLocalizedDateTimePattern()
         // Special character used in date format
         val dateFormatSeparator = getDateSeparator(localeDatePattern)
         textWatcher = DatePatternTextWatcher(dateFormatSeparator)
-        acceptableDateFormat = generateAcceptableDateFormat(localeDatePattern, dateFormatSeparator)
+        acceptableDateFormat = generateAcceptableDateFormat(localeDatePattern)
         textInputLayout.hint = acceptableDateFormat
         textInputEditText.removeTextChangedListener(textWatcher)
         if (isTextUpdateRequired(
@@ -318,6 +310,19 @@ internal fun handleDateFormatAfterTextChange(
 
 internal const val TAG = "date-picker"
 internal val ZONE_ID_UTC = ZoneId.of("UTC")
+
+/**
+ * Medium and long format styles use alphabetical month names which are difficult for the user to
+ * input. Use short format style which is always numerical.
+ */
+internal fun getLocalizedDateTimePattern(): String {
+  return DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+    FormatStyle.SHORT,
+    null,
+    IsoChronology.INSTANCE,
+    Locale.getDefault()
+  )
+}
 
 /**
  * Returns the [AppCompatActivity] if there exists one wrapped inside [ContextThemeWrapper] s, or

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -242,26 +242,13 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
           ) {}
 
           override fun afterTextChanged(editable: Editable) {
-            val editableLength = editable.length
-            if (editable.isEmpty()) {
-              return
-            }
-            if (editableLength > acceptableDateFormat.length) {
-              editable.replace(acceptableDateFormat.length, editableLength, "")
-              return
-            }
-            if (editableLength < acceptableDateFormat.length) {
-              if (acceptableDateFormat[editableLength] != dateFormatSeparator) {
-                editable.append(acceptableDateFormat[editableLength])
-              } else if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator
-              ) {
-                editable.append(acceptableDateFormat[editableLength])
-              }
-              if (acceptableDateFormat[editableLength - 1] == dateFormatSeparator &&
-                  editable[editableLength - 1] != dateFormatSeparator
-              ) {
-                editable.insert(editableLength - 1, dateFormatSeparator.toString())
-              }
+            dateFormatSeparator?.let {
+              handleDateFormatAfterTextChange(
+                editable,
+                acceptableDateFormat,
+                dateFormatSeparator!!,
+                isDeleting
+              )
             }
             updateAnswer(editable.toString())
           }
@@ -283,6 +270,36 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       return true
     }
     return answer?.localDate != inputDate
+  }
+}
+
+internal fun handleDateFormatAfterTextChange(
+  editable: Editable,
+  acceptableDateFormat: String,
+  dateFormatSeparator: Char,
+  isDeleting: Boolean
+) {
+  val editableLength = editable.length
+  if (editable.isEmpty()) {
+    return
+  }
+  // restrict date entry upto acceptable date length
+  if (editableLength > acceptableDateFormat.length) {
+    editable.replace(acceptableDateFormat.length, editableLength, "")
+    return
+  }
+  // handle delete text and separator
+  if (editableLength < acceptableDateFormat.length) {
+    if (acceptableDateFormat[editableLength] != dateFormatSeparator) {
+      editable.append(acceptableDateFormat[editableLength])
+    } else if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator) {
+      editable.append(acceptableDateFormat[editableLength])
+    }
+    if (acceptableDateFormat[editableLength - 1] == dateFormatSeparator &&
+        editable[editableLength - 1] != dateFormatSeparator
+    ) {
+      editable.insert(editableLength - 1, dateFormatSeparator.toString())
+    }
   }
 }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -273,13 +273,12 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
   }
 }
 
-internal fun formatDate(localDate: LocalDate?, acceptableDateFormat: String?): String {
+internal fun formatDate(localDate: LocalDate?, acceptableDateFormat: String?): String? {
   localDate?.let {
-    if (!acceptableDateFormat.isNullOrEmpty()) {
-      val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(acceptableDateFormat)
-      return formatter.format(localDate)
-    } else {
+    if (acceptableDateFormat.isNullOrEmpty()) {
       return it.localizedString
+    } else {
+      return DateTimeFormatter.ofPattern(acceptableDateFormat).format(localDate)
     }
   }
   return ""

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -49,7 +49,8 @@ import java.time.ZoneId
 import java.time.chrono.IsoChronology
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
-import java.util.*
+import java.util.Date
+import java.util.Locale
 import kotlin.collections.ArrayList
 import kotlin.math.abs
 import kotlin.math.log10

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -101,6 +101,13 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       @SuppressLint("NewApi") // java.time APIs can be used due to desugaring
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         header.bind(questionnaireItemViewItem.questionnaireItem)
+        val localeDatePattern =
+          DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+            FormatStyle.SHORT,
+            null,
+            IsoChronology.INSTANCE,
+            Locale.getDefault()
+          )
         acceptableDateFormat =
           generateAcceptableDateFormat(localeDatePattern, dateFormatSpecialChar)
         textInputLayout.hint = acceptableDateFormat
@@ -194,7 +201,7 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
                   acceptableDateFormat,
                   acceptableDateFormat
                     .replace("dd", "01")
-                    .replace("mm", "01")
+                    .replace("MM", "01")
                     .replace("yyyy", "2023")
                 )
               )
@@ -280,18 +287,6 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
 
 internal const val TAG = "date-picker"
 internal val ZONE_ID_UTC = ZoneId.of("UTC")
-
-/**
- * Medium and long format styles use alphabetical month names which are difficult for the user to
- * input. Use short format style which is always numerical.
- */
-internal val localeDatePattern =
-  DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-    FormatStyle.SHORT,
-    null,
-    IsoChronology.INSTANCE,
-    Locale.getDefault()
-  )
 
 /**
  * Returns the [AppCompatActivity] if there exists one wrapped inside [ContextThemeWrapper] s, or

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -69,7 +69,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       private var localDate: LocalDate? = null
       private var localTime: LocalTime? = null
       private lateinit var acceptableDateFormat: String
-      private var dateFormatSpecialChar: Char? = null
+      private var dateFormatSeparator: Char? = null
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
@@ -137,10 +137,10 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
             Locale.getDefault()
           )
         // Special character used in date format
-        dateFormatSpecialChar = getDateSeparator(localeDatePattern)
-        dateFormatSpecialChar?.let {
+        dateFormatSeparator = getDateSeparator(localeDatePattern)
+        dateFormatSeparator?.let {
           acceptableDateFormat =
-            generateAcceptableDateFormat(localeDatePattern, dateFormatSpecialChar!!)
+            generateAcceptableDateFormat(localeDatePattern, dateFormatSeparator!!)
         }
         dateInputLayout.hint = acceptableDateFormat
         dateInputEditText.removeTextChangedListener(textWatcher)
@@ -393,17 +393,16 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
               return
             }
             if (editableLength < acceptableDateFormat.length) {
-              if (acceptableDateFormat[editableLength] != dateFormatSpecialChar) {
+              if (acceptableDateFormat[editableLength] != dateFormatSeparator) {
                 editable.append(acceptableDateFormat[editableLength])
-              } else if (!isDeleting &&
-                  acceptableDateFormat[editableLength] == dateFormatSpecialChar
+              } else if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator
               ) {
                 editable.append(acceptableDateFormat[editableLength])
               }
-              if (acceptableDateFormat[editableLength - 1] == dateFormatSpecialChar &&
-                  editable[editableLength - 1] != dateFormatSpecialChar
+              if (acceptableDateFormat[editableLength - 1] == dateFormatSeparator &&
+                  editable[editableLength - 1] != dateFormatSeparator
               ) {
-                editable.insert(editableLength - 1, dateFormatSpecialChar.toString())
+                editable.insert(editableLength - 1, dateFormatSeparator.toString())
               }
             }
             updateAnswerAfterTextChanged(editable.toString())

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -359,9 +359,8 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
         }
       }
 
-      inner class DateTextWatcher(dateFormatSeparator: Char) : TextWatcher {
+      inner class DateTextWatcher(private val dateFormatSeparator: Char) : TextWatcher {
         private var isDeleting = false
-        private val dateFormatSeparator = dateFormatSeparator
 
         override fun beforeTextChanged(
           charSequence: CharSequence,

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -48,7 +48,11 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.FormatStyle
 import java.util.Date
+import java.util.Locale
 import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
@@ -124,6 +128,13 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         clearPreviousState()
         header.bind(questionnaireItemViewItem.questionnaireItem)
+        val localeDatePattern =
+          DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+            FormatStyle.SHORT,
+            null,
+            IsoChronology.INSTANCE,
+            Locale.getDefault()
+          )
         acceptableDateFormat =
           generateAcceptableDateFormat(localeDatePattern, dateFormatSpecialChar)
 
@@ -331,7 +342,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
                   acceptableDateFormat,
                   acceptableDateFormat
                     .replace("dd", "01")
-                    .replace("mm", "01")
+                    .replace("MM", "01")
                     .replace("yyyy", "2023")
                 )
               )

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -69,7 +69,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       private var localDate: LocalDate? = null
       private var localTime: LocalTime? = null
       private lateinit var acceptableDateFormat: String
-      private var dateFormatSeparator: Char? = null
+      private lateinit var textWatcher: DateTextWatcher
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
@@ -137,11 +137,9 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
             Locale.getDefault()
           )
         // Special character used in date format
-        dateFormatSeparator = getDateSeparator(localeDatePattern)
-        dateFormatSeparator?.let {
-          acceptableDateFormat =
-            generateAcceptableDateFormat(localeDatePattern, dateFormatSeparator!!)
-        }
+        val dateFormatSeparator = getDateSeparator(localeDatePattern)
+        textWatcher = DateTextWatcher(dateFormatSeparator)
+        acceptableDateFormat = generateAcceptableDateFormat(localeDatePattern, dateFormatSeparator)
         dateInputLayout.hint = acceptableDateFormat
         dateInputEditText.removeTextChangedListener(textWatcher)
         val dateTime = questionnaireItemViewItem.answers.singleOrNull()?.valueDateTimeType
@@ -363,38 +361,36 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
         }
       }
 
-      val textWatcher =
-        object : TextWatcher {
-          private var isDeleting = false
+      inner class DateTextWatcher(dateFormatSeparator: Char) : TextWatcher {
+        private var isDeleting = false
+        private val dateFormatSeparator = dateFormatSeparator
 
-          override fun beforeTextChanged(
-            charSequence: CharSequence,
-            start: Int,
-            count: Int,
-            after: Int
-          ) {
-            isDeleting = count > after
-          }
-
-          override fun onTextChanged(
-            charSequence: CharSequence,
-            start: Int,
-            before: Int,
-            count: Int
-          ) {}
-
-          override fun afterTextChanged(editable: Editable) {
-            dateFormatSeparator?.let {
-              handleDateFormatAfterTextChange(
-                editable,
-                acceptableDateFormat,
-                dateFormatSeparator!!,
-                isDeleting
-              )
-            }
-            updateAnswerAfterTextChanged(editable.toString())
-          }
+        override fun beforeTextChanged(
+          charSequence: CharSequence,
+          start: Int,
+          count: Int,
+          after: Int
+        ) {
+          isDeleting = count > after
         }
+
+        override fun onTextChanged(
+          charSequence: CharSequence,
+          start: Int,
+          before: Int,
+          count: Int
+        ) {}
+
+        override fun afterTextChanged(editable: Editable) {
+          handleDateFormatAfterTextChange(
+            editable,
+            acceptableDateFormat,
+            dateFormatSeparator,
+            isDeleting
+          )
+          updateAnswerAfterTextChanged(editable.toString())
+        }
+      }
     }
 }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -25,8 +25,8 @@ import android.text.format.DateFormat
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.utilities.dateFormatSpecialChar
 import com.google.android.fhir.datacapture.utilities.generateAcceptableDateFormat
+import com.google.android.fhir.datacapture.utilities.getDateSeparator
 import com.google.android.fhir.datacapture.utilities.localizedDateString
 import com.google.android.fhir.datacapture.utilities.localizedString
 import com.google.android.fhir.datacapture.utilities.parseDate
@@ -69,6 +69,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       private var localDate: LocalDate? = null
       private var localTime: LocalTime? = null
       private lateinit var acceptableDateFormat: String
+      private var dateFormatSpecialChar: Char? = null
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
@@ -135,9 +136,12 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
             IsoChronology.INSTANCE,
             Locale.getDefault()
           )
-        acceptableDateFormat =
-          generateAcceptableDateFormat(localeDatePattern, dateFormatSpecialChar)
-
+        // Special character used in date format
+        dateFormatSpecialChar = getDateSeparator(localeDatePattern)
+        dateFormatSpecialChar?.let {
+          acceptableDateFormat =
+            generateAcceptableDateFormat(localeDatePattern, dateFormatSpecialChar!!)
+        }
         dateInputLayout.hint = acceptableDateFormat
         dateInputEditText.removeTextChangedListener(textWatcher)
         val dateTime = questionnaireItemViewItem.answers.singleOrNull()?.valueDateTimeType
@@ -361,7 +365,6 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
 
       val textWatcher =
         object : TextWatcher {
-          private var isRunning = false
           private var isDeleting = false
 
           override fun beforeTextChanged(
@@ -389,8 +392,6 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
               editable.replace(acceptableDateFormat.length, editableLength, "")
               return
             }
-            isRunning = true
-
             if (editableLength < acceptableDateFormat.length) {
               if (acceptableDateFormat[editableLength] != dateFormatSpecialChar) {
                 editable.append(acceptableDateFormat[editableLength])
@@ -405,8 +406,6 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
                 editable.insert(editableLength - 1, dateFormatSpecialChar.toString())
               }
             }
-            isRunning = false
-
             updateAnswerAfterTextChanged(editable.toString())
           }
         }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -384,26 +384,13 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
           ) {}
 
           override fun afterTextChanged(editable: Editable) {
-            val editableLength = editable.length
-            if (editable.isEmpty()) {
-              return
-            }
-            if (editableLength > acceptableDateFormat.length) {
-              editable.replace(acceptableDateFormat.length, editableLength, "")
-              return
-            }
-            if (editableLength < acceptableDateFormat.length) {
-              if (acceptableDateFormat[editableLength] != dateFormatSeparator) {
-                editable.append(acceptableDateFormat[editableLength])
-              } else if (!isDeleting && acceptableDateFormat[editableLength] == dateFormatSeparator
-              ) {
-                editable.append(acceptableDateFormat[editableLength])
-              }
-              if (acceptableDateFormat[editableLength - 1] == dateFormatSeparator &&
-                  editable[editableLength - 1] != dateFormatSeparator
-              ) {
-                editable.insert(editableLength - 1, dateFormatSeparator.toString())
-              }
+            dateFormatSeparator?.let {
+              handleDateFormatAfterTextChange(
+                editable,
+                acceptableDateFormat,
+                dateFormatSeparator!!,
+                isDeleting
+              )
             }
             updateAnswerAfterTextChanged(editable.toString())
           }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -25,7 +25,7 @@ import android.text.format.DateFormat
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.utilities.canonicalizeDateFormat
+import com.google.android.fhir.datacapture.utilities.canonicalizeDatePattern
 import com.google.android.fhir.datacapture.utilities.format
 import com.google.android.fhir.datacapture.utilities.getDateSeparator
 import com.google.android.fhir.datacapture.utilities.parseDate
@@ -125,10 +125,10 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
         clearPreviousState()
         header.bind(questionnaireItemViewItem.questionnaireItem)
         val localeDatePattern = getLocalizedDateTimePattern()
-        // Special character used in date format
-        val dateFormatSeparator = getDateSeparator(localeDatePattern)
-        textWatcher = DatePatternTextWatcher(dateFormatSeparator)
-        canonicalizedDatePattern = canonicalizeDateFormat(localeDatePattern)
+        // Special character used in date pattern
+        val datePatternSeparator = getDateSeparator(localeDatePattern)
+        textWatcher = DatePatternTextWatcher(datePatternSeparator)
+        canonicalizedDatePattern = canonicalizeDatePattern(localeDatePattern)
         dateInputLayout.hint = canonicalizedDatePattern
         dateInputEditText.removeTextChangedListener(textWatcher)
         val dateTime = questionnaireItemViewItem.answers.singleOrNull()?.valueDateTimeType
@@ -354,7 +354,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       }
 
       /** Automatically appends date separator (e.g. "/") during date input. */
-      inner class DatePatternTextWatcher(private val dateFormatSeparator: Char) : TextWatcher {
+      inner class DatePatternTextWatcher(private val datePatternSeparator: Char) : TextWatcher {
         private var isDeleting = false
 
         override fun beforeTextChanged(
@@ -377,7 +377,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
           handleDateFormatAfterTextChange(
             editable,
             canonicalizedDatePattern,
-            dateFormatSeparator,
+            datePatternSeparator,
             isDeleting
           )
           updateAnswerAfterTextChanged(editable.toString())

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -27,8 +27,6 @@ import android.view.inputmethod.InputMethodManager
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.utilities.generateAcceptableDateFormat
 import com.google.android.fhir.datacapture.utilities.getDateSeparator
-import com.google.android.fhir.datacapture.utilities.localizedDateString
-import com.google.android.fhir.datacapture.utilities.localizedString
 import com.google.android.fhir.datacapture.utilities.parseDate
 import com.google.android.fhir.datacapture.utilities.toLocalizedString
 import com.google.android.fhir.datacapture.utilities.toLocalizedTimeString
@@ -95,7 +93,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
               addOnPositiveButtonClickListener { epochMilli ->
                 with(Instant.ofEpochMilli(epochMilli).atZone(ZONE_ID_UTC).toLocalDate()) {
                   localDate = this
-                  dateInputEditText.setText(this.localizedString)
+                  dateInputEditText.setText(formatDate(this, acceptableDateFormat))
                   enableOrDisableTimePicker(enableIt = true)
                   generateLocalDateTime(this, localTime)?.let {
                     updateDateTimeInput(it, acceptableDateFormat)
@@ -210,7 +208,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
             acceptableDateFormat
           )
         ) {
-          dateInputEditText.setText(localDateTime?.localizedDateString ?: "")
+          dateInputEditText.setText(formatDate(localDateTime?.toLocalDate(), acceptableDateFormat))
         }
         timeInputEditText.setText(
           localDateTime?.toLocalizedTimeString(timeInputEditText.context) ?: ""

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -67,7 +67,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       private var localDate: LocalDate? = null
       private var localTime: LocalTime? = null
       private lateinit var acceptableDateFormat: String
-      private lateinit var textWatcher: DateTextWatcher
+      private lateinit var textWatcher: DatePatternTextWatcher
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
@@ -136,7 +136,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
           )
         // Special character used in date format
         val dateFormatSeparator = getDateSeparator(localeDatePattern)
-        textWatcher = DateTextWatcher(dateFormatSeparator)
+        textWatcher = DatePatternTextWatcher(dateFormatSeparator)
         acceptableDateFormat = generateAcceptableDateFormat(localeDatePattern, dateFormatSeparator)
         dateInputLayout.hint = acceptableDateFormat
         dateInputEditText.removeTextChangedListener(textWatcher)
@@ -197,10 +197,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       }
 
       /** Update the date and time input fields in the UI. */
-      private fun updateDateTimeInput(
-        localDateTime: LocalDateTime?,
-        acceptableDateFormat: String?
-      ) {
+      private fun updateDateTimeInput(localDateTime: LocalDateTime?, acceptableDateFormat: String) {
         enableOrDisableTimePicker(enableIt = localDateTime != null)
         if (isTextUpdateRequired(
             localDateTime,
@@ -208,7 +205,9 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
             acceptableDateFormat
           )
         ) {
-          dateInputEditText.setText(formatDate(localDateTime?.toLocalDate(), acceptableDateFormat))
+          val formattedDate =
+            localDateTime?.toLocalDate()?.let { formatDate(it, acceptableDateFormat) }
+          dateInputEditText.setText(formattedDate)
         }
         timeInputEditText.setText(
           localDateTime?.toLocalizedTimeString(timeInputEditText.context) ?: ""
@@ -359,7 +358,8 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
         }
       }
 
-      inner class DateTextWatcher(private val dateFormatSeparator: Char) : TextWatcher {
+      /** Automatically appends date separator (e.g. "/") during date input. */
+      inner class DatePatternTextWatcher(private val dateFormatSeparator: Char) : TextWatcher {
         private var isDeleting = false
 
         override fun beforeTextChanged(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -46,11 +46,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.chrono.IsoChronology
-import java.time.format.DateTimeFormatterBuilder
-import java.time.format.FormatStyle
 import java.util.Date
-import java.util.Locale
 import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
@@ -127,17 +123,11 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       override fun bind(questionnaireItemViewItem: QuestionnaireItemViewItem) {
         clearPreviousState()
         header.bind(questionnaireItemViewItem.questionnaireItem)
-        val localeDatePattern =
-          DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-            FormatStyle.SHORT,
-            null,
-            IsoChronology.INSTANCE,
-            Locale.getDefault()
-          )
+        val localeDatePattern = getLocalizedDateTimePattern()
         // Special character used in date format
         val dateFormatSeparator = getDateSeparator(localeDatePattern)
         textWatcher = DatePatternTextWatcher(dateFormatSeparator)
-        acceptableDateFormat = generateAcceptableDateFormat(localeDatePattern, dateFormatSeparator)
+        acceptableDateFormat = generateAcceptableDateFormat(localeDatePattern)
         dateInputLayout.hint = acceptableDateFormat
         dateInputEditText.removeTextChangedListener(textWatcher)
         val dateTime = questionnaireItemViewItem.answers.singleOrNull()?.valueDateTimeType

--- a/datacapture/src/main/res/values/strings.xml
+++ b/datacapture/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
         name="date_format_validation_error_msg"
     >Date format needs to be <xliff:g
             id="locale_format"
-        >%1$s</xliff:g>\nExample: %2$s</string>
+        >%1$s</xliff:g> (e.g. %2$s)</string>
     <string name="submit_button_text">Submit</string>
     <string name="button_pagination_next">Next</string>
     <string name="button_pagination_previous">Previous</string>

--- a/datacapture/src/main/res/values/strings.xml
+++ b/datacapture/src/main/res/values/strings.xml
@@ -18,7 +18,9 @@
     >Only use (.) between two numbers. Other special characters are not supported.</string>
     <string
         name="date_format_validation_error_msg"
-    >Date format needs to be <xliff:g id="locale_format">%1$s</xliff:g></string>
+    >Date format needs to be <xliff:g
+            id="locale_format"
+        >%1$s</xliff:g>\nExample: %2$s</string>
     <string name="submit_button_text">Submit</string>
     <string name="button_pagination_next">Next</string>
     <string name="button_pagination_previous">Previous</string>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireResponseItemAnswerComponentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/MoreQuestionnaireResponseItemAnswerComponentTest.kt
@@ -20,7 +20,7 @@ import android.app.Application
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.fhir.datacapture.common.datatype.displayString
-import com.google.android.fhir.datacapture.utilities.localizedString
+import com.google.android.fhir.datacapture.utilities.format
 import com.google.android.fhir.datacapture.utilities.toLocalizedString
 import com.google.common.truth.Truth.assertThat
 import java.time.LocalDate
@@ -176,7 +176,7 @@ class MoreQuestionnaireResponseItemAnswerComponentTest {
     val answer =
       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().setValue(DateType(Date()))
 
-    assertThat(answer.value.displayString(context)).isEqualTo(LocalDate.now().localizedString)
+    assertThat(answer.value.displayString(context)).isEqualTo(LocalDate.now().format())
   }
 
   @Test
@@ -186,7 +186,7 @@ class MoreQuestionnaireResponseItemAnswerComponentTest {
         .setValue(DateTimeType(Date()))
 
     assertThat(answer.value.displayString(context))
-      .isEqualTo("${LocalDate.now().localizedString} ${LocalTime.now().toLocalizedString(context)}")
+      .isEqualTo("${LocalDate.now().format()} ${LocalTime.now().toLocalizedString(context)}")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDateTimesTest.kt
@@ -35,7 +35,7 @@ class MoreLocalDateTimesTest {
   fun localizedString_US() {
     Locale.setDefault(Locale.US)
     val localDateTime = LocalDateTime.of(LocalDate.of(2010, 10, 18), LocalTime.of(18, 10, 10))
-    assertThat(localDateTime.localizedDateString).isEqualTo("10/18/10")
+    assertThat(localDateTime.toLocalDate().format()).isEqualTo("10/18/10")
     assertThat(localDateTime.toLocalizedTimeString(ApplicationProvider.getApplicationContext()))
       .isEqualTo("6:10 PM")
   }
@@ -45,7 +45,7 @@ class MoreLocalDateTimesTest {
     org.robolectric.shadows.ShadowSettings.set24HourTimeFormat(true)
     Locale.setDefault(Locale.US)
     val localDateTime = LocalDateTime.of(LocalDate.of(2010, 10, 18), LocalTime.of(18, 10, 10))
-    assertThat(localDateTime.localizedDateString).isEqualTo("10/18/10")
+    assertThat(localDateTime.toLocalDate().format()).isEqualTo("10/18/10")
     assertThat(localDateTime.toLocalizedTimeString(ApplicationProvider.getApplicationContext()))
       .isEqualTo("18:10")
   }
@@ -54,7 +54,7 @@ class MoreLocalDateTimesTest {
   fun localizedString_Japan() {
     Locale.setDefault(Locale.JAPAN)
     val localDateTime = LocalDateTime.of(LocalDate.of(2010, 10, 18), LocalTime.of(18, 10, 10))
-    assertThat(localDateTime.localizedDateString).isEqualTo("2010/10/18")
+    assertThat(localDateTime.toLocalDate().format()).isEqualTo("2010/10/18")
     assertThat(localDateTime.toLocalizedTimeString(ApplicationProvider.getApplicationContext()))
       .isEqualTo("6:10 午後")
   }
@@ -64,7 +64,7 @@ class MoreLocalDateTimesTest {
     org.robolectric.shadows.ShadowSettings.set24HourTimeFormat(true)
     Locale.setDefault(Locale.JAPAN)
     val localDateTime = LocalDateTime.of(LocalDate.of(2010, 10, 18), LocalTime.of(18, 10, 10))
-    assertThat(localDateTime.localizedDateString).isEqualTo("2010/10/18")
+    assertThat(localDateTime.toLocalDate().format()).isEqualTo("2010/10/18")
     assertThat(localDateTime.toLocalizedTimeString(ApplicationProvider.getApplicationContext()))
       .isEqualTo("18:10")
   }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
@@ -95,7 +95,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun `generate acceptable date pattern from US locale date pattern`() {
+  fun `canonicalize date format from US locale date pattern`() {
     Locale.setDefault(Locale.US)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -104,11 +104,11 @@ class MoreLocalDatesTest {
         IsoChronology.INSTANCE,
         Locale.getDefault()
       )
-    assertThat(generateAcceptableDateFormat(localeDatePattern)).isEqualTo("MM/dd/yyyy")
+    assertThat(canonicalizeDateFormat(localeDatePattern)).isEqualTo("MM/dd/yyyy")
   }
 
   @Test
-  fun `generate acceptable date pattern from Korean locale date pattern`() {
+  fun `canonicalize date format from Korean locale date pattern`() {
     Locale.setDefault(Locale.KOREA)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -117,11 +117,11 @@ class MoreLocalDatesTest {
         IsoChronology.INSTANCE,
         Locale.getDefault()
       )
-    assertThat(generateAcceptableDateFormat(localeDatePattern)).isEqualTo("yyyy.MM.dd.")
+    assertThat(canonicalizeDateFormat(localeDatePattern)).isEqualTo("yyyy.MM.dd.")
   }
 
   @Test
-  fun `generate acceptable date pattern from Canada locale date pattern`() {
+  fun `canonicalize date format from Canada locale date pattern`() {
     Locale.setDefault(Locale.CANADA)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -130,7 +130,7 @@ class MoreLocalDatesTest {
         IsoChronology.INSTANCE,
         Locale.getDefault()
       )
-    assertThat(generateAcceptableDateFormat(localeDatePattern)).isEqualTo("yyyy-MM-dd")
+    assertThat(canonicalizeDateFormat(localeDatePattern)).isEqualTo("yyyy-MM-dd")
   }
 
   @Test
@@ -155,5 +155,26 @@ class MoreLocalDatesTest {
   fun `parse US locale date for Canada locale`() {
     Locale.setDefault(Locale.CANADA)
     assertFailsWith<ParseException> { parseDate("01/25/2023", "yyyy-MM-dd") }
+  }
+
+  @Test
+  fun `format ITALY locale date using its canonicalizedDatePattern`() {
+    Locale.setDefault(Locale.ITALY)
+    val localeDatePattern =
+      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        FormatStyle.SHORT,
+        null,
+        IsoChronology.INSTANCE,
+        Locale.getDefault()
+      )
+    val localDate = LocalDate.of(2010, 1, 1)
+    assertThat(localDate.format(canonicalizeDateFormat(localeDatePattern))).isEqualTo("01/01/2010")
+  }
+
+  @Test
+  fun `format ITALY locale date using no canonicalizedDatePattern gives localized date string`() {
+    Locale.setDefault(Locale.ITALY)
+    val localDate = LocalDate.of(2010, 1, 1)
+    assertThat(localDate.format("")).isEqualTo(localDate.localizedString)
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
@@ -56,7 +56,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun getDateSeparator_US() {
+  fun `get date separator for US locale`() {
     Locale.setDefault(Locale.US)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -69,7 +69,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun getDateSeparator_KOREA() {
+  fun `get date separator for Korean locale`() {
     Locale.setDefault(Locale.KOREA)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -82,7 +82,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun getDateSeparator_Canada() {
+  fun `get date separator for Canada locale`() {
     Locale.setDefault(Locale.CANADA)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -95,7 +95,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun generateAcceptableDateFormat_US() {
+  fun `generate acceptable date pattern from US locale date pattern`() {
     Locale.setDefault(Locale.US)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -109,7 +109,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun generateAcceptableDateFormat_KOREA() {
+  fun `generate acceptable date pattern from Korean locale date pattern`() {
     Locale.setDefault(Locale.KOREA)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -123,7 +123,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun generateAcceptableDateFormat_Canada() {
+  fun `generate acceptable date pattern from Canada locale date pattern`() {
     Locale.setDefault(Locale.CANADA)
     val localeDatePattern =
       DateTimeFormatterBuilder.getLocalizedDateTimePattern(
@@ -137,7 +137,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun parseDate_US() {
+  fun `parse date for US locale`() {
     Locale.setDefault(Locale.US)
     val localDate = parseDate("01/25/2023", "MM/dd/yyyy")
     assertThat(localDate.dayOfMonth).isEqualTo(25)
@@ -146,7 +146,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun parseDate_KOREA() {
+  fun `parse date for Korean locale`() {
     Locale.setDefault(Locale.KOREA)
     val localDate = parseDate("2023.01.25.", "yyyy.MM.dd.")
     assertThat(localDate.dayOfMonth).isEqualTo(25)
@@ -155,7 +155,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun parseDateUS_inCanadaFormat() {
+  fun `parse US locale date for Canada locale`() {
     Locale.setDefault(Locale.CANADA)
     assertFailsWith<ParseException> { parseDate("01/25/2023", "yyyy-MM-dd") }
   }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
@@ -74,19 +74,19 @@ class MoreLocalDatesTest {
   @Test
   fun `should canonicalize date format from US locale date pattern`() {
     Locale.setDefault(Locale.US)
-    assertThat(canonicalizeDateFormat(getLocalizedDateTimePattern())).isEqualTo("MM/dd/yyyy")
+    assertThat(canonicalizeDatePattern(getLocalizedDateTimePattern())).isEqualTo("MM/dd/yyyy")
   }
 
   @Test
   fun `should canonicalize date format from Korean locale date pattern`() {
     Locale.setDefault(Locale.KOREA)
-    assertThat(canonicalizeDateFormat(getLocalizedDateTimePattern())).isEqualTo("yyyy.MM.dd.")
+    assertThat(canonicalizeDatePattern(getLocalizedDateTimePattern())).isEqualTo("yyyy.MM.dd.")
   }
 
   @Test
   fun `should canonicalize date format from Canada locale date pattern`() {
     Locale.setDefault(Locale.CANADA)
-    assertThat(canonicalizeDateFormat(getLocalizedDateTimePattern())).isEqualTo("yyyy-MM-dd")
+    assertThat(canonicalizeDatePattern(getLocalizedDateTimePattern())).isEqualTo("yyyy-MM-dd")
   }
 
   @Test
@@ -117,7 +117,7 @@ class MoreLocalDatesTest {
   fun `should format ITALY locale date using its canonicalizedDatePattern`() {
     Locale.setDefault(Locale.ITALY)
     val localDate = LocalDate.of(2010, 1, 1)
-    assertThat(localDate.format(canonicalizeDateFormat(getLocalizedDateTimePattern())))
+    assertThat(localDate.format(canonicalizeDatePattern(getLocalizedDateTimePattern())))
       .isEqualTo("01/01/2010")
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
@@ -104,8 +104,7 @@ class MoreLocalDatesTest {
         IsoChronology.INSTANCE,
         Locale.getDefault()
       )
-    assertThat(generateAcceptableDateFormat(localeDatePattern, getDateSeparator(localeDatePattern)))
-      .isEqualTo("MM/dd/yyyy")
+    assertThat(generateAcceptableDateFormat(localeDatePattern)).isEqualTo("MM/dd/yyyy")
   }
 
   @Test
@@ -118,8 +117,7 @@ class MoreLocalDatesTest {
         IsoChronology.INSTANCE,
         Locale.getDefault()
       )
-    assertThat(generateAcceptableDateFormat(localeDatePattern, getDateSeparator(localeDatePattern)))
-      .isEqualTo("yyyy.MM.dd.")
+    assertThat(generateAcceptableDateFormat(localeDatePattern)).isEqualTo("yyyy.MM.dd.")
   }
 
   @Test
@@ -132,8 +130,7 @@ class MoreLocalDatesTest {
         IsoChronology.INSTANCE,
         Locale.getDefault()
       )
-    assertThat(generateAcceptableDateFormat(localeDatePattern, getDateSeparator(localeDatePattern)))
-      .isEqualTo("yyyy-MM-dd")
+    assertThat(generateAcceptableDateFormat(localeDatePattern)).isEqualTo("yyyy-MM-dd")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
@@ -18,8 +18,13 @@ package com.google.android.fhir.datacapture.utilities
 
 import android.os.Build
 import com.google.common.truth.Truth.assertThat
+import java.text.ParseException
 import java.time.LocalDate
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.FormatStyle
 import java.util.Locale
+import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -48,5 +53,110 @@ class MoreLocalDatesTest {
     Locale.setDefault(Locale.ITALY)
     val localDate = LocalDate.of(2010, 10, 18)
     assertThat(localDate.localizedString).isEqualTo("18/10/10")
+  }
+
+  @Test
+  fun getDateSeparator_US() {
+    Locale.setDefault(Locale.US)
+    val localeDatePattern =
+      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        FormatStyle.SHORT,
+        null,
+        IsoChronology.INSTANCE,
+        Locale.getDefault()
+      )
+    assertThat(getDateSeparator(localeDatePattern)).isEqualTo('/')
+  }
+
+  @Test
+  fun getDateSeparator_KOREA() {
+    Locale.setDefault(Locale.KOREA)
+    val localeDatePattern =
+      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        FormatStyle.SHORT,
+        null,
+        IsoChronology.INSTANCE,
+        Locale.getDefault()
+      )
+    assertThat(getDateSeparator(localeDatePattern)).isEqualTo('.')
+  }
+
+  @Test
+  fun getDateSeparator_Canada() {
+    Locale.setDefault(Locale.CANADA)
+    val localeDatePattern =
+      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        FormatStyle.SHORT,
+        null,
+        IsoChronology.INSTANCE,
+        Locale.getDefault()
+      )
+    assertThat(getDateSeparator(localeDatePattern)).isEqualTo('-')
+  }
+
+  @Test
+  fun generateAcceptableDateFormat_US() {
+    Locale.setDefault(Locale.US)
+    val localeDatePattern =
+      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        FormatStyle.SHORT,
+        null,
+        IsoChronology.INSTANCE,
+        Locale.getDefault()
+      )
+    assertThat(generateAcceptableDateFormat(localeDatePattern, getDateSeparator(localeDatePattern)))
+      .isEqualTo("MM/dd/yyyy")
+  }
+
+  @Test
+  fun generateAcceptableDateFormat_KOREA() {
+    Locale.setDefault(Locale.KOREA)
+    val localeDatePattern =
+      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        FormatStyle.SHORT,
+        null,
+        IsoChronology.INSTANCE,
+        Locale.getDefault()
+      )
+    assertThat(generateAcceptableDateFormat(localeDatePattern, getDateSeparator(localeDatePattern)))
+      .isEqualTo("yyyy.MM.dd.")
+  }
+
+  @Test
+  fun generateAcceptableDateFormat_Canada() {
+    Locale.setDefault(Locale.CANADA)
+    val localeDatePattern =
+      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        FormatStyle.SHORT,
+        null,
+        IsoChronology.INSTANCE,
+        Locale.getDefault()
+      )
+    assertThat(generateAcceptableDateFormat(localeDatePattern, getDateSeparator(localeDatePattern)))
+      .isEqualTo("yyyy-MM-dd")
+  }
+
+  @Test
+  fun parseDate_US() {
+    Locale.setDefault(Locale.US)
+    val localDate = parseDate("01/25/2023", "MM/dd/yyyy")
+    assertThat(localDate.dayOfMonth).isEqualTo(25)
+    assertThat(localDate.month.value).isEqualTo(1)
+    assertThat(localDate.year).isEqualTo(2023)
+  }
+
+  @Test
+  fun parseDate_KOREA() {
+    Locale.setDefault(Locale.KOREA)
+    val localDate = parseDate("2023.01.25.", "yyyy.MM.dd.")
+    assertThat(localDate.dayOfMonth).isEqualTo(25)
+    assertThat(localDate.month.value).isEqualTo(1)
+    assertThat(localDate.year).isEqualTo(2023)
+  }
+
+  @Test
+  fun parseDateUS_inCanadaFormat() {
+    Locale.setDefault(Locale.CANADA)
+    assertFailsWith<ParseException> { parseDate("01/25/2023", "yyyy-MM-dd") }
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/utilities/MoreLocalDatesTest.kt
@@ -17,12 +17,10 @@
 package com.google.android.fhir.datacapture.utilities
 
 import android.os.Build
+import com.google.android.fhir.datacapture.views.getLocalizedDateTimePattern
 import com.google.common.truth.Truth.assertThat
 import java.text.ParseException
 import java.time.LocalDate
-import java.time.chrono.IsoChronology
-import java.time.format.DateTimeFormatterBuilder
-import java.time.format.FormatStyle
 import java.util.Locale
 import kotlin.test.assertFailsWith
 import org.junit.Test
@@ -35,106 +33,64 @@ import org.robolectric.annotation.Config
 class MoreLocalDatesTest {
 
   @Test
-  fun localizedString_US() {
+  fun `should format date in US locale`() {
     Locale.setDefault(Locale.US)
     val localDate = LocalDate.of(2010, 10, 18)
-    assertThat(localDate.localizedString).isEqualTo("10/18/10")
+    assertThat(localDate.format()).isEqualTo("10/18/10")
   }
 
   @Test
-  fun localizedString_Japan() {
+  fun `should format date in Japan locale`() {
     Locale.setDefault(Locale.JAPAN)
     val localDate = LocalDate.of(2010, 10, 18)
-    assertThat(localDate.localizedString).isEqualTo("2010/10/18")
+    assertThat(localDate.format()).isEqualTo("2010/10/18")
   }
 
   @Test
-  fun localizedString_Italy() {
+  fun `should format date in Italy locale`() {
     Locale.setDefault(Locale.ITALY)
     val localDate = LocalDate.of(2010, 10, 18)
-    assertThat(localDate.localizedString).isEqualTo("18/10/10")
+    assertThat(localDate.format()).isEqualTo("18/10/10")
   }
 
   @Test
-  fun `get date separator for US locale`() {
+  fun `should get date separator for US locale`() {
     Locale.setDefault(Locale.US)
-    val localeDatePattern =
-      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT,
-        null,
-        IsoChronology.INSTANCE,
-        Locale.getDefault()
-      )
-    assertThat(getDateSeparator(localeDatePattern)).isEqualTo('/')
+    assertThat(getDateSeparator(getLocalizedDateTimePattern())).isEqualTo('/')
   }
 
   @Test
-  fun `get date separator for Korean locale`() {
+  fun `should get date separator for Korean locale`() {
     Locale.setDefault(Locale.KOREA)
-    val localeDatePattern =
-      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT,
-        null,
-        IsoChronology.INSTANCE,
-        Locale.getDefault()
-      )
-    assertThat(getDateSeparator(localeDatePattern)).isEqualTo('.')
+    assertThat(getDateSeparator(getLocalizedDateTimePattern())).isEqualTo('.')
   }
 
   @Test
-  fun `get date separator for Canada locale`() {
+  fun `should get date separator for Canada locale`() {
     Locale.setDefault(Locale.CANADA)
-    val localeDatePattern =
-      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT,
-        null,
-        IsoChronology.INSTANCE,
-        Locale.getDefault()
-      )
-    assertThat(getDateSeparator(localeDatePattern)).isEqualTo('-')
+    assertThat(getDateSeparator(getLocalizedDateTimePattern())).isEqualTo('-')
   }
 
   @Test
-  fun `canonicalize date format from US locale date pattern`() {
+  fun `should canonicalize date format from US locale date pattern`() {
     Locale.setDefault(Locale.US)
-    val localeDatePattern =
-      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT,
-        null,
-        IsoChronology.INSTANCE,
-        Locale.getDefault()
-      )
-    assertThat(canonicalizeDateFormat(localeDatePattern)).isEqualTo("MM/dd/yyyy")
+    assertThat(canonicalizeDateFormat(getLocalizedDateTimePattern())).isEqualTo("MM/dd/yyyy")
   }
 
   @Test
-  fun `canonicalize date format from Korean locale date pattern`() {
+  fun `should canonicalize date format from Korean locale date pattern`() {
     Locale.setDefault(Locale.KOREA)
-    val localeDatePattern =
-      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT,
-        null,
-        IsoChronology.INSTANCE,
-        Locale.getDefault()
-      )
-    assertThat(canonicalizeDateFormat(localeDatePattern)).isEqualTo("yyyy.MM.dd.")
+    assertThat(canonicalizeDateFormat(getLocalizedDateTimePattern())).isEqualTo("yyyy.MM.dd.")
   }
 
   @Test
-  fun `canonicalize date format from Canada locale date pattern`() {
+  fun `should canonicalize date format from Canada locale date pattern`() {
     Locale.setDefault(Locale.CANADA)
-    val localeDatePattern =
-      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT,
-        null,
-        IsoChronology.INSTANCE,
-        Locale.getDefault()
-      )
-    assertThat(canonicalizeDateFormat(localeDatePattern)).isEqualTo("yyyy-MM-dd")
+    assertThat(canonicalizeDateFormat(getLocalizedDateTimePattern())).isEqualTo("yyyy-MM-dd")
   }
 
   @Test
-  fun `parse date for US locale`() {
+  fun `should parse date for US locale`() {
     Locale.setDefault(Locale.US)
     val localDate = parseDate("01/25/2023", "MM/dd/yyyy")
     assertThat(localDate.dayOfMonth).isEqualTo(25)
@@ -143,7 +99,7 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun `parse date for Korean locale`() {
+  fun `should parse date for Korean locale`() {
     Locale.setDefault(Locale.KOREA)
     val localDate = parseDate("2023.01.25.", "yyyy.MM.dd.")
     assertThat(localDate.dayOfMonth).isEqualTo(25)
@@ -152,29 +108,23 @@ class MoreLocalDatesTest {
   }
 
   @Test
-  fun `parse US locale date for Canada locale`() {
+  fun `should parse US locale date for Canada locale`() {
     Locale.setDefault(Locale.CANADA)
     assertFailsWith<ParseException> { parseDate("01/25/2023", "yyyy-MM-dd") }
   }
 
   @Test
-  fun `format ITALY locale date using its canonicalizedDatePattern`() {
+  fun `should format ITALY locale date using its canonicalizedDatePattern`() {
     Locale.setDefault(Locale.ITALY)
-    val localeDatePattern =
-      DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT,
-        null,
-        IsoChronology.INSTANCE,
-        Locale.getDefault()
-      )
     val localDate = LocalDate.of(2010, 1, 1)
-    assertThat(localDate.format(canonicalizeDateFormat(localeDatePattern))).isEqualTo("01/01/2010")
+    assertThat(localDate.format(canonicalizeDateFormat(getLocalizedDateTimePattern())))
+      .isEqualTo("01/01/2010")
   }
 
   @Test
-  fun `format ITALY locale date using no canonicalizedDatePattern gives localized date string`() {
+  fun `should use default locale if pattern is empty`() {
     Locale.setDefault(Locale.ITALY)
     val localDate = LocalDate.of(2010, 1, 1)
-    assertThat(localDate.format("")).isEqualTo(localDate.localizedString)
+    assertThat(localDate.format("")).isEqualTo(localDate.format())
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
@@ -104,7 +104,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     )
-    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/20")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/2020")
   }
 
   @Test
@@ -140,7 +140,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     )
-    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/20")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/2020")
   }
 
   @Test
@@ -310,7 +310,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     )
-    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/20")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/2020")
 
     viewHolder.bind(
       QuestionnaireItemViewItem(
@@ -324,7 +324,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
         answersChangedCallback = { _, _, _ -> },
       )
     )
-    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/21")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/2021")
 
     viewHolder.bind(
       QuestionnaireItemViewItem(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
@@ -178,7 +178,7 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
       )
     viewHolder.bind(item)
     viewHolder.dateInputView.text = "2020/11/19"
-    val answer = answers!!.single()?.value as DateType
+    val answer = answers!!.single().value as DateType
 
     assertThat(answer.day).isEqualTo(19)
     assertThat(answer.month).isEqualTo(10)

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
@@ -94,7 +94,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2/5/20")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("02/05/2020")
     assertThat(viewHolder.timeInputView.text.toString()).isEqualTo("1:30 AM")
   }
 
@@ -293,7 +293,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2/5/20")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("02/05/2020")
     assertThat(viewHolder.timeInputView.text.toString()).isEqualTo("1:30 AM")
 
     viewHolder.bind(
@@ -309,7 +309,7 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
       )
     )
 
-    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2/5/21")
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("02/05/2021")
     assertThat(viewHolder.timeInputView.text.toString()).isEqualTo("2:30 AM")
 
     viewHolder.bind(


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1802

**Description**
1. Fixed date format error message was visible after entering valid date which was partial answer in  QuestionnaireItemDateTimePickerViewHolderFactory.
2. isAndroidIcuSupported check is removed as 24 min API level is supported
3. Figure out separator from date pattern
4. Generate new date format have 2 digits for day and month, 4 digits for year mandatory.
5. Automatically date separator are added between day month year
6.  Change made to always get the latest value from Locale.getLocale()  
7. before setting date to editText from questionnaire answer , it is formatted to acceptable format having 2 digits for day and month, 4 digits for year mandatory
8. entered digit for years must be 4, if its less than 4 it will throw ParseException.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature 

**Screenshots (if applicable)**

https://user-images.githubusercontent.com/13957417/214569929-6b4edf33-dc7a-4199-9a7e-70053c3be0ed.mp4


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
