### PR TITLE
Add builder api for EXTRA_SHOW_SUBMIT_BUTTON

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -246,7 +246,7 @@ class QuestionnaireFragment : Fragment() {
    */
   fun getQuestionnaireResponse() = viewModel.getQuestionnaireResponse()
 
-  /** Helper to create [Questionnaire] with appropriate [Bundle] arguments. */
+  /** Helper to create [QuestionnaireFragment] with appropriate [Bundle] arguments. */
   class Builder {
 
     private val args = mutableListOf<Pair<String, Any>>()
@@ -332,6 +332,11 @@ class QuestionnaireFragment : Fragment() {
       matchersProviderFactory: String
     ) = apply { args.add(EXTRA_MATCHERS_FACTORY to matchersProviderFactory) }
 
+    /**
+     * A [Boolean] extra to show or hide the Submit button in the questionnaire. Default is true.
+     */
+    fun setShowSubmitButton(value: Boolean) = apply { args.add(EXTRA_SHOW_SUBMIT_BUTTON to value) }
+
     @VisibleForTesting fun buildArgs() = bundleOf(*args.toTypedArray())
 
     /** @return A [QuestionnaireFragment] with provided [Bundle] arguments. */
@@ -406,11 +411,12 @@ class QuestionnaireFragment : Fragment() {
 
     const val SUBMIT_REQUEST_KEY = "submit-request-key"
 
-    fun builder() = Builder()
     /**
      * A [Boolean] extra to show or hide the Submit button in the questionnaire. Default is true.
      */
-    const val EXTRA_SHOW_SUBMIT_BUTTON = "show-submit-button"
+    internal const val EXTRA_SHOW_SUBMIT_BUTTON = "show-submit-button"
+
+    fun builder() = Builder()
   }
 
   /**


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Added `setShowSubmitButton` to the `QuestionnaireFragment.Builder`.
**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
