### PR TITLE
Implement new Search#has function accepting resource type as param

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/search/NestedSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/NestedSearch.kt
@@ -86,14 +86,14 @@ internal fun List<NestedSearch>.nestedQuery(
     null
   } else {
     map { it.nestedQuery(type) }
-      .let {
+      .let { searchQueries ->
         SearchQuery(
           query =
-            it.joinToString(
+            searchQueries.joinToString(
               prefix = "AND a.resourceUuid IN ",
               separator = " ${operation.logicalOperator} a.resourceUuid IN"
-            ) { "(\n${it.query}\n) " },
-          args = it.flatMap { it.args }
+            ) { searchQuery -> "(\n${searchQuery.query}\n) " },
+          args = searchQueries.flatMap { it.args }
         )
       }
   }

--- a/engine/src/main/java/com/google/android/fhir/search/NestedSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/NestedSearch.kt
@@ -51,6 +51,30 @@ inline fun <reified R : Resource> Search.has(
 }
 
 /**
+ * Provide limited support for reverse chaining on [Search]
+ * (See [this](https://www.hl7.org/fhir/search.html#has)).
+ *
+ * Example usage (Search for all Patients with Condition - Diabetes):
+ *
+ * ```
+ *   fhirEngine.search<Patient> {
+ *        has(resourceType = ResourceType.Condition, referenceParam = (Condition.SUBJECT) {
+ *          filter(Condition.CODE, Coding("http://snomed.info/sct", "44054006", "Diabetes"))
+ *        }
+ *     }
+ * ```
+ */
+fun Search.has(
+  resourceType: ResourceType,
+  referenceParam: ReferenceClientParam,
+  init: Search.() -> Unit
+) {
+  nestedSearches.add(
+    NestedSearch(referenceParam, Search(type = resourceType)).apply { search.init() }
+  )
+}
+
+/**
  * Generates the complete nested query going to several depths depending on the [Search] dsl
  * specified by the user .
  */

--- a/engine/src/main/java/com/google/android/fhir/search/NestedSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/NestedSearch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,8 +51,8 @@ inline fun <reified R : Resource> Search.has(
 }
 
 /**
- * Provide limited support for reverse chaining on [Search]
- * (See [this](https://www.hl7.org/fhir/search.html#has)).
+ * Provide limited support for reverse chaining on [Search] (See
+ * [this](https://www.hl7.org/fhir/search.html#has)).
  *
  * Example usage (Search for all Patients with Condition - Diabetes):
  *
@@ -85,16 +85,17 @@ internal fun List<NestedSearch>.nestedQuery(
   return if (isEmpty()) {
     null
   } else {
-    map { it.nestedQuery(type) }.let {
-      SearchQuery(
-        query =
-          it.joinToString(
-            prefix = "AND a.resourceUuid IN ",
-            separator = " ${operation.logicalOperator} a.resourceUuid IN"
-          ) { "(\n${it.query}\n) " },
-        args = it.flatMap { it.args }
-      )
-    }
+    map { it.nestedQuery(type) }
+      .let {
+        SearchQuery(
+          query =
+            it.joinToString(
+              prefix = "AND a.resourceUuid IN ",
+              separator = " ${operation.logicalOperator} a.resourceUuid IN"
+            ) { "(\n${it.query}\n) " },
+          args = it.flatMap { it.args }
+        )
+      }
   }
 }
 

--- a/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
@@ -1761,7 +1761,7 @@ class SearchTest {
     val query =
       Search(ResourceType.Patient)
         .apply {
-          has<Condition>(Condition.SUBJECT) {
+          has(ResourceType.Condition, Condition.SUBJECT) {
             filter(
               Condition.CODE,
               { value = of(Coding("http://snomed.info/sct", "44054006", "Diabetes")) }

--- a/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
@@ -1761,7 +1761,7 @@ class SearchTest {
     val query =
       Search(ResourceType.Patient)
         .apply {
-          has(ResourceType.Condition, Condition.SUBJECT) {
+          has(resourceType = ResourceType.Condition, referenceParam = Condition.SUBJECT) {
             filter(
               Condition.CODE,
               { value = of(Coding("http://snomed.info/sct", "44054006", "Diabetes")) }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1921

**Description**
Implemented a new `Search#has` function that accepts resource type as parameter and is not reified. 

**Alternative(s) considered**
The alternative was to update the existing function that is reified and based on generic types. Chose this approach to provide an alternative API for using `Search#has` function instead of refactoring the existing one.

**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
