### PR TITLE
Show submit button in review mode.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -34,6 +34,7 @@ import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.views.QuestionnaireItemViewHolderFactory
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import org.hl7.fhir.r4.model.Questionnaire
+import timber.log.Timber
 
 /**
  * A [Fragment] for displaying FHIR Questionnaires and getting user responses as FHIR
@@ -208,7 +209,13 @@ open class QuestionnaireFragment : Fragment() {
           // Go back to the Edit mode if currently in the Review mode.
           viewModel.setReviewMode(false)
         }
-        else -> setFragmentResult(SUBMIT_REQUEST_KEY, Bundle.EMPTY)
+        QuestionnaireValidationErrorMessageDialogFragment.RESULT_VALUE_SUBMIT -> {
+          setFragmentResult(SUBMIT_REQUEST_KEY, Bundle.EMPTY)
+        }
+        else ->
+          Timber.e(
+            "Unknown fragment result ${bundle[QuestionnaireValidationErrorMessageDialogFragment.RESULT_KEY]}"
+          )
       }
     }
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -131,7 +131,7 @@ open class QuestionnaireFragment : Fragment() {
             questionnaireReviewRecyclerView.visibility = View.VISIBLE
 
             // Set button visibility
-            submitButton.visibility = View.GONE
+            submitButton.visibility = if (displayMode.showSubmitButton) View.VISIBLE else View.GONE
             reviewModeButton.visibility = View.GONE
             reviewModeEditButton.visibility =
               if (displayMode.showEditButton) {
@@ -202,7 +202,15 @@ open class QuestionnaireFragment : Fragment() {
     requireActivity().supportFragmentManager.setFragmentResultListener(
       QuestionnaireValidationErrorMessageDialogFragment.RESULT_CALLBACK,
       viewLifecycleOwner
-    ) { _, _ -> setFragmentResult(SUBMIT_REQUEST_KEY, Bundle.EMPTY) }
+    ) { _, bundle ->
+      when (bundle[QuestionnaireValidationErrorMessageDialogFragment.RESULT_KEY]) {
+        QuestionnaireValidationErrorMessageDialogFragment.RESULT_VALUE_FIX -> {
+          // Go back to the Edit mode if currently in the Review mode.
+          viewModel.setReviewMode(false)
+        }
+        else -> setFragmentResult(SUBMIT_REQUEST_KEY, Bundle.EMPTY)
+      }
+    }
   }
 
   /** Calculates the progress percentage from given [count] and [totalCount] values. */

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -24,6 +24,7 @@ import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.res.use
+import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResult
@@ -51,10 +52,11 @@ internal class QuestionnaireValidationErrorMessageDialogFragment(
     return MaterialAlertDialogBuilder(requireContext())
       .setView(onCreateCustomView())
       .setPositiveButton(R.string.questionnaire_validation_error_fix_button_text) { dialog, _ ->
+        setFragmentResult(RESULT_CALLBACK, bundleOf(RESULT_KEY to RESULT_VALUE_FIX))
         dialog?.dismiss()
       }
       .setNegativeButton(R.string.questionnaire_validation_error_submit_button_text) { dialog, _ ->
-        setFragmentResult(RESULT_CALLBACK, Bundle.EMPTY)
+        setFragmentResult(RESULT_CALLBACK, bundleOf(RESULT_KEY to RESULT_VALUE_SUBMIT))
         dialog?.dismiss()
       }
       .create()
@@ -90,6 +92,9 @@ internal class QuestionnaireValidationErrorMessageDialogFragment(
   companion object {
     const val TAG = "QuestionnaireValidationErrorMessageDialogFragment"
     const val RESULT_CALLBACK = "QuestionnaireValidationResultCallback"
+    const val RESULT_KEY = "result"
+    const val RESULT_VALUE_FIX = "result_fix"
+    const val RESULT_VALUE_SUBMIT = "result_submit"
   }
 }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -509,7 +509,11 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
     if (isReadOnly || isInReviewModeFlow.value) {
       return QuestionnaireState(
         items = questionnaireItemViewItems,
-        displayMode = DisplayMode.ReviewMode(showEditButton = !isReadOnly)
+        displayMode =
+          DisplayMode.ReviewMode(
+            showEditButton = !isReadOnly,
+            showSubmitButton = !isReadOnly && shouldShowSubmitButton
+          )
       )
     }
 
@@ -777,7 +781,7 @@ internal data class QuestionnaireState(
 
 internal sealed class DisplayMode {
   class EditMode(val pagination: QuestionnairePagination) : DisplayMode()
-  class ReviewMode(val showEditButton: Boolean) : DisplayMode()
+  class ReviewMode(val showEditButton: Boolean, val showSubmitButton: Boolean) : DisplayMode()
 }
 
 /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -781,7 +781,7 @@ internal data class QuestionnaireState(
 
 internal sealed class DisplayMode {
   class EditMode(val pagination: QuestionnairePagination) : DisplayMode()
-  class ReviewMode(val showEditButton: Boolean, val showSubmitButton: Boolean) : DisplayMode()
+  data class ReviewMode(val showEditButton: Boolean, val showSubmitButton: Boolean) : DisplayMode()
 }
 
 /**

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireFragmentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireFragmentTest.kt
@@ -17,13 +17,17 @@
 package com.google.android.fhir.datacapture
 
 import android.os.Build
+import android.view.View
+import android.widget.Button
 import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.fragment.app.testing.withFragment
 import androidx.lifecycle.Lifecycle
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_ENABLE_REVIEW_PAGE
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_JSON_STRING
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_SHOW_REVIEW_PAGE_FIRST
 import com.google.common.truth.Truth.assertThat
 import org.hl7.fhir.r4.model.Questionnaire
 import org.junit.Test
@@ -87,5 +91,35 @@ class QuestionnaireFragmentTest {
     scenario.withFragment {
       assertThat(calculateProgressPercentage(count = 10, totalCount = 50)).isEqualTo(20)
     }
+  }
+
+  @Test
+  fun `review page should show both edit and submit button`() {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          Questionnaire.QuestionnaireItemComponent().apply {
+            linkId = "a-link-id"
+            type = Questionnaire.QuestionnaireItemType.BOOLEAN
+          }
+        )
+      }
+    val questionnaireJson = parser.encodeResourceToString(questionnaire)
+    val scenario =
+      launchFragmentInContainer<QuestionnaireFragment>(
+        bundleOf(
+          EXTRA_QUESTIONNAIRE_JSON_STRING to questionnaireJson,
+          EXTRA_ENABLE_REVIEW_PAGE to true,
+          EXTRA_SHOW_REVIEW_PAGE_FIRST to true
+        )
+      )
+    scenario.moveToState(Lifecycle.State.RESUMED)
+    val view = scenario.withFragment { requireView() }
+
+    assertThat(view.findViewById<Button>(R.id.review_mode_edit_button).visibility)
+      .isEqualTo(View.VISIBLE)
+    assertThat(view.findViewById<Button>(R.id.submit_questionnaire).visibility)
+      .isEqualTo(View.VISIBLE)
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -3294,6 +3294,8 @@ class QuestionnaireViewModelTest {
       viewModel.setReviewMode(true)
       assertThat(viewModel.questionnaireStateFlow.first().displayMode)
         .isInstanceOf(DisplayMode.ReviewMode::class.java)
+      assertThat(viewModel.questionnaireStateFlow.first().displayMode)
+        .isEqualTo(DisplayMode.ReviewMode(showEditButton = true, showSubmitButton = true))
     }
   }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1817

**Description**
 1. Make submit button Visible in Review mode if the app is using the inbuilt submit button.
 2. Updated `QuestionnaireValidationErrorMessageDialogFragment` and `QuestionnaireFragment` to pass in appropriate result messages in callback to change mode from Review to Edit incase there are errors on Submit and user decides to fix them.

**Alternative(s) considered**
No

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**
[review_mode_edit.webm](https://user-images.githubusercontent.com/18224849/214304944-d5fd066d-a9f8-4626-91a8-d5fe219b8843.webm)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
