### PR TITLE
Fix engine upload sync.

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/sync/remote/RemoteFhirService.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/remote/RemoteFhirService.kt
@@ -27,6 +27,7 @@ import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.Resource
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Url
@@ -36,7 +37,7 @@ internal interface RemoteFhirService : DataSource {
 
   @GET override suspend fun download(@Url path: String): Resource
 
-  @POST(".") override suspend fun upload(bundle: Bundle): Resource
+  @POST(".") override suspend fun upload(@Body bundle: Bundle): Resource
 
   class Builder(
     private val baseUrl: String,

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/BundleUploader.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/BundleUploader.kt
@@ -29,6 +29,7 @@ import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.OperationOutcome
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
+import timber.log.Timber
 
 /** [Uploader] implementation to work with Fhir [Bundle]. */
 internal class BundleUploader(
@@ -51,6 +52,7 @@ internal class BundleUploader(
         completed += bundle.entry.size
         emit(getUploadResult(response, localChangeTokens, total, completed))
       } catch (e: Exception) {
+        Timber.e(e)
         emit(UploadResult.Failure(ResourceSyncException(ResourceType.Bundle, e)))
       }
     }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1892

**Description**
The retrofit's `@Body` annotation was accidentally removed from `RemoteFhirService.upload` api in a previous PR causing upload to fail.

1. Added Body annotation for retrofit upload api.
2. Logging exception when uploading.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
