### PR TITLE
Do not clear the date input from textfield on clear answer.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -121,8 +121,7 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {
-        // When answers are cleared then it triggers [answersChangedCallback] with ValidationResult
-        // value is valid.
+        // do not clear an error text if answer is cleared and validation result is valid.
         if (questionnaireItemViewItem.answers.isEmpty() && validationResult == Valid) {
           return
         }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactory.kt
@@ -121,6 +121,12 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       }
 
       override fun displayValidationResult(validationResult: ValidationResult) {
+        // When answers are cleared then it triggers [answersChangedCallback] with ValidationResult
+        // value is valid.
+        if (questionnaireItemViewItem.answers.isEmpty() && validationResult == Valid) {
+          return
+        }
+
         textInputLayout.error =
           when (validationResult) {
             is NotValidated,
@@ -211,9 +217,6 @@ internal object QuestionnaireItemDatePickerViewHolderFactory :
       } catch (e: Exception) {
         null
       }
-    if (inputDate == null || answer == null) {
-      return true
-    }
     return answer?.localDate != inputDate
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -169,6 +169,11 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       }
 
       fun displayDateValidationError(validationResult: ValidationResult) {
+        // When answers are cleared then it triggers [answersChangedCallback] with ValidationResult
+        // value is valid.
+        if (questionnaireItemViewItem.answers.isEmpty() && validationResult == Valid) {
+          return
+        }
         dateInputLayout.error =
           when (validationResult) {
             is NotValidated,
@@ -295,8 +300,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
           } catch (e: Exception) {
             null
           }
-        if (answer == null || inputDate == null) return true
-        return answer.toLocalDate() != inputDate.toLocalDate()
+        return answer?.toLocalDate() != inputDate?.toLocalDate()
       }
 
       private fun showMaterialTimePicker(context: Context, inputMode: Int) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactory.kt
@@ -169,8 +169,7 @@ internal object QuestionnaireItemDateTimePickerViewHolderFactory :
       }
 
       fun displayDateValidationError(validationResult: ValidationResult) {
-        // When answers are cleared then it triggers [answersChangedCallback] with ValidationResult
-        // value is valid.
+        // do not clear an error text if answer is cleared and validation result is valid.
         if (questionnaireItemViewItem.answers.isEmpty() && validationResult == Valid) {
           return
         }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDatePickerViewHolderFactoryTest.kt
@@ -207,6 +207,27 @@ class QuestionnaireItemDatePickerViewHolderFactoryTest {
   }
 
   @Test
+  fun `do not clear the textField input on invalid date`() {
+    setLocale(Locale.US)
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    val questionnaireItem =
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+          .addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+              .setValue(DateType(2020, 10, 19))
+          ),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    viewHolder.bind(questionnaireItem)
+
+    viewHolder.dateInputView.text = "11/19/"
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("11/19/")
+  }
+
+  @Test
   fun displayValidationResult_error_shouldShowErrorMessage() {
     viewHolder.bind(
       QuestionnaireItemViewItem(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/QuestionnaireItemDateTimePickerViewHolderFactoryTest.kt
@@ -168,6 +168,25 @@ class QuestionnaireItemDateTimePickerViewHolderFactoryTest {
   }
 
   @Test
+  fun `do not clear the textField input on invalid date`() {
+    val itemViewItem =
+      QuestionnaireItemViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent()
+          .addAnswer(
+            QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
+              .setValue(DateTimeType(Date(2020 - 1900, 1, 5, 1, 30, 0)))
+          ),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _ -> },
+      )
+    viewHolder.bind(itemViewItem)
+    viewHolder.dateInputView.text = "2020/11/"
+
+    assertThat(viewHolder.dateInputView.text.toString()).isEqualTo("2020/11/")
+  }
+
+  @Test
   fun `if date input is invalid then do not enable time text input layout`() {
     val itemViewItem =
       QuestionnaireItemViewItem(


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1802

**Description**
Issue :
After user typed valid date input or selected it from calendar, it get parsed and answer get stored, but as soon as user make changes to make the date input invalid, then answer get cleared, and it also clears the textField text. 

https://user-images.githubusercontent.com/86107848/216016117-a4ae34a8-9ef1-46a9-9163-90c8fbd4d6d8.mov




Solution : 
Do not clear date text input from the textfield when answer get cleared on parsing get failed.

https://user-images.githubusercontent.com/86107848/216014947-35aac413-4faf-4dd8-b483-fbdabbc16c93.mov

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
