### PR TITLE
Do not move cursor when leading zero is part of int

### DIFF
--- a/datacapture/sampledata/text_questionnaire_decimal.json
+++ b/datacapture/sampledata/text_questionnaire_decimal.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "status": "active",
+  "item": [
+    {
+      "linkId": "1",
+      "type": "decimal",
+      "text": "Enter a decimal"
+    }
+  ]
+}

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/QuestionnaireUiEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/QuestionnaireUiEspressoTest.kt
@@ -41,8 +41,10 @@ import com.google.android.fhir.datacapture.validation.QuestionnaireResponseValid
 import com.google.android.fhir.datacapture.validation.Valid
 import com.google.android.fhir.datacapture.views.factories.localDate
 import com.google.android.fhir.datacapture.views.factories.localDateTime
+import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.google.common.truth.Truth.assertThat
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Calendar
@@ -110,6 +112,46 @@ class QuestionnaireUiEspressoTest {
       val actualError = (view as TextInputLayout).error
       assertThat(actualError).isEqualTo("Number must be between -2,147,483,648 and 2,147,483,647")
     }
+  }
+
+  @Test
+  fun integerTextEdit_typingZeroBeforeAnyIntegerShouldKeepZeroDisplayed() {
+    buildFragmentFromQuestionnaire("/text_questionnaire_integer.json")
+
+    onView(withId(R.id.text_input_edit_text)).perform(typeText("0"))
+    assertThat(getQuestionnaireResponse().item.first().answer.first().valueIntegerType.value)
+      .isEqualTo(0)
+
+    onView(withId(R.id.text_input_edit_text)).perform(typeText("01"))
+    assertThat(getQuestionnaireResponse().item.first().answer.first().valueIntegerType.value)
+      .isEqualTo(1)
+
+    onView(withId(R.id.text_input_edit_text)).check { view, _ ->
+      assertThat((view as TextInputEditText).text.toString()).isEqualTo("001")
+    }
+
+    assertThat(getQuestionnaireResponse().item.first().answer.first().valueIntegerType.value)
+      .isEqualTo(1)
+  }
+
+  @Test
+  fun decimalTextEdit_typingZeroBeforeAnyIntegerShouldKeepZeroDisplayed() {
+    buildFragmentFromQuestionnaire("/text_questionnaire_decimal.json")
+
+    onView(withId(R.id.text_input_edit_text)).perform(typeText("0."))
+    assertThat(getQuestionnaireResponse().item.first().answer.first().valueDecimalType.value)
+      .isEqualTo(BigDecimal.valueOf(0.0))
+
+    onView(withId(R.id.text_input_edit_text)).perform(typeText("01"))
+    assertThat(getQuestionnaireResponse().item.first().answer.first().valueDecimalType.value)
+      .isEqualTo(BigDecimal.valueOf(0.01))
+
+    onView(withId(R.id.text_input_edit_text)).check { view, _ ->
+      assertThat((view as TextInputEditText).text.toString()).isEqualTo("0.01")
+    }
+
+    assertThat(getQuestionnaireResponse().item.first().answer.first().valueDecimalType.value)
+      .isEqualTo(BigDecimal.valueOf(0.01))
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/QuestionnaireUiEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/QuestionnaireUiEspressoTest.kt
@@ -116,6 +116,9 @@ class QuestionnaireUiEspressoTest {
 
   @Test
   fun integerTextEdit_typingZeroBeforeAnyIntegerShouldKeepZeroDisplayed() {
+    // Do not skip cursor when typing on the numeric field if the initial value is set to 0
+    // as from an integer comparison, leading zeros do not change how the answer is saved.
+    // e.g whether 000001 or 1 is input, the answer saved will be 1.
     buildFragmentFromQuestionnaire("/text_questionnaire_integer.json")
 
     onView(withId(R.id.text_input_edit_text)).perform(typeText("0"))

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
@@ -66,7 +66,7 @@ internal object EditTextIntegerViewHolderFactory :
 
         // Update the text
         val text = answer ?: draftAnswer
-        if ((text != textInputEditText.text.toString())) {
+        if ((text?.toIntOrNull() != textInputEditText.text.toString().toIntOrNull())) {
           textInputEditText.setText(text)
         }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
@@ -64,8 +64,12 @@ internal object EditTextIntegerViewHolderFactory :
           questionnaireViewItem.answers.singleOrNull()?.valueIntegerType?.value?.toString()
         val draftAnswer = questionnaireViewItem.draftAnswer?.toString()
 
-        // Update the text
         val text = answer ?: draftAnswer
+
+        // Update the text on the UI only if the value of the saved answer or draft answer
+        // is different from what the user is typing. We compare the two fields as integers to
+        // avoid shifting focus if the text values are different, but their integer representation
+        // is the same (e.g. "001" compared to "1")
         if ((text?.toIntOrNull() != textInputEditText.text.toString().toIntOrNull())) {
           textInputEditText.setText(text)
         }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactoryTest.kt
@@ -30,7 +30,6 @@ import java.math.BigDecimal
 import org.hl7.fhir.r4.model.DecimalType
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -118,16 +117,14 @@ class EditTextDecimalViewHolderFactoryTest {
   }
 
   @Test
-  @Ignore(
-    "Needs to be moved to instrumentation tests https://github.com/google/android-fhir/issues/1494"
-  )
-  fun shouldSetQuestionnaireResponseItemAnswer() {
+  fun shouldSetQuestionnaireResponseItemAnswerIfValidText() {
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _, _ -> },
+        answersChangedCallback = { _, _, result, _ -> answers = result },
       )
     viewHolder.bind(questionnaireViewItem)
     viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).apply {
@@ -135,24 +132,22 @@ class EditTextDecimalViewHolderFactoryTest {
       clearFocus()
     }
     viewHolder.itemView.clearFocus()
-
-    assertThat(questionnaireViewItem.answers.single().valueDecimalType.value)
-      .isEqualTo(BigDecimal("1.1"))
+    assertThat(answers!!.single().valueDecimalType.value).isEqualTo(BigDecimal.valueOf(1.1))
   }
 
   @Test
   fun shouldSetQuestionnaireResponseItemAnswerToEmpty() {
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _, _ -> },
+        answersChangedCallback = { _, _, result, _ -> answers = result },
       )
     viewHolder.bind(questionnaireViewItem)
     viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).setText("")
-
-    assertThat(questionnaireViewItem.answers).isEmpty()
+    assertThat(answers).isEmpty()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
@@ -29,7 +29,6 @@ import com.google.common.truth.Truth.assertThat
 import org.hl7.fhir.r4.model.IntegerType
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -117,38 +116,49 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  @Ignore(
-    "Needs to be moved to instrumentation tests https://github.com/google/android-fhir/issues/1494"
-  )
-  fun shouldSetQuestionnaireResponseItemAnswer() {
-    val questionnaireViewItem =
-      QuestionnaireViewItem(
-        Questionnaire.QuestionnaireItemComponent(),
-        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
-        validationResult = NotValidated,
-        answersChangedCallback = { _, _, _, _ -> },
-      )
-    viewHolder.bind(questionnaireViewItem)
-    viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).setText("10")
-
-    val answer = questionnaireViewItem.answers
-    assertThat(answer.size).isEqualTo(1)
-    assertThat(answer[0].valueIntegerType.value).isEqualTo(10)
-  }
-
-  @Test
   fun shouldSetQuestionnaireResponseItemAnswerToEmpty() {
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
-        answersChangedCallback = { _, _, _, _ -> },
+        answersChangedCallback = { _, _, result, _ -> answers = result },
       )
     viewHolder.bind(questionnaireViewItem)
     viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).setText("")
