### PR TITLE
[Part 2] remove ResourceType reference from FhirEngine interface and dependent calls

### DIFF
--- a/demo/src/main/java/com/google/android/fhir/demo/data/DownloadWorkManagerImpl.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/data/DownloadWorkManagerImpl.kt
@@ -38,7 +38,7 @@ class DownloadWorkManagerImpl : DownloadWorkManager {
 
     val resourceTypeToDownload =
       ResourceType.fromCode(url.findAnyOf(resourceTypeList, ignoreCase = true)!!.second)
-    context.getLatestTimestampFor(resourceTypeToDownload)?.let {
+    context.getLatestTimestampFor(resourceTypeToDownload.name)?.let {
       url = affixLastUpdatedTimestamp(url!!, it)
     }
     return url

--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
@@ -123,7 +123,7 @@ class DatabaseImplTest {
     database.insert(TEST_PATIENT_2)
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
   }
 
@@ -135,11 +135,11 @@ class DatabaseImplTest {
     database.insert(*patients.toTypedArray())
     testingUtils.assertResourceEquals(
       TEST_PATIENT_1,
-      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     )
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
   }
 
@@ -151,7 +151,7 @@ class DatabaseImplTest {
     database.update(patient)
     testingUtils.assertResourceEquals(
       patient,
-      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     )
   }
 
@@ -191,7 +191,7 @@ class DatabaseImplTest {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
     val patientString = services.parser.encodeResourceToString(patient)
-    val squashedLocalChange = database.getLocalChange(patient.resourceType, patient.logicalId)
+    val squashedLocalChange = database.getLocalChange(patient.resourceType.name, patient.logicalId)
     with(squashedLocalChange!!.localChange) {
       assertThat(resourceId).isEqualTo(patient.logicalId)
       assertThat(resourceType).isEqualTo(patient.resourceType.name)
@@ -211,7 +211,7 @@ class DatabaseImplTest {
     database.update(patient)
 
     val patientString = services.parser.encodeResourceToString(patient)
-    val squashedLocalChange = database.getLocalChange(patient.resourceType, patient.logicalId)
+    val squashedLocalChange = database.getLocalChange(patient.resourceType.name, patient.logicalId)
     with(squashedLocalChange!!.toLocalChange()) {
       assertThat(resourceId).isEqualTo(patient.logicalId)
       assertThat(resourceType).isEqualTo(patient.resourceType.name)
@@ -224,14 +224,14 @@ class DatabaseImplTest {
   fun getLocalChanges_withWrongResourceId_shouldReturnNull() = runBlocking {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
-    assertThat(database.getLocalChange(patient.resourceType, "nonexistent_patient")).isNull()
+    assertThat(database.getLocalChange(patient.resourceType.name, "nonexistent_patient")).isNull()
   }
 
   @Test
   fun getLocalChanges_withWrongResourceType_shouldReturnNull() = runBlocking {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
-    assertThat(database.getLocalChange(ResourceType.Encounter, patient.logicalId)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Encounter.name, patient.logicalId)).isNull()
   }
 
   @Test
@@ -239,7 +239,7 @@ class DatabaseImplTest {
     val patient: Patient = testingUtils.readFromFile(Patient::class.java, "/date_test_patient.json")
     database.insert(patient)
     val patientString = services.parser.encodeResourceToString(patient)
-    val squashedLocalChange = database.getLocalChange(patient.resourceType, patient.logicalId)
+    val squashedLocalChange = database.getLocalChange(patient.resourceType.name, patient.logicalId)
     with(squashedLocalChange!!.toLocalChange()) {
       assertThat(resourceId).isEqualTo(patient.logicalId)
       assertThat(resourceType).isEqualTo(patient.resourceType.name)
@@ -248,15 +248,15 @@ class DatabaseImplTest {
     }
     testingUtils.assertResourceEquals(
       patient,
-      database.select(ResourceType.Patient, patient.logicalId)
+      database.select(ResourceType.Patient.name, patient.logicalId)
     )
     database.clearDatabase()
 
-    assertThat(database.getLocalChange(patient.resourceType, patient.logicalId)).isNull()
+    assertThat(database.getLocalChange(patient.resourceType.name, patient.logicalId)).isNull()
 
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, patient.logicalId) }
+        runBlocking { database.select(ResourceType.Patient.name, patient.logicalId) }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo("Resource not found with type Patient and id ${patient.logicalId}!")
@@ -264,24 +264,24 @@ class DatabaseImplTest {
 
   @Test
   fun purge_withLocalChangeAndForcePurgeTrue_shouldPurgeResource() = runBlocking {
-    database.purge(ResourceType.Patient, TEST_PATIENT_1_ID, true)
+    database.purge(ResourceType.Patient.name, TEST_PATIENT_1_ID, true)
     // after purge the resource is not available in database
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, TEST_PATIENT_1_ID) }
+        runBlocking { database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID) }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo(
         "Resource not found with type ${TEST_PATIENT_1.resourceType.name} and id $TEST_PATIENT_1_ID!"
       )
-    assertThat(database.getLocalChange(ResourceType.Patient, TEST_PATIENT_1_ID)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Patient.name, TEST_PATIENT_1_ID)).isNull()
   }
 
   @Test
   fun purge_withLocalChangeAndForcePurgeFalse_shouldThrowIllegalStateException() = runBlocking {
     val resourceIllegalStateException =
       assertThrows(IllegalStateException::class.java) {
-        runBlocking { database.purge(ResourceType.Patient, TEST_PATIENT_1_ID) }
+        runBlocking { database.purge(ResourceType.Patient.name, TEST_PATIENT_1_ID) }
       }
     assertThat(resourceIllegalStateException.message)
       .isEqualTo(
@@ -293,47 +293,51 @@ class DatabaseImplTest {
   fun purge_withNoLocalChangeAndForcePurgeFalse_shouldPurgeResource() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
 
-    assertThat(database.getLocalChange(ResourceType.Patient, TEST_PATIENT_2_ID)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Patient.name, TEST_PATIENT_2_ID)).isNull()
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
 
-    database.purge(TEST_PATIENT_2.resourceType, TEST_PATIENT_2_ID)
+    database.purge(TEST_PATIENT_2.resourceType.name, TEST_PATIENT_2_ID)
 
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, TEST_PATIENT_2_ID) }
+        runBlocking { database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID) }
       }
     assertThat(resourceNotFoundException.message)
-      .isEqualTo("Resource not found with type ${ResourceType.Patient} and id $TEST_PATIENT_2_ID!")
+      .isEqualTo(
+        "Resource not found with type ${ResourceType.Patient.name} and id $TEST_PATIENT_2_ID!"
+      )
   }
 
   @Test
   fun purge_withNoLocalChangeAndForcePurgeTrue_shouldPurgeResource() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
