### PR TITLE
[Part 1] Remove ResourceType from Database interface and dependent calls

### DIFF
--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
@@ -123,7 +123,7 @@ class DatabaseImplTest {
     database.insert(TEST_PATIENT_2)
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
   }
 
@@ -135,11 +135,11 @@ class DatabaseImplTest {
     database.insert(*patients.toTypedArray())
     testingUtils.assertResourceEquals(
       TEST_PATIENT_1,
-      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     )
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
   }
 
@@ -151,7 +151,7 @@ class DatabaseImplTest {
     database.update(patient)
     testingUtils.assertResourceEquals(
       patient,
-      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     )
   }
 
@@ -191,7 +191,7 @@ class DatabaseImplTest {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
     val patientString = services.parser.encodeResourceToString(patient)
-    val squashedLocalChange = database.getLocalChange(patient.resourceType, patient.logicalId)
+    val squashedLocalChange = database.getLocalChange(patient.resourceType.name, patient.logicalId)
     with(squashedLocalChange!!.localChange) {
       assertThat(resourceId).isEqualTo(patient.logicalId)
       assertThat(resourceType).isEqualTo(patient.resourceType.name)
@@ -211,7 +211,7 @@ class DatabaseImplTest {
     database.update(patient)
 
     val patientString = services.parser.encodeResourceToString(patient)
-    val squashedLocalChange = database.getLocalChange(patient.resourceType, patient.logicalId)
+    val squashedLocalChange = database.getLocalChange(patient.resourceType.name, patient.logicalId)
     with(squashedLocalChange!!.toLocalChange()) {
       assertThat(resourceId).isEqualTo(patient.logicalId)
       assertThat(resourceType).isEqualTo(patient.resourceType.name)
@@ -224,14 +224,14 @@ class DatabaseImplTest {
   fun getLocalChanges_withWrongResourceId_shouldReturnNull() = runBlocking {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
-    assertThat(database.getLocalChange(patient.resourceType, "nonexistent_patient")).isNull()
+    assertThat(database.getLocalChange(patient.resourceType.name, "nonexistent_patient")).isNull()
   }
 
   @Test
   fun getLocalChanges_withWrongResourceType_shouldReturnNull() = runBlocking {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
-    assertThat(database.getLocalChange(ResourceType.Encounter, patient.logicalId)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Encounter.name, patient.logicalId)).isNull()
   }
 
   @Test
@@ -239,7 +239,7 @@ class DatabaseImplTest {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
     val patientString = services.parser.encodeResourceToString(patient)
-    val squashedLocalChange = database.getLocalChange(patient.resourceType, patient.logicalId)
+    val squashedLocalChange = database.getLocalChange(patient.resourceType.name, patient.logicalId)
     with(squashedLocalChange!!.toLocalChange()) {
       assertThat(resourceId).isEqualTo(patient.logicalId)
       assertThat(resourceType).isEqualTo(patient.resourceType.name)
@@ -248,15 +248,15 @@ class DatabaseImplTest {
     }
     testingUtils.assertResourceEquals(
       patient,
-      database.select(ResourceType.Patient, patient.logicalId)
+      database.select(ResourceType.Patient.name, patient.logicalId)
     )
     database.clearDatabase()
 
-    assertThat(database.getLocalChange(patient.resourceType, patient.logicalId)).isNull()
+    assertThat(database.getLocalChange(patient.resourceType.name, patient.logicalId)).isNull()
 
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, patient.logicalId) }
+        runBlocking { database.select(ResourceType.Patient.name, patient.logicalId) }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo("Resource not found with type Patient and id ${patient.logicalId}!")
@@ -264,24 +264,24 @@ class DatabaseImplTest {
 
   @Test
   fun purge_withLocalChangeAndForcePurgeTrue_shouldPurgeResource() = runBlocking {
-    database.purge(ResourceType.Patient, TEST_PATIENT_1_ID, true)
+    database.purge(ResourceType.Patient.name, TEST_PATIENT_1_ID, true)
     // after purge the resource is not available in database
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, TEST_PATIENT_1_ID) }
+        runBlocking { database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID) }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo(
         "Resource not found with type ${TEST_PATIENT_1.resourceType.name} and id $TEST_PATIENT_1_ID!"
       )
-    assertThat(database.getLocalChange(ResourceType.Patient, TEST_PATIENT_1_ID)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Patient.name, TEST_PATIENT_1_ID)).isNull()
   }
 
   @Test
   fun purge_withLocalChangeAndForcePurgeFalse_shouldThrowIllegalStateException() = runBlocking {
     val resourceIllegalStateException =
       assertThrows(IllegalStateException::class.java) {
-        runBlocking { database.purge(ResourceType.Patient, TEST_PATIENT_1_ID) }
+        runBlocking { database.purge(ResourceType.Patient.name, TEST_PATIENT_1_ID) }
       }
     assertThat(resourceIllegalStateException.message)
       .isEqualTo(
@@ -293,47 +293,51 @@ class DatabaseImplTest {
   fun purge_withNoLocalChangeAndForcePurgeFalse_shouldPurgeResource() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
 
-    assertThat(database.getLocalChange(ResourceType.Patient, TEST_PATIENT_2_ID)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Patient.name, TEST_PATIENT_2_ID)).isNull()
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
 
-    database.purge(TEST_PATIENT_2.resourceType, TEST_PATIENT_2_ID)
+    database.purge(TEST_PATIENT_2.resourceType.name, TEST_PATIENT_2_ID)
 
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, TEST_PATIENT_2_ID) }
+        runBlocking { database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID) }
       }
     assertThat(resourceNotFoundException.message)
