### PR TITLE
Get code coverage working again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ buildscript {
   dependencies {
     classpath(Plugins.androidGradlePlugin)
     classpath(Plugins.benchmarkGradlePlugin)
+    classpath(Plugins.flankGradlePlugin)
     classpath(Plugins.kotlinGradlePlugin)
     classpath(Plugins.navSafeArgsGradlePlugin)
     classpath(Plugins.rulerGradlePlugin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ subprojects {
     maxParallelForks = 1
     if (project.providers.environmentVariable("GITHUB_ACTIONS").isPresent) {
       // limit memory usage to avoid running out of memory in the docker container.
-      maxHeapSize = "1024m"
+      maxHeapSize = "512m"
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ subprojects {
     maxParallelForks = 1
     if (project.providers.environmentVariable("GITHUB_ACTIONS").isPresent) {
       // limit memory usage to avoid running out of memory in the docker container.
-      maxHeapSize = "512m"
+      maxHeapSize = "1024m"
     }
   }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation("com.android.tools.build:gradle:7.1.1")
 
   implementation("app.cash.licensee:licensee-gradle-plugin:1.3.0")
+  implementation("com.osacky.flank.gradle:fladle:0.17.4")
 
   implementation("com.spotify.ruler:ruler-gradle-plugin:1.2.1")
 

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+
+@Suppress("SdCardPath")
+fun Project.configureFirebaseTestLab() {
+  apply(plugin = Plugins.BuildPlugins.fladle)
+  configure<com.osacky.flank.gradle.FlankGradleExtension> {
+    projectId.set("android-fhir-instrumeted-tests")
+    debugApk.set(
+      project.provider {
+        "$rootDir/demo/build/outputs/apk/androidTest/debug/demo-debug-androidTest.apk"
+      }
+    )
+    devices.set(
+      listOf(
+        mapOf("model" to "Nexus6P", "version" to "24", "locale" to "en_US"),
+        mapOf("model" to "Nexus6P", "version" to "27", "locale" to "en_US"),
+        mapOf("model" to "Pixel2", "version" to "30", "locale" to "en_US"),
+      )
+    )
+    instrumentationApk.set(project.provider { "$buildDir/outputs/apk/androidTest/debug/*.apk" })
+    flakyTestAttempts.set(3)
+    maxTestShards.set(50)
+    shardTime.set(120)
+    useOrchestrator.set(false)
+    environmentVariables.set(
+      mapOf("coverage" to "true", "coverageFile" to "/sdcard/Download/coverage.ec")
+    )
+    directoriesToPull.set(listOf("/sdcard/Download"))
+    resultsBucket.set("android-fhir-build-artifacts")
+    filesToDownload.set(listOf(".*/sdcard/Download/.*.ec"))
+  }
+}

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -37,8 +37,6 @@ fun Project.configureFirebaseTestLab() {
     )
     instrumentationApk.set(project.provider { "$buildDir/outputs/apk/androidTest/debug/*.apk" })
     flakyTestAttempts.set(3)
-    maxTestShards.set(50)
-    shardTime.set(120)
     useOrchestrator.set(false)
     environmentVariables.set(
       mapOf("coverage" to "true", "coverageFile" to "/sdcard/Download/coverage.ec")

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -37,12 +37,13 @@ fun Project.configureFirebaseTestLab() {
       )
     )
     instrumentationApk.set(project.provider { "$buildDir/outputs/apk/androidTest/debug/*.apk" })
-    flakyTestAttempts.set(3)
     useOrchestrator.set(false)
+    flakyTestAttempts.set(3)
     environmentVariables.set(
       mapOf("coverage" to "true", "coverageFile" to "/sdcard/Download/coverage.ec")
     )
     directoriesToPull.set(listOf("/sdcard/Download"))
+    filesToDownload.set(listOf(".*/sdcard/Download/.*.ec"))
     resultsBucket.set("android-fhir-build-artifacts")
     resultsDir.set(
       if (project.providers.environmentVariable("KOKORO_BUILD_ARTIFACTS_SUBDIR").isPresent) {
@@ -51,6 +52,10 @@ fun Project.configureFirebaseTestLab() {
         "${project.name}-${UUID.randomUUID()}"
       }
     )
-    filesToDownload.set(listOf(".*/sdcard/Download/.*.ec"))
+    maxTestShards.set(50)
+    shardTime.set(120)
+    smartFlankGcsPath.set(
+      "gs://android-fhir-build-artifacts/smart-flank/${project.name}/JUnitReport.xml"
+    )
   }
 }

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import java.util.UUID
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
@@ -43,6 +44,13 @@ fun Project.configureFirebaseTestLab() {
     )
     directoriesToPull.set(listOf("/sdcard/Download"))
     resultsBucket.set("android-fhir-build-artifacts")
+    resultsDir.set(
+      if (project.providers.environmentVariable("KOKORO_BUILD_ARTIFACTS_SUBDIR").isPresent) {
+        "${System.getenv("KOKORO_BUILD_ARTIFACTS_SUBDIR")}/firebase/${project.name}"
+      } else {
+        "${project.name}-${UUID.randomUUID()}"
+      }
+    )
     filesToDownload.set(listOf(".*/sdcard/Download/.*.ec"))
   }
 }

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -52,10 +52,5 @@ fun Project.configureFirebaseTestLab() {
         "${project.name}-${UUID.randomUUID()}"
       }
     )
-    maxTestShards.set(50)
-    shardTime.set(120)
-    smartFlankGcsPath.set(
-      "gs://android-fhir-build-artifacts/smart-flank/${project.name}/JUnitReport.xml"
-    )
   }
 }

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.android.build.api.dsl.LibraryExtension
 import java.util.UUID
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -31,9 +32,19 @@ fun Project.configureFirebaseTestLab() {
     )
     devices.set(
       listOf(
-        mapOf("model" to "Nexus6P", "version" to "24", "locale" to "en_US"),
+        mapOf(
+          "model" to "Nexus6P",
+          "version" to
+            "${this@configureFirebaseTestLab.extensions.getByType(LibraryExtension::class.java).defaultConfig.minSdk}",
+          "locale" to "en_US"
+        ),
         mapOf("model" to "Nexus6P", "version" to "27", "locale" to "en_US"),
-        mapOf("model" to "Pixel2", "version" to "30", "locale" to "en_US"),
+        mapOf(
+          "model" to "oriole",
+          "version" to
+            "${this@configureFirebaseTestLab.extensions.getByType(LibraryExtension::class.java).defaultConfig.targetSdk}",
+          "locale" to "en_US"
+        ),
       )
     )
     instrumentationApk.set(project.provider { "$buildDir/outputs/apk/androidTest/debug/*.apk" })

