### PR TITLE
Fix for removing old indexes when resource is updated

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -54,8 +54,12 @@ internal abstract class ResourceDao {
   open suspend fun update(resource: Resource) {
     getResourceEntity(resource.logicalId, resource.resourceType)?.let {
       val entity = it.copy(serializedResource = iParser.encodeResourceToString(resource))
+      // The foreign key in Index entity tables is set with cascade delete constraint and
+      // insertResource has REPLACE conflict resolution. So, when we do an insert to update the
+      // resource, it deletes old resource and corresponding index entities (based on foreign key
+      // constrain) before inserting the new resource.
       insertResource(entity)
-      val index = ResourceIndexer.index(resource)
+      val index = resourceIndexer.index(resource)
       updateIndicesForResource(index, entity, it.resourceUuid)
     }
       ?: throw ResourceNotFoundException(resource.resourceType.name, resource.id)


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1825

**Description**
Issue: Updating resource via `FhirEngine.update ` api doesn't delete previous indexes.

Solution: In the database, for the `ResourceEntity` do `Insert` instead of `Update` as it results in the Deletion of old `ResourceEntity` (based on ConflictStrategy) that causes of its `IndexEntities` to get deleted as well based on their `ForeignKey` constrain.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

The other approach is to have a `Unique Index` for each IndexEntity that will Delete it based on the `insert*Index`'s `OnConflictStrategy`. 

Proposed solution is inline with how we handle updates for remote updates.

**Type**
Choose one: Bug fix
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