-      .isEqualTo("Resource not found with type ${ResourceType.Patient} and id $TEST_PATIENT_2_ID!")
+      .isEqualTo(
+        "Resource not found with type ${ResourceType.Patient.name} and id $TEST_PATIENT_2_ID!"
+      )
   }
 
   @Test
   fun purge_withNoLocalChangeAndForcePurgeTrue_shouldPurgeResource() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
-    assertThat(database.getLocalChange(ResourceType.Patient, TEST_PATIENT_2_ID)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Patient.name, TEST_PATIENT_2_ID)).isNull()
 
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
 
-    database.purge(TEST_PATIENT_2.resourceType, TEST_PATIENT_2_ID, true)
+    database.purge(TEST_PATIENT_2.resourceType.name, TEST_PATIENT_2_ID, true)
 
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, TEST_PATIENT_2_ID) }
+        runBlocking { database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID) }
       }
     assertThat(resourceNotFoundException.message)
-      .isEqualTo("Resource not found with type ${ResourceType.Patient} and id $TEST_PATIENT_2_ID!")
+      .isEqualTo(
+        "Resource not found with type ${ResourceType.Patient.name} and id $TEST_PATIENT_2_ID!"
+      )
   }
 
   @Test
   fun purge_resourceNotAvailable_shouldThrowResourceNotFoundException() = runBlocking {
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.purge(ResourceType.Patient, TEST_PATIENT_2_ID) }
+        runBlocking { database.purge(ResourceType.Patient.name, TEST_PATIENT_2_ID) }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo(
@@ -359,7 +363,7 @@ class DatabaseImplTest {
   fun select_nonexistentResource_shouldThrowResourceNotFoundException() {
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, "nonexistent_patient") }
+        runBlocking { database.select(ResourceType.Patient.name, "nonexistent_patient") }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo("Resource not found with type Patient and id nonexistent_patient!")
@@ -369,7 +373,7 @@ class DatabaseImplTest {
   fun select_shouldReturnResource() = runBlocking {
     testingUtils.assertResourceEquals(
       TEST_PATIENT_1,
-      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     )
   }
 
@@ -438,7 +442,7 @@ class DatabaseImplTest {
       }
     database.update(updatedPatient)
 
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-1")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-1")
     assertThat(selectedEntity.resourceId).isEqualTo("remote-patient-1")
     assertThat(selectedEntity.versionId).isEqualTo(patient.meta.versionId)
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(patient.meta.lastUpdated.toInstant())
@@ -454,7 +458,7 @@ class DatabaseImplTest {
 
   @Test
   fun delete_shouldAddDeleteLocalChange() = runBlocking {
-    database.delete(ResourceType.Patient, TEST_PATIENT_1_ID)
+    database.delete(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     val (_, resourceType, resourceId, _, type, payload, _) =
       database
         .getAllLocalChanges()
@@ -468,7 +472,7 @@ class DatabaseImplTest {
 
   @Test
   fun delete_nonExistent_shouldNotInsertLocalChange() = runBlocking {
-    database.delete(ResourceType.Patient, "nonexistent_patient")
+    database.delete(ResourceType.Patient.name, "nonexistent_patient")
     assertThat(
         database
           .getAllLocalChanges()
@@ -522,7 +526,7 @@ class DatabaseImplTest {
           }
       }
     database.insertRemote(patient)
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-1")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-1")
     assertThat(selectedEntity.versionId).isEqualTo("remote-patient-1-version-1")
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(patient.meta.lastUpdated.toInstant())
   }
@@ -531,7 +535,7 @@ class DatabaseImplTest {
   fun insert_remoteResourceWithNoMeta_shouldSaveNullRemoteVersionAndLastUpdated() = runBlocking {
     val patient = Patient().apply { id = "remote-patient-2" }
     database.insertRemote(patient)
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-2")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-2")
     assertThat(selectedEntity.versionId).isNull()
     assertThat(selectedEntity.lastUpdatedRemote).isNull()
   }
@@ -540,7 +544,7 @@ class DatabaseImplTest {
   fun insert_localResourceWithNoMeta_shouldSaveNullRemoteVersionAndLastUpdated() = runBlocking {
     val patient = Patient().apply { id = "local-patient-2" }
     database.insert(patient)
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "local-patient-2")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "local-patient-2")
     assertThat(selectedEntity.versionId).isNull()
     assertThat(selectedEntity.lastUpdatedRemote).isNull()
   }
@@ -567,7 +571,7 @@ class DatabaseImplTest {
           )
         }
     }
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-3")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-3")
     assertThat(selectedEntity.versionId).isEqualTo(remoteMeta.versionId)
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(remoteMeta.lastUpdated.toInstant())
   }