--- a/buildSrc/src/main/kotlin/JacocoConfig.kt
+++ b/buildSrc/src/main/kotlin/JacocoConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,18 @@ fun Project.createJacocoTestReportTask() {
       html.required.set(true)
     }
     sourceDirectories.setFrom("$projectDir/src/main/java")
-    classDirectories.setFrom(fileTree("$buildDir/tmp/kotlin-classes/debug"))
+    classDirectories.setFrom(
+      fileTree("$buildDir/tmp/kotlin-classes/debug")
+        .exclude(
+          "**/R.class",
+          "**/R$*.class",
+          "**/BuildConfig.*",
+          "**/Manifest*.*",
+          "**/*Test*.*",
+          "android/**/*.*"
+        )
+    )
+
     executionData.setFrom(
       fileTree(buildDir) {
         include(
@@ -66,6 +77,8 @@ fun Project.createJacocoTestReportTask() {
             "outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec",
             // Instrumentation coverage report location
             "outputs/code_coverage/debugAndroidTest/connected/**/*.ec",
+            // Instrumentation coverage report location from Firebase Test Lab
+            "fladle/results/**/*.ec",
           )
         )
       }

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -26,6 +26,7 @@ object Plugins {
     const val kotlinAndroid = "kotlin-android"
     const val kotlinKapt = "kotlin-kapt"
     const val mavenPublish = "maven-publish"
+    const val fladle = "com.osacky.fladle"
     const val navSafeArgs = "androidx.navigation.safeargs.kotlin"
     const val ruler = "com.spotify.ruler"
     const val spotless = "com.diffplug.spotless"
@@ -40,6 +41,7 @@ object Plugins {
   const val navSafeArgsGradlePlugin =
     "androidx.navigation:navigation-safe-args-gradle-plugin:${Dependencies.Versions.Androidx.navigation}"
   const val rulerGradlePlugin = "com.spotify.ruler:ruler-gradle-plugin:1.2.1"
+  const val flankGradlePlugin = "com.osacky.flank.gradle:fladle:0.17.4"
 
   object Versions {
     const val androidGradlePlugin = "7.2.1"

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -10,8 +10,6 @@ plugins {
 
 publishArtifact(Releases.DataCapture)
 
-configureFirebaseTestLab()
-
 createJacocoTestReportTask()
 
 android {
@@ -55,6 +53,8 @@ android {
 
   testOptions { animationsDisabled = true }
 }
+
+afterEvaluate { configureFirebaseTestLab() }
 
 configurations { all { exclude(module = "xpp3") } }
 

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 publishArtifact(Releases.DataCapture)
 
+configureFirebaseTestLab()
+
 createJacocoTestReportTask()
 
 android {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -12,8 +12,6 @@ plugins {
 
 publishArtifact(Releases.Engine)
 
-configureFirebaseTestLab()
-
 createJacocoTestReportTask()
 
 val generateSourcesTask =
@@ -76,6 +74,8 @@ android {
 
   configureJacocoTestOptions()
 }
+
+afterEvaluate { configureFirebaseTestLab() }
 
 configurations {
   all {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
 
 publishArtifact(Releases.Engine)
 
+configureFirebaseTestLab()
+
 createJacocoTestReportTask()
 
 val generateSourcesTask =

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -50,10 +50,6 @@ function zip_artifacts() {
   zip test-results/build.zip ./*/build -r -q
   find . -type f -regex ".*[t|androidT]est-results/.*xml" \
     -exec cp {} test-results/ \;
-
-  echo "URLs for screen capture videos:"
-  gsutil ls gs://$GCS_BUCKET/$KOKORO_BUILD_ARTIFACTS_SUBDIR/**/*.mp4 \
-    | sed 's|gs://|https://storage.googleapis.com/|'
 }
 
 # Installs dependencies to run CI pipeline. Dependencies are:
@@ -87,67 +83,10 @@ function build_only() {
 }
 
 # Runs instrumentation tests using Firebase Test Lab, and retrieves the code
-# coverage reports. First, we have to create the APKs to upload to Firebase.
-# There are four APKs that we use: one for each of the libraries we want to test,
-# and one for the demo app.
-#
-# 9 tests run in total: for each library, we run against 3 different API levels.
-# The tests for each library run in parallel and as background processes, but,
-# we wait for Firebase to finish execution of all the tests before pulling the
-# code coverage results from the GCS bucket.
-#
-# See: https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
-# for documentation on the gcloud command used in this function
-# See: https://cloud.google.com/storage/docs/gsutil/commands/cp
-# for documentation on the gsutil command used in this function
+# coverage reports.
 function device_tests() {
   ./gradlew packageDebugAndroidTest --scan --stacktrace
-  local lib_names=("datacapture" "engine")
-  firebase_pids=()
-  for lib_name in "${lib_names[@]}"; do
-   gcloud firebase test android run --type instrumentation \
-      --app demo/build/outputs/apk/androidTest/debug/demo-debug-androidTest.apk \
-      --test $lib_name/build/outputs/apk/androidTest/debug/$lib_name-debug-androidTest.apk \
-      --timeout 30m \
-      --device model=Nexus6P,version=24,locale=en_US \
-      --device model=Nexus6P,version=27,locale=en_US \
-      --device model=Pixel2,version=30,locale=en_US \
-      --environment-variables coverage=true,coverageFile="/sdcard/Download/coverage.ec" \
-      --directories-to-pull /sdcard/Download  \
-      --results-bucket=$GCS_BUCKET \
-      --results-dir=$KOKORO_BUILD_ARTIFACTS_SUBDIR/firebase/$lib_name \
-      --project=android-fhir-instrumeted-tests \
-      --num-flaky-test-attempts 3 \
-      --no-use-orchestrator &
-      firebase_pids+=("$!")
-  done
-
-  local lib_names_min_sdk_26=("workflow")
-  for lib_name in "${lib_names_min_sdk_26[@]}"; do
-   gcloud firebase test android run --type instrumentation \
-      --app demo/build/outputs/apk/androidTest/debug/demo-debug-androidTest.apk \
-      --test $lib_name/build/outputs/apk/androidTest/debug/$lib_name-debug-androidTest.apk \
-      --timeout 30m \
-      --device model=Nexus6P,version=27,locale=en_US \
-      --device model=Pixel2,version=30,locale=en_US \
-      --environment-variables coverage=true,coverageFile="/sdcard/Download/coverage.ec" \
-      --directories-to-pull /sdcard/Download  \
-      --results-bucket=$GCS_BUCKET \
-      --results-dir=$KOKORO_BUILD_ARTIFACTS_SUBDIR/firebase/$lib_name \
-      --project=android-fhir-instrumeted-tests \
-      --no-use-orchestrator &
-      firebase_pids+=("$!")
-  done
-
-  for firebase_pid in ${firebase_pids[*]}; do
-    wait $firebase_pid
-  done
-
-  mkdir -p {datacapture,engine,workflow}/build/outputs/code_coverage/debugAndroidTest/connected/firebase
-  for lib_name in "${lib_names[@]}"; do
-    gsutil -m cp -R gs://$GCS_BUCKET/$KOKORO_BUILD_ARTIFACTS_SUBDIR/firebase/$lib_name/Pixel2-30-en_US-portrait/**/coverage.ec \
-      $lib_name/build/outputs/code_coverage/debugAndroidTest/connected/firebase
-  done
+  ./gradlew runFlank  --scan --stacktrace
 }
 
 # Generates JaCoCo reports and uploads to Codecov: https://about.codecov.io/

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -73,7 +73,7 @@ android {
   configureJacocoTestOptions()
 }
 
-configureFirebaseTestLab()
+afterEvaluate { configureFirebaseTestLab() }
 
 configurations {
   all {

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -1,6 +1,5 @@
 import Dependencies.forceHapiVersion
 import Dependencies.removeIncompatibleDependencies
-import com.osacky.flank.gradle.FlankGradleExtension
 import java.net.URL
 
 plugins {
@@ -75,15 +74,6 @@ android {
 }
 
 configureFirebaseTestLab()
-
-configure<FlankGradleExtension> {
-  devices.set(
-    listOf(
-      mapOf("model" to "Nexus6P", "version" to "27", "locale" to "en_US"),
-      mapOf("model" to "Pixel2", "version" to "30", "locale" to "en_US"),
-    )
-  )
-}
 
 configurations {
   all {

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -1,5 +1,6 @@
 import Dependencies.forceHapiVersion
 import Dependencies.removeIncompatibleDependencies
+import com.osacky.flank.gradle.FlankGradleExtension
 import java.net.URL
 
 plugins {
@@ -71,6 +72,17 @@ android {
   kotlinOptions { jvmTarget = Java.kotlinJvmTarget.toString() }
 
   configureJacocoTestOptions()
+}
+
+configureFirebaseTestLab()
+
+configure<FlankGradleExtension> {
+  devices.set(
+    listOf(
+      mapOf("model" to "Nexus6P", "version" to "27", "locale" to "en_US"),
+      mapOf("model" to "Pixel2", "version" to "30", "locale" to "en_US"),
+    )
+  )
 }
 
 configurations {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**


**Description**
* Move firebase test lab setup from running in script to being a Gradle config
* Using new method fixes upload error Codecov used to face when adding instrumentation tests
* Codecov could not parse coverage.ec returned via gcloud, but does so now when run from gradle


**Type**
Choose one: (**Bug fix** | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