+    assertThat(answers).isEmpty()
+  }
 
-    assertThat(questionnaireViewItem.answers.size).isEqualTo(0)
+  @Test
+  fun shouldSetQuestionnaireResponseItemAnswerIfValidText() {
+    var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, result, _ -> answers = result },
+      )
+    viewHolder.bind(questionnaireViewItem)
+    viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).setText("13")
+    assertThat(answers!!.single().valueIntegerType.value).isEqualTo(13)
+  }
+
+  @Test
+  fun shouldSetDraftAnswerIfInvalidText() {
+    var draftAnswer: Any? = null
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, result -> draftAnswer = result },
+      )
+    viewHolder.bind(questionnaireViewItem)
+    // The character is the letter O, not the number 0
+    viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).setText("1O2")
+    assertThat(draftAnswer as String).isEqualTo("1O2")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
@@ -43,7 +43,7 @@ class EditTextIntegerViewHolderFactoryTest {
   private val viewHolder = EditTextIntegerViewHolderFactory.create(parent)
 
   @Test
-  fun shouldSetQuestionHeader() {
+  fun `should set questionnaire header`() {
     viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { text = "Question?" },
@@ -58,7 +58,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun shouldSetInputText() {
+  fun `should set input text`() {
     viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent(),
@@ -83,7 +83,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun shouldSetInputTextToEmpty() {
+  fun `should set input text to empty`() {
     viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent(),
@@ -116,7 +116,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun shouldSetQuestionnaireResponseItemAnswerToEmpty() {
+  fun `should set QuestionnaireResponseItemAnswer to empty`() {
     var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
@@ -131,7 +131,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun shouldSetQuestionnaireResponseItemAnswerIfValidText() {
+  fun `should set QuestionnaireResponseItemAnswer if valid text`() {
     var answers: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
@@ -146,7 +146,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun shouldSetDraftAnswerIfInvalidText() {
+  fun `should set draft answer if invalid text`() {
     var draftAnswer: Any? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
@@ -162,7 +162,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun displayValidationResult_noError_shouldShowNoErrorMessage() {
+  fun `displayValidationResult should show no error message`() {
     viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -192,7 +192,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun displayValidationResult_error_shouldShowErrorMessage() {
+  fun `displayValidationResult should show error message`() {
     viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent().apply {
@@ -237,7 +237,7 @@ class EditTextIntegerViewHolderFactoryTest {
   }
 
   @Test
-  fun bind_readOnly_shouldDisableView() {
+  fun `bind readOnly should disable view`() {
     viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent().apply { readOnly = true },


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1914

**Description**
Do not move cursor when leading zero is part of int

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

No

**Type**
Choose one: (**Bug fix** | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
