### PR TITLE
Added Builder to Questionnaire Fragment.

### DIFF
--- a/catalog/src/main/java/com/google/android/fhir/catalog/CustomQuestionnaireFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/CustomQuestionnaireFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package com.google.android.fhir.catalog
 
-import com.google.android.fhir.datacapture.QuestionnaireFragment
+import com.google.android.fhir.datacapture.QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatcher
 import com.google.android.fhir.datacapture.contrib.views.barcode.QuestionnaireItemBarCodeReaderViewHolderFactory
 
-class CustomQuestionnaireFragment : QuestionnaireFragment() {
-  override fun getCustomQuestionnaireItemViewHolderFactoryMatchers():
+// TODO Remove this file and move this code to maybe a custom view in catalog app?
+class CustomQuestionnaireFragment /*: QuestionnaireFragment()*/ {
+  /*override*/ fun getCustomQuestionnaireItemViewHolderFactoryMatchers():
     List<QuestionnaireItemViewHolderFactoryMatcher> {
     return listOf(
       QuestionnaireItemViewHolderFactoryMatcher(CustomNumberPickerFactory) { questionnaireItem ->

--- a/catalog/src/main/java/com/google/android/fhir/catalog/CustomQuestionnaireFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/CustomQuestionnaireFragment.kt
@@ -31,9 +31,8 @@ class CustomQuestionnaireFragment /*: QuestionnaireFragment()*/ {
       },
       QuestionnaireItemViewHolderFactoryMatcher(QuestionnaireItemBarCodeReaderViewHolderFactory) {
         questionnaireItem ->
-        questionnaireItem.getExtensionByUrl(
-            QuestionnaireItemBarCodeReaderViewHolderFactory.WIDGET_EXTENSION
-          )
+        questionnaireItem
+          .getExtensionByUrl(QuestionnaireItemBarCodeReaderViewHolderFactory.WIDGET_EXTENSION)
           .let {
             if (it == null) false
             else it.value.toString() == QuestionnaireItemBarCodeReaderViewHolderFactory.WIDGET_TYPE

--- a/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireFragment.kt
@@ -145,7 +145,9 @@ class DemoQuestionnaireFragment : Fragment() {
           setReorderingAllowed(true)
           add(
             R.id.container,
-            QuestionnaireFragment.builder().setQuestionnaire(viewModel.getQuestionnaireJson()).build(),
+            QuestionnaireFragment.builder()
+              .setQuestionnaire(viewModel.getQuestionnaireJson())
+              .build(),
             QUESTIONNAIRE_FRAGMENT_TAG
           )
         }

--- a/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireFragment.kt
@@ -26,11 +26,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.add
 import androidx.fragment.app.commit
-import androidx.fragment.app.replace
 import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -146,14 +143,10 @@ class DemoQuestionnaireFragment : Fragment() {
       if (childFragmentManager.findFragmentByTag(QUESTIONNAIRE_FRAGMENT_TAG) == null) {
         childFragmentManager.commit {
           setReorderingAllowed(true)
-          add<QuestionnaireFragment>(
+          add(
             R.id.container,
-            tag = QUESTIONNAIRE_FRAGMENT_TAG,
-            args =
-              bundleOf(
-                QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to
-                  viewModel.getQuestionnaireJson()
-              )
+            QuestionnaireFragment.builder().setQuestionnaire(viewModel.getQuestionnaireJson()).build(),
+            QUESTIONNAIRE_FRAGMENT_TAG
           )
         }
       }
@@ -179,13 +172,10 @@ class DemoQuestionnaireFragment : Fragment() {
         }
       childFragmentManager.commit {
         setReorderingAllowed(true)
-        replace<QuestionnaireFragment>(
+        replace(
           R.id.container,
-          tag = QUESTIONNAIRE_FRAGMENT_TAG,
-          args =
-            bundleOf(
-              QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to questionnaireJsonString
-            )
+          QuestionnaireFragment.builder().setQuestionnaire(questionnaireJsonString).build(),
+          QUESTIONNAIRE_FRAGMENT_TAG
         )
       }
     }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
@@ -57,7 +57,9 @@ data class DataCaptureConfig(
   var xFhirQueryResolver: XFhirQueryResolver? = null,
 
   /**
-   * A [QuestionnaireItemViewHolderFactoryMatchersProviderFactory] may be set by the client to provide [QuestionnaireItemViewHolderFactoryMatcher]s to add custom questionnaire components or override the behaviour of existing components in the sdc.
+   * A [QuestionnaireItemViewHolderFactoryMatchersProviderFactory] may be set by the client to
+   * provide [QuestionnaireItemViewHolderFactoryMatcher]s to add custom questionnaire components or
+   * override the behaviour of existing components in the sdc.
    */
   var questionnaireItemViewHolderFactoryMatchersProviderFactory:
     QuestionnaireItemViewHolderFactoryMatchersProviderFactory? =
@@ -104,18 +106,15 @@ fun interface XFhirQueryResolver {
 }
 
 /**
- * Factory to create [QuestionnaireItemViewHolderFactoryMatchersProvider] for
- * the [QuestionnaireFragment] to provide [List] of
- * [QuestionnaireItemViewHolderFactoryMatcher]. The developers may provide the
- * factory to the library via [DataCaptureConfig] to add custom questionnaire components or override
- * the behaviour of existing components in the sdc.
+ * Factory to create [QuestionnaireItemViewHolderFactoryMatchersProvider] for the
+ * [QuestionnaireFragment] to provide [List] of [QuestionnaireItemViewHolderFactoryMatcher]. The
+ * developers may provide the factory to the library via [DataCaptureConfig] to add custom
+ * questionnaire components or override the behaviour of existing components in the sdc.
  *
  * See the
  * [developer guide](https://github.com/google/android-fhir/wiki/SDCL:-Customize-how-a-Questionnaire-is-displayed#custom-questionnaire-components)
  * for more information.
  */
 fun interface QuestionnaireItemViewHolderFactoryMatchersProviderFactory {
-  fun get(
-    provider: String
-  ): QuestionnaireItemViewHolderFactoryMatchersProvider
+  fun get(provider: String): QuestionnaireItemViewHolderFactoryMatchersProvider
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
@@ -18,6 +18,8 @@ package com.google.android.fhir.datacapture
 
 import android.app.Application
 import com.google.android.fhir.datacapture.DataCaptureConfig.Provider
+import com.google.android.fhir.datacapture.QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatcher
+import com.google.android.fhir.datacapture.QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatchersProvider
 import org.hl7.fhir.r4.context.SimpleWorkerContext
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Resource
@@ -53,6 +55,13 @@ data class DataCaptureConfig(
    * https://build.fhir.org/ig/HL7/sdc/expressions.html#fhirquery for more details.
    */
   var xFhirQueryResolver: XFhirQueryResolver? = null,
+
+  /**
+   * A [QuestionnaireItemViewHolderFactoryMatchersProviderFactory] may be set by the client to provide [QuestionnaireItemViewHolderFactoryMatcher]s to add custom questionnaire components or override the behaviour of existing components in the sdc.
+   */
+  var questionnaireItemViewHolderFactoryMatchersProviderFactory:
+    QuestionnaireItemViewHolderFactoryMatchersProviderFactory? =
+    null
 ) {
 
   internal val simpleWorkerContext: SimpleWorkerContext by lazy {
@@ -92,4 +101,21 @@ interface ExternalAnswerValueSetResolver {
  */
 fun interface XFhirQueryResolver {
   suspend fun resolve(xFhirQuery: String): List<Resource>
+}
+
+/**
+ * Factory to create [QuestionnaireItemViewHolderFactoryMatchersProvider] for
+ * the [QuestionnaireFragment] to provide [List] of
+ * [QuestionnaireItemViewHolderFactoryMatcher]. The developers may provide the
+ * factory to the library via [DataCaptureConfig] to add custom questionnaire components or override
+ * the behaviour of existing components in the sdc.
+ *
+ * See the
+ * [developer guide](https://github.com/google/android-fhir/wiki/SDCL:-Customize-how-a-Questionnaire-is-displayed#custom-questionnaire-components)
+ * for more information.
+ */
+fun interface QuestionnaireItemViewHolderFactoryMatchersProviderFactory {
+  fun get(
+    provider: String
+  ): QuestionnaireItemViewHolderFactoryMatchersProvider
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -310,21 +310,22 @@ class QuestionnaireFragment : Fragment() {
      * An [Boolean] extra to control if the questionnaire is read-only. If review page and read-only
      * are both enabled, read-only will take precedence.
      */
-    fun setIsReadOnly() = apply { args.add(EXTRA_READ_ONLY to true) }
+    fun setIsReadOnly(value: Boolean) = apply { args.add(EXTRA_READ_ONLY to value) }
 
     /**
      * A [Boolean] extra to control if a review page is shown. By default it will be shown at the
      * end of the questionnaire.
      */
-    fun showReviewPageBeforeSubmit() = apply { args.add(EXTRA_ENABLE_REVIEW_PAGE to true) }
+    fun showReviewPageBeforeSubmit(value: Boolean) = apply {
+      args.add(EXTRA_ENABLE_REVIEW_PAGE to value)
+    }
 
     /**
      * A [Boolean] extra to control if the review page is to be opened first. This has no effect if
      * review page is not enabled.
      */
-    fun showReviewPageFirst() = apply {
-      args.add(EXTRA_ENABLE_REVIEW_PAGE to true)
-      args.add(EXTRA_SHOW_REVIEW_PAGE_FIRST to true)
+    fun showReviewPageFirst(value: Boolean) = apply {
+      args.add(EXTRA_SHOW_REVIEW_PAGE_FIRST to value)
     }
 
     /**
@@ -345,6 +346,7 @@ class QuestionnaireFragment : Fragment() {
       return QuestionnaireFragment().apply { arguments = buildArgs() }
     }
   }
+
   /**
    * Extras that can be passed to [QuestionnaireFragment] to define its behavior. When you create a
    * QuestionnaireFragment, one of [EXTRA_QUESTIONNAIRE_JSON_URI] or

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -414,7 +414,7 @@ class QuestionnaireFragment : Fragment() {
      * A [Boolean] extra to show or hide the Submit button in the questionnaire. Default is true.
      */
     const val EXTRA_SHOW_SUBMIT_BUTTON = "show-submit-button"
-}
+  }
 
   /**
    * Data class that holds a matcher function ([matches]) which evaluates whether a given [factory]

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.fhir.datacapture
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -23,6 +24,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.res.use
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResult
@@ -44,8 +46,23 @@ import timber.log.Timber
  * [QuestionnaireFragment](https://github.com/google/android-fhir/wiki/SDCL%3A-Use-QuestionnaireFragment)
  * developer guide.
  */
-open class QuestionnaireFragment : Fragment() {
+class QuestionnaireFragment : Fragment() {
   private val viewModel: QuestionnaireViewModel by viewModels()
+
+  /**
+   * Provides a [QuestionnaireItemViewHolderFactoryMatcher]s which are used to evaluate whether a
+   * custom [QuestionnaireItemViewHolderFactory] should be used to render a given questionnaire
+   * item.
+   * The provider may be provided by the application developer via [DataCaptureConfig], otherwise default no-op implementation is used.
+   */
+  private val customQuestionnaireItemViewHolderFactoryMatchersProvider:
+    QuestionnaireItemViewHolderFactoryMatchersProvider by lazy {
+    DataCapture.getConfiguration(requireContext())
+      .questionnaireItemViewHolderFactoryMatchersProviderFactory?.get(
+        requireArguments().getString(EXTRA_MATCHERS_FACTORY, "")
+      )
+      ?: NoOpQuestionnaireItemViewHolderFactoryMatchersProviderImpl
+  }
 
   /** @suppress */
   override fun onCreateView(
@@ -95,7 +112,10 @@ open class QuestionnaireFragment : Fragment() {
     val questionnaireProgressIndicator: LinearProgressIndicator =
       view.findViewById(R.id.questionnaire_progress_indicator)
     val questionnaireItemEditAdapter =
-      QuestionnaireItemEditAdapter(getCustomQuestionnaireItemViewHolderFactoryMatchers())
+      QuestionnaireItemEditAdapter(
+        customQuestionnaireItemViewHolderFactoryMatchersProvider
+          .getQuestionnaireItemViewHolderFactoryMatcher()
+      )
     val questionnaireItemReviewAdapter = QuestionnaireItemReviewAdapter()
 
     val submitButton = requireView().findViewById<Button>(R.id.submit_questionnaire)
@@ -226,28 +246,105 @@ open class QuestionnaireFragment : Fragment() {
   }
 
   /**
-   * Override this method to specify when custom questionnaire components should be used. It should
-   * return a [List] of [QuestionnaireItemViewHolderFactoryMatcher]s which are used to evaluate
-   * whether a custom [QuestionnaireItemViewHolderFactory] should be used to render a given
-   * questionnaire item.
-   *
-   * User-provided custom views take precedence over canonical views provided by the library. If
-   * multiple [QuestionnaireItemViewHolderFactoryMatcher] are applicable for the same item, the
-   * behavior is undefined (any of them may be selected).
-   *
-   * See the
-   * [developer guide](https://github.com/google/android-fhir/wiki/SDCL:-Customize-how-a-Questionnaire-is-displayed#custom-questionnaire-components)
-   * for more information.
-   */
-  open fun getCustomQuestionnaireItemViewHolderFactoryMatchers() =
-    emptyList<QuestionnaireItemViewHolderFactoryMatcher>()
-
-  /**
    * Returns a [QuestionnaireResponse][org.hl7.fhir.r4.model.QuestionnaireResponse] populated with
    * any answers that are present on the rendered [QuestionnaireFragment] when it is called.
    */
   fun getQuestionnaireResponse() = viewModel.getQuestionnaireResponse()
 
+  /**
+   * Helper to create [Questionnaire] with appropriate [Bundle] arguments.
+   */
+  class Builder {
+
+    private val args = mutableListOf<Pair<String, Any>>()
+
+    /**
+     * A JSON encoded string extra for a questionnaire. This should only be used for questionnaires
+     * with size at most 512KB. For large questionnaires, use `setQuestionnaire(questionnaireUri:
+     * Uri)`.
+     *
+     * This is required unless `setQuestionnaire(questionnaireUri: Uri)` is provided.
+     *
+     * If this and `setQuestionnaire(questionnaireUri: Uri)` are provided,
+     * [setQuestionnaire(questionnaireUri: Uri)] takes precedence.
+     */
+    fun setQuestionnaire(questionnaireJson: String) = apply {
+      args.add(EXTRA_QUESTIONNAIRE_JSON_STRING to questionnaireJson)
+    }
+
+    /**
+     * A [URI][android.net.Uri] extra for streaming a JSON encoded questionnaire.
+     *
+     * This is required unless `setQuestionnaire(questionnaireJson: String)` is provided.
+     *
+     * If this and `setQuestionnaire(questionnaireJson: String)` are provided, this extra takes
+     * precedence.
+     */
+    fun setQuestionnaire(questionnaireUri: Uri) = apply {
+      args.add(EXTRA_QUESTIONNAIRE_JSON_URI to questionnaireUri)
+    }
+
+    /**
+     * A JSON encoded string extra for a prefilled questionnaire response. This should only be used
+     * for questionnaire response with size at most 512KB. For large questionnaire response, use
+     * `setQuestionnaireResponse(questionnaireResponseUri: Uri)`.
+     *
+     * If this and `setQuestionnaireResponse(questionnaireResponseUri: Uri)` are provided,
+     * `setQuestionnaireResponse(questionnaireResponseUri: Uri)` takes precedence.
+     */
+    fun setQuestionnaireResponse(questionnaireResponseJson: String) = apply {
+      args.add(EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING to questionnaireResponseJson)
+    }
+
+    /**
+     * A [URI][android.net.Uri] extra for streaming a JSON encoded questionnaire response.
+     *
+     * If this and `setQuestionnaireResponse(questionnaireResponseJson: String)` are provided, this
+     * extra takes precedence.
+     */
+    fun setQuestionnaireResponse(questionnaireResponseUri: Uri) = apply {
+      args.add(EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI to questionnaireResponseUri)
+    }
+
+    /**
+     * An [Boolean] extra to control if the questionnaire is read-only. If review page and read-only
+     * are both enabled, read-only will take precedence.
+     */
+    fun setIsReadOnly() = apply { args.add(EXTRA_READ_ONLY to true) }
+
+    /**
+     * A [Boolean] extra to control if a review page is shown. By default it will be shown at the
+     * end of the questionnaire.
+     */
+    fun showReviewPageBeforeSubmit() = apply { args.add(EXTRA_ENABLE_REVIEW_PAGE to true) }
+
+    /**
+     * A [Boolean] extra to control if the review page is to be opened first. This has no effect if
+     * review page is not enabled.
+     */
+    fun showReviewPageFirst() = apply {
+      args.add(EXTRA_ENABLE_REVIEW_PAGE to true)
+      args.add(EXTRA_SHOW_REVIEW_PAGE_FIRST to true)
+    }
+
+    /**
+     * A matcher to provide [QuestionnaireItemViewHolderFactoryMatcher]s for custom
+     * [Questionnaire.QuestionnaireItemType]. The application needs to provide a
+     * [QuestionnaireItemViewHolderFactoryMatchersProviderFactory] in the [DataCaptureConfig]
+     * so that the [QuestionnaireFragment] can get instance of
+     * [QuestionnaireItemViewHolderFactoryMatchersProvider].
+     */
+    fun setCustomQuestionnaireItemViewHolderFactoryMatchersProvider(
+      matchersProviderFactory: String
+    ) = apply { args.add(EXTRA_MATCHERS_FACTORY to matchersProviderFactory) }
+
+    /**
+     * @return A [QuestionnaireFragment] with provided [Bundle] arguments.
+     */
+    fun build(): QuestionnaireFragment {
+      return QuestionnaireFragment().apply { arguments = bundleOf(*args.toTypedArray()) }
+    }
+  }
   /**
    * Extras that can be passed to [QuestionnaireFragment] to define its behavior. When you create a
    * QuestionnaireFragment, one of [EXTRA_QUESTIONNAIRE_JSON_URI] or
@@ -263,7 +360,7 @@ open class QuestionnaireFragment : Fragment() {
      * If this and [EXTRA_QUESTIONNAIRE_JSON_URI] are provided, [EXTRA_QUESTIONNAIRE_JSON_URI] takes
      * precedence.
      */
-    const val EXTRA_QUESTIONNAIRE_JSON_STRING = "questionnaire"
+    internal const val EXTRA_QUESTIONNAIRE_JSON_STRING = "questionnaire"
 
     /**
      * A [URI][android.net.Uri] extra for streaming a JSON encoded questionnaire.
@@ -272,7 +369,7 @@ open class QuestionnaireFragment : Fragment() {
      *
      * If this and [EXTRA_QUESTIONNAIRE_JSON_STRING] are provided, this extra takes precedence.
      */
-    const val EXTRA_QUESTIONNAIRE_JSON_URI = "questionnaire-uri"
+    internal const val EXTRA_QUESTIONNAIRE_JSON_URI = "questionnaire-uri"
 
     /**
      * A JSON encoded string extra for a prefilled questionnaire response. This should only be used
@@ -282,7 +379,7 @@ open class QuestionnaireFragment : Fragment() {
      * If this and [EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI] are provided,
      * [EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI] takes precedence.
      */
-    const val EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING = "questionnaire-response"
+    internal const val EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING = "questionnaire-response"
 
     /**
      * A [URI][android.net.Uri] extra for streaming a JSON encoded questionnaire response.
@@ -290,27 +387,31 @@ open class QuestionnaireFragment : Fragment() {
      * If this and [EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING] are provided, this extra takes
      * precedence.
      */
-    const val EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI = "questionnaire-response-uri"
+    internal const val EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI = "questionnaire-response-uri"
 
     /**
      * A [Boolean] extra to control if a review page is shown. By default it will be shown at the
      * end of the questionnaire.
      */
-    const val EXTRA_ENABLE_REVIEW_PAGE = "enable-review-page"
+    internal const val EXTRA_ENABLE_REVIEW_PAGE = "enable-review-page"
 
     /**
      * A [Boolean] extra to control if the review page is to be opened first. This has no effect if
      * review page is not enabled.
      */
-    const val EXTRA_SHOW_REVIEW_PAGE_FIRST = "show-review-page-first"
+    internal const val EXTRA_SHOW_REVIEW_PAGE_FIRST = "show-review-page-first"
 
     /**
      * An [Boolean] extra to control if the questionnaire is read-only. If review page and read-only
      * are both enabled, read-only will take precedence.
      */
-    const val EXTRA_READ_ONLY = "read-only"
+    internal const val EXTRA_READ_ONLY = "read-only"
+
+    internal const val EXTRA_MATCHERS_FACTORY = "matcher_factory_class"
 
     const val SUBMIT_REQUEST_KEY = "submit-request-key"
+
+    fun builder() = Builder()
   }
 
   /**
@@ -330,6 +431,42 @@ open class QuestionnaireFragment : Fragment() {
      */
     val matches: (Questionnaire.QuestionnaireItemComponent) -> Boolean,
   )
+
+  /**
+   * Provides the [QuestionnaireItemViewHolderFactoryMatcher]s which are used to evaluate whether a
+   * custom [QuestionnaireItemViewHolderFactory] should be used to render a given questionnaire
+   * item.
+   *
+   * **NOTE**:
+   *
+   * User-provided custom views take precedence over canonical views provided by the library. If
+   * multiple [QuestionnaireItemViewHolderFactoryMatcher] are applicable for the same item, the
+   * behavior is undefined (any of them may be selected).
+   *
+   * See the
+   * [developer guide](https://github.com/google/android-fhir/wiki/SDCL:-Customize-how-a-Questionnaire-is-displayed#custom-questionnaire-components)
+   * for more information.
+   */
+  abstract class QuestionnaireItemViewHolderFactoryMatchersProvider {
+    /**
+     * Implementation should specify when custom questionnaire components should be used.
+     *
+     * @return A [List] of [QuestionnaireItemViewHolderFactoryMatcher]s which are used to evaluate
+     * whether a custom [QuestionnaireItemViewHolderFactory] should be used to render a given
+     * questionnaire item.
+     */
+    abstract fun getQuestionnaireItemViewHolderFactoryMatcher():
+      List<QuestionnaireItemViewHolderFactoryMatcher>
+  }
+
+  /**
+   * No-op implementation that provides no custom [QuestionnaireItemViewHolderFactoryMatcher]s .
+   */
+  private object NoOpQuestionnaireItemViewHolderFactoryMatchersProviderImpl :
+    QuestionnaireItemViewHolderFactoryMatchersProvider() {
+    override fun getQuestionnaireItemViewHolderFactoryMatcher() =
+      emptyList<QuestionnaireItemViewHolderFactoryMatcher>()
+  }
 }
 
 /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -63,7 +63,7 @@ class QuestionnaireFragment : Fragment() {
       DataCapture.getConfiguration(requireContext())
         .questionnaireItemViewHolderFactoryMatchersProviderFactory?.get(it)
     }
-      ?: NoOpQuestionnaireItemViewHolderFactoryMatchersProviderImpl
+      ?: EmptyQuestionnaireItemViewHolderFactoryMatchersProviderImpl
   }
 
   /** @suppress */
@@ -114,10 +114,7 @@ class QuestionnaireFragment : Fragment() {
     val questionnaireProgressIndicator: LinearProgressIndicator =
       view.findViewById(R.id.questionnaire_progress_indicator)
     val questionnaireItemEditAdapter =
-      QuestionnaireItemEditAdapter(
-        questionnaireItemViewHolderFactoryMatchersProvider
-          .getQuestionnaireItemViewHolderFactoryMatcher()
-      )
+      QuestionnaireItemEditAdapter(questionnaireItemViewHolderFactoryMatchersProvider.get())
     val questionnaireItemReviewAdapter = QuestionnaireItemReviewAdapter()
 
     val submitButton = requireView().findViewById<Button>(R.id.submit_questionnaire)
@@ -457,15 +454,13 @@ class QuestionnaireFragment : Fragment() {
      * whether a custom [QuestionnaireItemViewHolderFactory] should be used to render a given
      * questionnaire item.
      */
-    abstract fun getQuestionnaireItemViewHolderFactoryMatcher():
-      List<QuestionnaireItemViewHolderFactoryMatcher>
+    abstract fun get(): List<QuestionnaireItemViewHolderFactoryMatcher>
   }
 
   /** No-op implementation that provides no custom [QuestionnaireItemViewHolderFactoryMatcher]s . */
-  private object NoOpQuestionnaireItemViewHolderFactoryMatchersProviderImpl :
+  private object EmptyQuestionnaireItemViewHolderFactoryMatchersProviderImpl :
     QuestionnaireItemViewHolderFactoryMatchersProvider() {
-    override fun getQuestionnaireItemViewHolderFactoryMatcher() =
-      emptyList<QuestionnaireItemViewHolderFactoryMatcher>()
+    override fun get() = emptyList<QuestionnaireItemViewHolderFactoryMatcher>()
   }
 }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireFragmentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireFragmentTest.kt
@@ -165,12 +165,7 @@ class QuestionnaireFragmentTest {
       )
     scenario.moveToState(Lifecycle.State.RESUMED)
     scenario.withFragment {
-      assertThat(
-          this.questionnaireItemViewHolderFactoryMatchersProvider
-            .getQuestionnaireItemViewHolderFactoryMatcher()
-            .size
-        )
-        .isEqualTo(1)
+      assertThat(this.questionnaireItemViewHolderFactoryMatchersProvider.get().size).isEqualTo(1)
     }
   }
 
@@ -201,11 +196,7 @@ class QuestionnaireFragmentTest {
       )
     scenario.moveToState(Lifecycle.State.RESUMED)
     scenario.withFragment {
-      assertThat(
-          this.questionnaireItemViewHolderFactoryMatchersProvider
-            .getQuestionnaireItemViewHolderFactoryMatcher()
-        )
-        .isEmpty()
+      assertThat(this.questionnaireItemViewHolderFactoryMatchersProvider.get()).isEmpty()
     }
   }
 
@@ -235,11 +226,7 @@ class QuestionnaireFragmentTest {
       )
     scenario.moveToState(Lifecycle.State.RESUMED)
     scenario.withFragment {
-      assertThat(
-          this.questionnaireItemViewHolderFactoryMatchersProvider
-            .getQuestionnaireItemViewHolderFactoryMatcher()
-        )
-        .isEmpty()
+      assertThat(this.questionnaireItemViewHolderFactoryMatchersProvider.get()).isEmpty()
     }
   }
 
@@ -254,8 +241,7 @@ class QuestionnaireFragmentTest {
 
   object QuestionnaireItemViewHolderFactoryMatchersProviderTestImpl :
     QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatchersProvider() {
-    override fun getQuestionnaireItemViewHolderFactoryMatcher():
-      List<QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatcher> {
+    override fun get(): List<QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatcher> {
       return listOf(
         QuestionnaireFragment.QuestionnaireItemViewHolderFactoryMatcher(
           factory = QuestionnaireItemDateTimePickerViewHolderFactory,

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireFragmentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireFragmentTest.kt
@@ -33,11 +33,12 @@ import com.google.android.fhir.datacapture.testing.DataCaptureTestApplication
 import com.google.android.fhir.datacapture.views.QuestionnaireItemDateTimePickerViewHolderFactory
 import com.google.common.truth.Truth.assertThat
 import org.hl7.fhir.r4.model.Questionnaire
-import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P], application = DataCaptureTestApplication::class)
@@ -45,10 +46,13 @@ class QuestionnaireFragmentTest {
 
   private val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
 
-  @After
-  fun tearDown() {
-    ApplicationProvider.getApplicationContext<DataCaptureTestApplication>()
-      .dataCaptureConfiguration = null
+  @Before
+  fun setup() {
+    check(
+      ApplicationProvider.getApplicationContext<DataCaptureTestApplication>()
+        is DataCaptureConfig.Provider
+    ) { "Few tests require a custom application class that implements DataCaptureConfig.Provider" }
+    ReflectionHelpers.setStaticField(DataCapture::class.java, "configuration", null)
   }
 
   @Test

--- a/demo/src/main/java/com/google/android/fhir/demo/AddPatientFragment.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/AddPatientFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
@@ -80,11 +79,12 @@ class AddPatientFragment : Fragment(R.layout.add_patient_fragment) {
   }
 
   private fun addQuestionnaireFragment() {
-    val fragment = QuestionnaireFragment()
-    fragment.arguments =
-      bundleOf(QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to viewModel.questionnaire)
     childFragmentManager.commit {
-      add(R.id.add_patient_container, fragment, QUESTIONNAIRE_FRAGMENT_TAG)
+      add(
+        R.id.add_patient_container,
+        QuestionnaireFragment.builder().setQuestionnaire(viewModel.questionnaire).build(),
+        QUESTIONNAIRE_FRAGMENT_TAG
+      )
     }
   }
 

--- a/demo/src/main/java/com/google/android/fhir/demo/EditPatientFragment.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/EditPatientFragment.kt
@@ -23,7 +23,6 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
@@ -85,14 +84,15 @@ class EditPatientFragment : Fragment(R.layout.add_patient_fragment) {
   }
 
   private fun addQuestionnaireFragment(pair: Pair<String, String>) {
-    val fragment = QuestionnaireFragment()
-    fragment.arguments =
-      bundleOf(
-        QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to pair.first,
-        QuestionnaireFragment.EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING to pair.second
-      )
     childFragmentManager.commit {
-      add(R.id.add_patient_container, fragment, QUESTIONNAIRE_FRAGMENT_TAG)
+      add(
+        R.id.add_patient_container,
+        QuestionnaireFragment.builder()
+          .setQuestionnaire(pair.first)
+          .setQuestionnaireResponse(pair.second)
+          .build(),
+        QUESTIONNAIRE_FRAGMENT_TAG
+      )
     }
   }
 

--- a/demo/src/main/java/com/google/android/fhir/demo/ScreenerFragment.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/ScreenerFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
@@ -81,11 +80,12 @@ class ScreenerFragment : Fragment(R.layout.screener_encounter_fragment) {
   }
 
   private fun addQuestionnaireFragment() {
-    val fragment = QuestionnaireFragment()
-    fragment.arguments =
-      bundleOf(QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to viewModel.questionnaire)
     childFragmentManager.commit {
-      add(R.id.add_patient_container, fragment, QUESTIONNAIRE_FRAGMENT_TAG)
+      add(
+        R.id.add_patient_container,
+        QuestionnaireFragment.builder().setQuestionnaire(viewModel.questionnaire).build(),
+        QUESTIONNAIRE_FRAGMENT_TAG
+      )
     }
   }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1848

**Description**
1. Added Builder to QuestionnaireFragment so that the application developers don't have to lookup appropriate keys for Bundle args.
2. Made QuestionnaireFragment closed and added `QuestionnaireItemViewHolderFactoryMatchersProvider` and `QuestionnaireItemViewHolderFactoryMatchersProviderFactory` that can now be used by application developers to add custom `QuestionnaireItemViewHolderFactory` to the questionnaire.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one:   Code health 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