-    assertThat(database.getLocalChange(ResourceType.Patient, TEST_PATIENT_2_ID)).isNull()
+    assertThat(database.getLocalChange(ResourceType.Patient.name, TEST_PATIENT_2_ID)).isNull()
 
     testingUtils.assertResourceEquals(
       TEST_PATIENT_2,
-      database.select(ResourceType.Patient, TEST_PATIENT_2_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     )
 
-    database.purge(TEST_PATIENT_2.resourceType, TEST_PATIENT_2_ID, true)
+    database.purge(TEST_PATIENT_2.resourceType.name, TEST_PATIENT_2_ID, true)
 
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, TEST_PATIENT_2_ID) }
+        runBlocking { database.select(ResourceType.Patient.name, TEST_PATIENT_2_ID) }
       }
     assertThat(resourceNotFoundException.message)
-      .isEqualTo("Resource not found with type ${ResourceType.Patient} and id $TEST_PATIENT_2_ID!")
+      .isEqualTo(
+        "Resource not found with type ${ResourceType.Patient.name} and id $TEST_PATIENT_2_ID!"
+      )
   }
 
   @Test
   fun purge_resourceNotAvailable_shouldThrowResourceNotFoundException() = runBlocking {
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.purge(ResourceType.Patient, TEST_PATIENT_2_ID) }
+        runBlocking { database.purge(ResourceType.Patient.name, TEST_PATIENT_2_ID) }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo(
@@ -359,7 +363,7 @@ class DatabaseImplTest {
   fun select_nonexistentResource_shouldThrowResourceNotFoundException() {
     val resourceNotFoundException =
       assertThrows(ResourceNotFoundException::class.java) {
-        runBlocking { database.select(ResourceType.Patient, "nonexistent_patient") }
+        runBlocking { database.select(ResourceType.Patient.name, "nonexistent_patient") }
       }
     assertThat(resourceNotFoundException.message)
       .isEqualTo("Resource not found with type Patient and id nonexistent_patient!")
@@ -369,7 +373,7 @@ class DatabaseImplTest {
   fun select_shouldReturnResource() = runBlocking {
     testingUtils.assertResourceEquals(
       TEST_PATIENT_1,
-      database.select(ResourceType.Patient, TEST_PATIENT_1_ID)
+      database.select(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     )
   }
 
@@ -438,7 +442,7 @@ class DatabaseImplTest {
       }
     database.update(updatedPatient)
 
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-1")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-1")
     assertThat(selectedEntity.resourceId).isEqualTo("remote-patient-1")
     assertThat(selectedEntity.versionId).isEqualTo(patient.meta.versionId)
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(patient.meta.lastUpdated.toInstant())
@@ -454,7 +458,7 @@ class DatabaseImplTest {
 
   @Test
   fun delete_shouldAddDeleteLocalChange() = runBlocking {
-    database.delete(ResourceType.Patient, TEST_PATIENT_1_ID)
+    database.delete(ResourceType.Patient.name, TEST_PATIENT_1_ID)
     val (_, resourceType, resourceId, _, type, payload, _) =
       database
         .getAllLocalChanges()
@@ -468,7 +472,7 @@ class DatabaseImplTest {
 
   @Test
   fun delete_nonExistent_shouldNotInsertLocalChange() = runBlocking {
-    database.delete(ResourceType.Patient, "nonexistent_patient")
+    database.delete(ResourceType.Patient.name, "nonexistent_patient")
     assertThat(
         database
           .getAllLocalChanges()
@@ -522,7 +526,7 @@ class DatabaseImplTest {
           }
       }
     database.insertRemote(patient)
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-1")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-1")
     assertThat(selectedEntity.versionId).isEqualTo("remote-patient-1-version-1")
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(patient.meta.lastUpdated.toInstant())
   }
@@ -531,7 +535,7 @@ class DatabaseImplTest {
   fun insert_remoteResourceWithNoMeta_shouldSaveNullRemoteVersionAndLastUpdated() = runBlocking {
     val patient = Patient().apply { id = "remote-patient-2" }
     database.insertRemote(patient)
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-2")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-2")
     assertThat(selectedEntity.versionId).isNull()
     assertThat(selectedEntity.lastUpdatedRemote).isNull()
   }
@@ -540,7 +544,7 @@ class DatabaseImplTest {
   fun insert_localResourceWithNoMeta_shouldSaveNullRemoteVersionAndLastUpdated() = runBlocking {
     val patient = Patient().apply { id = "local-patient-2" }
     database.insert(patient)
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "local-patient-2")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "local-patient-2")
     assertThat(selectedEntity.versionId).isNull()
     assertThat(selectedEntity.lastUpdatedRemote).isNull()
   }
@@ -567,7 +571,7 @@ class DatabaseImplTest {
           )
         }
     }
-    val selectedEntity = database.selectEntity(ResourceType.Patient, "remote-patient-3")
+    val selectedEntity = database.selectEntity(ResourceType.Patient.name, "remote-patient-3")
     assertThat(selectedEntity.versionId).isEqualTo(remoteMeta.versionId)
     assertThat(selectedEntity.lastUpdatedRemote).isEqualTo(remoteMeta.lastUpdated.toInstant())
   }
@@ -752,7 +756,7 @@ class DatabaseImplTest {
   @Test
   fun delete_remoteResource_shouldReturnDeleteLocalChange() = runBlocking {
     database.insertRemote(TEST_PATIENT_2)
-    database.delete(ResourceType.Patient, TEST_PATIENT_2_ID)
+    database.delete(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     val (_, resourceType, resourceId, _, type, payload, versionId) =
       database
         .getAllLocalChanges()
@@ -773,7 +777,7 @@ class DatabaseImplTest {
     database.update(TEST_PATIENT_2)
     TEST_PATIENT_2.name = listOf(HumanName().addGiven("Jimmy").setFamily("Doe"))
     database.update(TEST_PATIENT_2)
-    database.delete(ResourceType.Patient, TEST_PATIENT_2_ID)
+    database.delete(ResourceType.Patient.name, TEST_PATIENT_2_ID)
     val (_, resourceType, resourceId, _, type, payload, _) =
       database
         .getAllLocalChanges()

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -23,7 +23,6 @@ import com.google.android.fhir.sync.ConflictResolver
 import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.Flow
 import org.hl7.fhir.r4.model.Resource
-import org.hl7.fhir.r4.model.ResourceType
 
 /** The FHIR Engine interface that handles the local storage of FHIR resources. */
 interface FhirEngine {
@@ -35,13 +34,13 @@ interface FhirEngine {
   suspend fun create(vararg resource: Resource): List<String>
 
   /** Loads a FHIR resource given the class and the logical ID. */
-  suspend fun get(type: ResourceType, id: String): Resource
+  suspend fun get(resourceType: String, id: String): Resource
 
   /** Updates a FHIR [resource] in the local storage. */
   suspend fun update(vararg resource: Resource)
 
   /** Removes a FHIR resource given the class and the logical ID. */
-  suspend fun delete(type: ResourceType, id: String)
+  suspend fun delete(resourceType: String, id: String)
 
   /**
    * Searches the database and returns a list resources according to the [search] specifications.
@@ -90,24 +89,24 @@ interface FhirEngine {
    * [LocalChange](multiple
    * changes are squashed). If there is no local change for given
    * [resourceType] and [Resource.id], return `null`.
-   * @param type The [ResourceType]
+   * @param resourceType The resource type name
    * @param id The resource id [Resource.id]
    * @return [LocalChange] A squashed local changes for given [resourceType] and [Resource.id] . If
    * there is no local change for given [resourceType] and [Resource.id], return `null`.
    */
-  suspend fun getLocalChange(type: ResourceType, id: String): LocalChange?
+  suspend fun getLocalChange(resourceType: String, id: String): LocalChange?
 
   /**
    * Purges a resource from the database based on resource type and id without any deletion of data
    * from the server.
-   * @param type The [ResourceType]
+   * @param resourceType The resource type name
    * @param id The resource id [Resource.id]
-   * @param isLocalPurge default value is false here resource will not be deleted from
+   * @param forcePurge default value is false here resource will not be deleted from
    * LocalChangeEntity table but it will throw IllegalStateException("Resource has local changes
    * either sync with server or FORCE_PURGE required") if local change exists. If true this API will
    * delete resource entry from LocalChangeEntity table.
    */
-  suspend fun purge(type: ResourceType, id: String, forcePurge: Boolean = false)
+  suspend fun purge(resourceType: String, id: String, forcePurge: Boolean = false)
 }
 
 /**
@@ -129,5 +128,5 @@ suspend inline fun <reified R : Resource> FhirEngine.delete(id: String) {
 }
 
 interface SyncDownloadContext {
-  suspend fun getLatestTimestampFor(type: ResourceType): String?
+  suspend fun getLatestTimestampFor(resourceType: String): String?
 }

--- a/engine/src/main/java/com/google/android/fhir/MoreResources.kt
+++ b/engine/src/main/java/com/google/android/fhir/MoreResources.kt
@@ -28,9 +28,9 @@ internal const val R4_RESOURCE_PACKAGE_PREFIX = "org.hl7.fhir.r4.model."
  *
  * @throws IllegalArgumentException if class name cannot be mapped to valid resource type
  */
-fun <R : Resource> getResourceType(clazz: Class<R>): ResourceType {
+fun <R : Resource> getResourceType(clazz: Class<R>): String {
   try {
-    return clazz.getConstructor().newInstance().resourceType
+    return clazz.getConstructor().newInstance().resourceType.name
   } catch (e: NoSuchMethodException) {
     throw IllegalArgumentException("Cannot resolve resource type for " + clazz.name, e)
   } catch (e: IllegalAccessException) {

--- a/engine/src/main/java/com/google/android/fhir/db/Database.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/Database.kt
@@ -24,7 +24,6 @@ import com.google.android.fhir.db.impl.entities.SyncedResourceEntity
 import com.google.android.fhir.search.SearchQuery
 import java.time.Instant
 import org.hl7.fhir.r4.model.Resource
-import org.hl7.fhir.r4.model.ResourceType
 
 /** The interface for the FHIR resource database. */
 internal interface Database {
@@ -56,7 +55,7 @@ internal interface Database {
   /** Updates the `resource` meta in the FHIR resource database. */
   suspend fun updateVersionIdAndLastUpdated(
     resourceId: String,
-    resourceType: ResourceType,
+    resourceType: String,
     versionId: String,
     lastUpdated: Instant
   )
@@ -68,7 +67,7 @@ internal interface Database {
    * @throws ResourceNotFoundException if the resource is not found in the database
    */
   @Throws(ResourceNotFoundException::class)
-  suspend fun select(type: ResourceType, id: String): Resource
+  suspend fun select(resourceType: String, id: String): Resource
 
   /**
    * Selects the saved `ResourceEntity` of type `clazz` with `id`.
@@ -77,14 +76,14 @@ internal interface Database {
    * @throws ResourceNotFoundException if the resource is not found in the database
    */
   @Throws(ResourceNotFoundException::class)
-  suspend fun selectEntity(type: ResourceType, id: String): ResourceEntity
+  suspend fun selectEntity(resourceType: String, id: String): ResourceEntity
 
   /**
    * Return the last update data of a resource based on the resource type. If no resource of
    * [resourceType] is inserted, return `null`.
    * @param resourceType The resource type
    */
-  suspend fun lastUpdate(resourceType: ResourceType): String?
+  suspend fun lastUpdate(resourceType: String): String?
 
   /**
    * Insert resources that were synchronised.
@@ -101,7 +100,7 @@ internal interface Database {
    *
    * @param <R> The resource type
    */
-  suspend fun delete(type: ResourceType, id: String)
+  suspend fun delete(resourceType: String, id: String)
 
   suspend fun <R : Resource> search(query: SearchQuery): List<R>
 
@@ -138,22 +137,22 @@ internal interface Database {
    * [LocalChangeEntity](multiple
    * changes are squashed). If there is no local change for given
    * [resourceType] and [Resource.id], return `null`.
-   * @param type The [ResourceType]
+   * @param resourceType The resource type name
    * @param id The resource id [Resource.id]
    * @return [LocalChangeEntity] A squashed local changes for given [resourceType] and [Resource.id]
    * . If there is no local change for given [resourceType] and [Resource.id], return `null`.
    */
-  suspend fun getLocalChange(type: ResourceType, id: String): SquashedLocalChange?
+  suspend fun getLocalChange(resourceType: String, id: String): SquashedLocalChange?
 
   /**
    * Purge resource from database based on resource type and id without any deletion of data from
    * the server.
-   * @param type The [ResourceType]
+   * @param resourceType The resource type name
    * @param id The resource id [Resource.id]
-   * @param isLocalPurge default value is false here resource will not be deleted from
+   * @param forcePurge default value is false here resource will not be deleted from
    * LocalChangeEntity table but it will throw IllegalStateException("Resource has local changes
    * either sync with server or FORCE_PURGE required") if local change exists. If true this API will
    * delete resource entry from LocalChangeEntity table.
    */
-  suspend fun purge(type: ResourceType, id: String, forcePurge: Boolean = false)
+  suspend fun purge(resourceType: String, id: String, forcePurge: Boolean = false)
 }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -42,7 +42,6 @@ import com.google.android.fhir.versionId
 import java.time.Instant
 import java.util.UUID
 import org.hl7.fhir.r4.model.Resource
-import org.hl7.fhir.r4.model.ResourceType
 
 @Dao
 internal abstract class ResourceDao {
@@ -52,7 +51,7 @@ internal abstract class ResourceDao {
   lateinit var resourceIndexer: ResourceIndexer
 
   open suspend fun update(resource: Resource) {
-    getResourceEntity(resource.logicalId, resource.resourceType)?.let {
+    getResourceEntity(resource.logicalId, resource.resourceType.name)?.let {
       val entity = it.copy(serializedResource = iParser.encodeResourceToString(resource))
       // The foreign key in Index entity tables is set with cascade delete constraint and
       // insertResource has REPLACE conflict resolution. So, when we do an insert to update the
@@ -114,7 +113,7 @@ internal abstract class ResourceDao {
   )
   abstract suspend fun updateRemoteVersionIdAndLastUpdate(
     resourceId: String,
-    resourceType: ResourceType,
+    resourceType: String,
     versionId: String?,
     lastUpdatedRemote: Instant?
   )
@@ -124,7 +123,7 @@ internal abstract class ResourceDao {
         DELETE FROM ResourceEntity
         WHERE resourceId = :resourceId AND resourceType = :resourceType"""
   )
-  abstract suspend fun deleteResource(resourceId: String, resourceType: ResourceType): Int
+  abstract suspend fun deleteResource(resourceId: String, resourceType: String): Int
 
   @Query(
     """
@@ -132,7 +131,7 @@ internal abstract class ResourceDao {
         FROM ResourceEntity
         WHERE resourceId = :resourceId AND resourceType = :resourceType"""
   )
-  abstract suspend fun getResource(resourceId: String, resourceType: ResourceType): String?
+  abstract suspend fun getResource(resourceId: String, resourceType: String): String?
 
   @Query(
     """
@@ -141,10 +140,7 @@ internal abstract class ResourceDao {
         WHERE resourceId = :resourceId AND resourceType = :resourceType
     """
   )
-  abstract suspend fun getResourceEntity(
-    resourceId: String,
-    resourceType: ResourceType
-  ): ResourceEntity?
+  abstract suspend fun getResourceEntity(resourceId: String, resourceType: String): ResourceEntity?
 
   @RawQuery abstract suspend fun getResources(query: SupportSQLiteQuery): List<String>
 

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/SyncedResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/SyncedResourceDao.kt
@@ -39,5 +39,5 @@ internal interface SyncedResourceDao {
     """SELECT lastUpdate FROM SyncedResourceEntity 
         WHERE resourceType = :resourceType LIMIT 1"""
   )
-  suspend fun getLastUpdate(resourceType: ResourceType): String?
+  suspend fun getLastUpdate(resourceType: String): String?
 }

--- a/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -47,16 +47,16 @@ internal class FhirEngineImpl(private val database: Database, private val contex
     return database.insert(*resource)
   }
 
-  override suspend fun get(type: ResourceType, id: String): Resource {
-    return database.select(type.name, id)
+  override suspend fun get(resourceType: String, id: String): Resource {
+    return database.select(resourceType, id)
   }
 
   override suspend fun update(vararg resource: Resource) {
     database.update(*resource)
   }
 
-  override suspend fun delete(type: ResourceType, id: String) {
-    database.delete(type.name, id)
+  override suspend fun delete(resourceType: String, id: String) {
+    database.delete(resourceType, id)
   }
 
   override suspend fun <R : Resource> search(search: Search): List<R> {
@@ -75,12 +75,12 @@ internal class FhirEngineImpl(private val database: Database, private val contex
     database.clearDatabase()
   }
 
-  override suspend fun getLocalChange(type: ResourceType, id: String): LocalChange? {
-    return database.getLocalChange(type.name, id)?.toLocalChange()
+  override suspend fun getLocalChange(resourceType: String, id: String): LocalChange? {
+    return database.getLocalChange(resourceType, id)?.toLocalChange()
   }
 
-  override suspend fun purge(type: ResourceType, id: String, forcePurge: Boolean) {
-    database.purge(type.name, id, forcePurge)
+  override suspend fun purge(resourceType: String, id: String, forcePurge: Boolean) {
+    database.purge(resourceType, id, forcePurge)
   }
 
   override suspend fun syncDownload(
@@ -89,8 +89,8 @@ internal class FhirEngineImpl(private val database: Database, private val contex
   ) {
     download(
         object : SyncDownloadContext {
-          override suspend fun getLatestTimestampFor(type: ResourceType) =
-            database.lastUpdate(type.name)
+          override suspend fun getLatestTimestampFor(resourceType: String) =
+            database.lastUpdate(resourceType)
         }
       )
       .collect { resources ->

--- a/engine/src/main/java/com/google/android/fhir/sync/download/ResourceParamsBasedDownloadWorkManager.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/download/ResourceParamsBasedDownloadWorkManager.kt
@@ -80,7 +80,7 @@ class ResourceParamsBasedDownloadWorkManager(syncParams: ResourceSearchParams) :
       newParams[SyncDataParams.SORT_KEY] = SyncDataParams.LAST_UPDATED_KEY
     }
     if (!params.containsKey(SyncDataParams.LAST_UPDATED_KEY)) {
-      val lastUpdate = context.getLatestTimestampFor(resourceType)
+      val lastUpdate = context.getLatestTimestampFor(resourceType.name)
       if (!lastUpdate.isNullOrEmpty()) {
         newParams[SyncDataParams.LAST_UPDATED_KEY] = "$GREATER_THAN_PREFIX$lastUpdate"
       }

--- a/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
+++ b/engine/src/test-common/java/com/google/android/fhir/resource/TestingUtils.kt
@@ -101,7 +101,7 @@ class TestingUtils constructor(private val iParser: IParser) {
   }
 
   open class TestDownloadManagerImpl(
-    val queries: List<String> = listOf("Patient?address-city=NAIROBI")
+    private val queries: List<String> = listOf("Patient?address-city=NAIROBI")
   ) : DownloadWorkManager {
     private val urls = LinkedList(queries)
 
@@ -122,20 +122,16 @@ class TestingUtils constructor(private val iParser: IParser) {
     }
   }
 
-  class TestDownloadManagerImplWithQueue(
-    queries: List<String> = listOf("Patient/bob", "Encounter/doc")
-  ) : TestDownloadManagerImpl(queries)
-
   object TestFhirEngineImpl : FhirEngine {
     override suspend fun create(vararg resource: Resource) = emptyList<String>()
 
     override suspend fun update(vararg resource: Resource) {}
 
-    override suspend fun get(type: ResourceType, id: String): Resource {
+    override suspend fun get(resourceType: String, id: String): Resource {
       return Patient()
     }
 
-    override suspend fun delete(type: ResourceType, id: String) {}
+    override suspend fun delete(resourceType: String, id: String) {}
 
     override suspend fun <R : Resource> search(search: Search): List<R> {
       return emptyList()
@@ -144,7 +140,7 @@ class TestingUtils constructor(private val iParser: IParser) {
     override suspend fun syncUpload(
       upload: suspend (List<LocalChange>) -> Flow<Pair<LocalChangeToken, Resource>>
     ) {
-      upload(listOf(getLocalChange(ResourceType.Patient, "123")))
+      upload(listOf(getLocalChange(ResourceType.Patient.name, "123")))
     }
 
     override suspend fun syncDownload(
@@ -153,7 +149,7 @@ class TestingUtils constructor(private val iParser: IParser) {
     ) {
       download(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType): String {
+            override suspend fun getLatestTimestampFor(resourceType: String): String {
               return "123456788"
             }
           }
@@ -170,9 +166,9 @@ class TestingUtils constructor(private val iParser: IParser) {
 
     override suspend fun clearDatabase() {}
 
-    override suspend fun getLocalChange(type: ResourceType, id: String): LocalChange {
+    override suspend fun getLocalChange(resourceType: String, id: String): LocalChange {
       return LocalChange(
-        resourceType = type.name,
+        resourceType = resourceType,
         resourceId = id,
         payload = "{}",
         token = LocalChangeToken(listOf()),
@@ -180,7 +176,7 @@ class TestingUtils constructor(private val iParser: IParser) {
       )
     }
 
-    override suspend fun purge(type: ResourceType, id: String, forcePurge: Boolean) {}
+    override suspend fun purge(resourceType: String, id: String, forcePurge: Boolean) {}
   }
 
   object TestFailingDatasource : DataSource {

--- a/engine/src/test/java/com/google/android/fhir/MoreResourcesTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/MoreResourcesTest.kt
@@ -31,7 +31,7 @@ import org.robolectric.annotation.Config
 class MoreResourcesTest {
   @Test
   fun getResourceType() {
-    assertThat(getResourceType(Patient::class.java)).isEqualTo(ResourceType.Patient)
+    assertThat(getResourceType(Patient::class.java)).isEqualTo(ResourceType.Patient.name)
   }
 
   @Test

--- a/engine/src/test/java/com/google/android/fhir/sync/download/DownloaderImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/download/DownloaderImplTest.kt
@@ -112,7 +112,7 @@ class DownloaderImplTest {
     downloader
       .download(
         object : SyncDownloadContext {
-          override suspend fun getLatestTimestampFor(type: ResourceType): String? = null
+          override suspend fun getLatestTimestampFor(resourceType: String): String? = null
         }
       )
       .collect { result.add(it) }
@@ -174,7 +174,7 @@ class DownloaderImplTest {
       downloader
         .download(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = null
+            override suspend fun getLatestTimestampFor(resourceType: String) = null
           }
         )
         .collect { result.add(it) }
@@ -240,7 +240,7 @@ class DownloaderImplTest {
       downloader
         .download(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = null
+            override suspend fun getLatestTimestampFor(resourceType: String) = null
           }
         )
         .collect { result.add(it) }
@@ -288,10 +288,10 @@ class DownloaderImplTest {
     downloader
       .download(
         object : SyncDownloadContext {
-          override suspend fun getLatestTimestampFor(type: ResourceType): String? = null
+          override suspend fun getLatestTimestampFor(resourceType: String): String? = null
         }
       )
-      .collectIndexed { index, value -> result.add(value) }
+      .collectIndexed { _, value -> result.add(value) }
 
     assertThat(result.first()).isInstanceOf(DownloadState.Started::class.java)
   }
@@ -322,10 +322,10 @@ class DownloaderImplTest {
     downloader
       .download(
         object : SyncDownloadContext {
-          override suspend fun getLatestTimestampFor(type: ResourceType): String? = null
+          override suspend fun getLatestTimestampFor(resourceType: String): String? = null
         }
       )
-      .collectIndexed { index, value -> result.add(value) }
+      .collectIndexed { _, value -> result.add(value) }
 
     assertThat(result.first()).isInstanceOf(DownloadState.Started::class.java)
     assertThat(result.elementAt(1)).isInstanceOf(DownloadState.Success::class.java)

--- a/engine/src/test/java/com/google/android/fhir/sync/download/ResourceParamsBasedDownloadWorkManagerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/download/ResourceParamsBasedDownloadWorkManagerTest.kt
@@ -50,7 +50,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
       val url =
         downloadManager.getNextRequestUrl(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = "2022-03-20"
+            override suspend fun getLatestTimestampFor(resourceType: String) = "2022-03-20"
           }
         )
       if (url != null) {
@@ -78,7 +78,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
       val url =
         downloadManager.getNextRequestUrl(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = "2022-03-20"
+            override suspend fun getLatestTimestampFor(resourceType: String) = "2022-03-20"
           }
         )
 
@@ -121,7 +121,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
       val url =
         downloadManager.getNextRequestUrl(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = "2022-06-28"
+            override suspend fun getLatestTimestampFor(resourceType: String) = "2022-06-28"
           }
         )
       assertThat(url).isEqualTo("Patient?_sort=_lastUpdated&_lastUpdated=gt2022-06-28")
@@ -143,7 +143,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
       val url =
         downloadManager.getNextRequestUrl(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = "2022-07-07"
+            override suspend fun getLatestTimestampFor(resourceType: String) = "2022-07-07"
           }
         )
       assertThat(url).isEqualTo("Patient?_lastUpdated=2022-06-28&_sort=status")
@@ -159,7 +159,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
       val url =
         downloadManager.getNextRequestUrl(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = "2022-07-07"
+            override suspend fun getLatestTimestampFor(resourceType: String) = "2022-07-07"
           }
         )
       assertThat(url).isEqualTo("Patient?_lastUpdated=gt2022-06-28&_sort=_lastUpdated")
@@ -175,7 +175,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
       val actual =
         downloadManager.getNextRequestUrl(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = null
+            override suspend fun getLatestTimestampFor(resourceType: String) = null
           }
         )
       assertThat(actual).isEqualTo("Patient?address-city=NAIROBI&_sort=_lastUpdated")
@@ -191,7 +191,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
       val actual =
         downloadManager.getNextRequestUrl(
           object : SyncDownloadContext {
-            override suspend fun getLatestTimestampFor(type: ResourceType) = ""
+            override suspend fun getLatestTimestampFor(resourceType: String) = ""
           }
         )
       assertThat(actual).isEqualTo("Patient?address-city=NAIROBI&_sort=_lastUpdated")
@@ -211,7 +211,7 @@ class ResourceParamsBasedDownloadWorkManagerTest {
     val urls =
       downloadManager.getSummaryRequestUrls(
         object : SyncDownloadContext {
-          override suspend fun getLatestTimestampFor(type: ResourceType) = "2022-03-20"
+          override suspend fun getLatestTimestampFor(resourceType: String) = "2022-03-20"
         }
       )
 

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineRetrieveProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineRetrieveProvider.kt
@@ -217,7 +217,7 @@ internal class FhirEngineRetrieveProvider(private val fhirEngine: FhirEngine) :
 
   private suspend fun safeGet(fhirEngine: FhirEngine, type: ResourceType, id: String): Resource? {
     return try {
-      fhirEngine.get(type, id)
+      fhirEngine.get(type.name, id)
     } catch (e: ResourceNotFoundException) {
       null
     }

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineTerminologyProvider.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirEngineTerminologyProvider.kt
@@ -113,7 +113,7 @@ internal class FhirEngineTerminologyProvider(
 
   private suspend fun safeGet(fhirEngine: FhirEngine, type: ResourceType, id: String): Resource? {
     return try {
-      fhirEngine.get(type, id)
+      fhirEngine.get(type.name, id)
     } catch (e: ResourceNotFoundException) {
       null
     }

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineDalTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineDalTest.kt
@@ -73,7 +73,7 @@ class FhirEngineDalTest {
       }
 
     fhirEngineDal.create(patient)
-    val result = fhirEngine.get(ResourceType.Patient, "2") as Patient
+    val result = fhirEngine.get(ResourceType.Patient.name, "2") as Patient
 
     assertThat(result.nameFirstRep.givenAsSingleString)
       .isEqualTo(patient.nameFirstRep.givenAsSingleString)
@@ -112,7 +112,8 @@ class FhirEngineDalTest {
       fhirEngineDal.delete(testPatient.idElement)
     }
 
-  @After fun fhirEngine() = runBlocking { fhirEngine.delete(ResourceType.Patient, "Patient/1") }
+  @After
+  fun fhirEngine() = runBlocking { fhirEngine.delete(ResourceType.Patient.name, "Patient/1") }
 
   companion object {
     val testPatient =


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1706

**Description**
Remove ResourceType from the FhirEngine interface and dependent calls.
All I did was change the parameters in the FhirEngine interface from ResourceType to String, then updated any function that depends on any of the APIs changed.

Im breaking the work of making the FHIR Engine version agnostic into multiple PRs. This is Part 2

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | **Feature** | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