@@ -752,7 +756,7 @@ class DatabaseImplTest {
   @Test
   fun delete_remoteResource_shouldReturnDeleteLocalChange() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
-    database.delete(ResourceType.Patient, TEST_PATIENT_2_ID)
+    database.delete(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     val (_, resourceType, resourceId, _, type, payload, versionId) =
       database
         .getAllLocalChanges()
@@ -773,7 +777,7 @@ class DatabaseImplTest {
     database.update(TEST_PATIENT_2)
     TEST_PATIENT_2.name = listOf(HumanName().addGiven("Jimmy").setFamily("Doe"))
     database.update(TEST_PATIENT_2)
-    database.delete(ResourceType.Patient, TEST_PATIENT_2_ID)
+    database.delete(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     val (_, resourceType, resourceId, _, type, payload, _) =
       database
         .getAllLocalChanges()

--- a/engine/src/main/java/com/google/android/fhir/db/Database.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/Database.kt
@@ -24,7 +24,6 @@ import com.google.android.fhir.db.impl.entities.SyncedResourceEntity
 import com.google.android.fhir.search.SearchQuery
 import java.time.Instant
 import org.hl7.fhir.r4.model.Resource
-import org.hl7.fhir.r4.model.ResourceType
 
 /** The interface for the FHIR resource database. */
 internal interface Database {
@@ -56,7 +55,7 @@ internal interface Database {
   /** Updates the `resource` meta in the FHIR resource database. */
   suspend fun updateVersionIdAndLastUpdated(
     resourceId: String,
-    resourceType: ResourceType,
+    resourceType: String,
     versionId: String,
     lastUpdated: Instant
   )
@@ -68,7 +67,7 @@ internal interface Database {
    * @throws ResourceNotFoundException if the resource is not found in the database
    */
   @Throws(ResourceNotFoundException::class)
-  suspend fun select(type: ResourceType, id: String): Resource
+  suspend fun select(resourceType: String, id: String): Resource
 
   /**
    * Selects the saved `ResourceEntity` of type `clazz` with `id`.
@@ -77,14 +76,14 @@ internal interface Database {
    * @throws ResourceNotFoundException if the resource is not found in the database
    */
   @Throws(ResourceNotFoundException::class)
-  suspend fun selectEntity(type: ResourceType, id: String): ResourceEntity
+  suspend fun selectEntity(resourceType: String, id: String): ResourceEntity
 
   /**
    * Return the last update data of a resource based on the resource type. If no resource of
    * [resourceType] is inserted, return `null`.
    * @param resourceType The resource type
    */
-  suspend fun lastUpdate(resourceType: ResourceType): String?
+  suspend fun lastUpdate(resourceType: String): String?
 
   /**
    * Insert resources that were synchronised.
@@ -101,7 +100,7 @@ internal interface Database {
    *
    * @param <R> The resource type
    */
-  suspend fun delete(type: ResourceType, id: String)
+  suspend fun delete(resourceType: String, id: String)
 
   suspend fun <R : Resource> search(query: SearchQuery): List<R>
 
@@ -138,22 +137,22 @@ internal interface Database {
    * [LocalChangeEntity](multiple
    * changes are squashed). If there is no local change for given
    * [resourceType] and [Resource.id], return `null`.
-   * @param type The [ResourceType]
+   * @param resourceType The resource type name
    * @param id The resource id [Resource.id]
    * @return [LocalChangeEntity] A squashed local changes for given [resourceType] and [Resource.id]
    * . If there is no local change for given [resourceType] and [Resource.id], return `null`.
    */
-  suspend fun getLocalChange(type: ResourceType, id: String): SquashedLocalChange?
+  suspend fun getLocalChange(resourceType: String, id: String): SquashedLocalChange?
 
   /**
    * Purge resource from database based on resource type and id without any deletion of data from
    * the server.
-   * @param type The [ResourceType]
+   * @param resourceType The resource type name
    * @param id The resource id [Resource.id]
-   * @param isLocalPurge default value is false here resource will not be deleted from
+   * @param forcePurge default value is false here resource will not be deleted from
    * LocalChangeEntity table but it will throw IllegalStateException("Resource has local changes
    * either sync with server or FORCE_PURGE required") if local change exists. If true this API will
    * delete resource entry from LocalChangeEntity table.
    */
-  suspend fun purge(type: ResourceType, id: String, forcePurge: Boolean = false)
+  suspend fun purge(resourceType: String, id: String, forcePurge: Boolean = false)
 }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -42,7 +42,6 @@ import com.google.android.fhir.versionId
 import java.time.Instant
 import java.util.UUID
 import org.hl7.fhir.r4.model.Resource
-import org.hl7.fhir.r4.model.ResourceType
 
 @Dao
 internal abstract class ResourceDao {
@@ -52,7 +51,7 @@ internal abstract class ResourceDao {
   lateinit var resourceIndexer: ResourceIndexer
 
   open suspend fun update(resource: Resource) {
-    getResourceEntity(resource.logicalId, resource.resourceType)?.let {
+    getResourceEntity(resource.logicalId, resource.resourceType.name)?.let {
       val entity = it.copy(serializedResource = iParser.encodeResourceToString(resource))
       // The foreign key in Index entity tables is set with cascade delete constraint and
       // insertResource has REPLACE conflict resolution. So, when we do an insert to update the
@@ -114,7 +113,7 @@ internal abstract class ResourceDao {
   )
   abstract suspend fun updateRemoteVersionIdAndLastUpdate(
     resourceId: String,
-    resourceType: ResourceType,
+    resourceType: String,
     versionId: String?,
     lastUpdatedRemote: Instant?
   )
@@ -124,7 +123,7 @@ internal abstract class ResourceDao {
         DELETE FROM ResourceEntity
         WHERE resourceId = :resourceId AND resourceType = :resourceType"""
   )
-  abstract suspend fun deleteResource(resourceId: String, resourceType: ResourceType): Int
+  abstract suspend fun deleteResource(resourceId: String, resourceType: String): Int
 
   @Query(
     """
@@ -132,7 +131,7 @@ internal abstract class ResourceDao {
         FROM ResourceEntity
         WHERE resourceId = :resourceId AND resourceType = :resourceType"""
   )
-  abstract suspend fun getResource(resourceId: String, resourceType: ResourceType): String?
+  abstract suspend fun getResource(resourceId: String, resourceType: String): String?
 
   @Query(
     """
@@ -141,10 +140,7 @@ internal abstract class ResourceDao {
         WHERE resourceId = :resourceId AND resourceType = :resourceType
     """
   )
-  abstract suspend fun getResourceEntity(
-    resourceId: String,
-    resourceType: ResourceType
-  ): ResourceEntity?
+  abstract suspend fun getResourceEntity(resourceId: String, resourceType: String): ResourceEntity?
 
   @RawQuery abstract suspend fun getResources(query: SupportSQLiteQuery): List<String>
 

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/SyncedResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/SyncedResourceDao.kt
@@ -39,5 +39,5 @@ internal interface SyncedResourceDao {
     """SELECT lastUpdate FROM SyncedResourceEntity 
         WHERE resourceType = :resourceType LIMIT 1"""
   )
-  suspend fun getLastUpdate(resourceType: ResourceType): String?
+  suspend fun getLastUpdate(resourceType: String): String?
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1706

**Description**
Remove ResourceType from Database interface and dependent calls. 
All I did was change the parameters in the Database interface from `ResourceType` to `String`, then updated any function that depends on any of the APIs changed.

Im breaking the work of making the FHIR Engine version agnostic into multiple PRs. This is Part 1


**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
