### PR TITLE
Fix zip index based mapping issue in uppack repeat groups extension

### DIFF
--- a/catalog/src/main/assets/behavior_skip_logic.json
+++ b/catalog/src/main/assets/behavior_skip_logic.json
@@ -74,9 +74,9 @@
       ]
     },
     {
-      "text": "Date of Vaccination?",
-      "type": "date",
-      "linkId": "1.1",
+      "text": "Confirm that vaccine date is known",
+      "type": "boolean",
+      "linkId": "2.0.1",
       "enableWhen": [
         {
           "question": "1.0",
@@ -87,6 +87,49 @@
           }
         }
       ]
+    },
+    {
+      "text": "Confirm that vaccine date is unknown",
+      "type": "boolean",
+      "linkId": "2.0.2",
+      "enableWhen": [
+        {
+          "question": "1.0",
+          "operator": "=",
+          "answerCoding": {
+            "system": "custom",
+            "code": "unknown"
+          }
+        }
+      ]
+    },
+    {
+      "text": "Provide vaccine dates for 2 doses",
+      "type": "group",
+      "linkId": "3.0",
+      "repeats": true,
+      "enableWhen": [
+        {
+          "question": "1.0",
+          "operator": "=",
+          "answerCoding": {
+            "system": "custom",
+            "code": "Y"
+          }
+        }
+      ],
+      "item": [
+        {
+          "text": "Date of Vaccination?",
+          "type": "date",
+          "linkId": "3.1"
+        }
+      ]
+    },
+    {
+      "text": "Additional details",
+      "type": "string",
+      "linkId": "4.0"
     }
   ]
 }

--- a/catalog/src/main/assets/behavior_skip_logic.json
+++ b/catalog/src/main/assets/behavior_skip_logic.json
@@ -76,7 +76,7 @@
     {
       "text": "Confirm that vaccine date is known",
       "type": "boolean",
-      "linkId": "2.0.1",
+      "linkId": "2",
       "enableWhen": [
         {
           "question": "1.0",
@@ -90,8 +90,22 @@
     },
     {
       "text": "Confirm that vaccine date is unknown",
-      "type": "boolean",
-      "linkId": "2.0.2",
+      "type": "choice",
+      "linkId": "3",
+      "answerOption": [
+        {
+          "valueCoding": {
+            "code": "Y",
+            "display": "Yes"
+          }
+        },
+        {
+          "valueCoding": {
+            "code": "N",
+            "display": "No"
+          }
+        }
+      ],
       "enableWhen": [
         {
           "question": "1.0",
@@ -104,10 +118,24 @@
       ]
     },
     {
+      "text": "Confirm that vaccine date is not known",
+      "type": "boolean",
+      "linkId": "4",
+      "enableWhen": [
+        {
+          "question": "1.0",
+          "operator": "=",
+          "answerCoding": {
+            "system": "custom",
+            "code": "N"
+          }
+        }
+      ]
+    },
+    {
       "text": "Provide vaccine dates for 2 doses",
       "type": "group",
-      "linkId": "3.0",
-      "repeats": true,
+      "linkId": "5",
       "enableWhen": [
         {
           "question": "1.0",
@@ -129,7 +157,7 @@
     {
       "text": "Additional details",
       "type": "string",
-      "linkId": "4.0"
+      "linkId": "6"
     }
   ]
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -89,10 +89,12 @@ private fun unpackRepeatedGroups(
   questionnaireItems: List<Questionnaire.QuestionnaireItemComponent>,
   questionnaireResponseItems: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>
 ): List<QuestionnaireResponse.QuestionnaireResponseItemComponent> {
-  return questionnaireItems.zip(questionnaireResponseItems).flatMap {
-    (questionnaireItem, questionnaireResponseItem) ->
-    unpackRepeatedGroups(questionnaireItem, questionnaireResponseItem)
-  }
+  return questionnaireItems
+    .map { qItem -> qItem to questionnaireResponseItems.find { it.linkId == qItem.linkId } }
+    .filter { it.second != null }
+    .flatMap { (questionnaireItem, questionnaireResponseItem) ->
+      unpackRepeatedGroups(questionnaireItem, questionnaireResponseItem!!)
+    }
 }
 
 private fun unpackRepeatedGroups(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
@@ -25,6 +25,7 @@ import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
+import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.Resource
 import org.junit.Test
 
@@ -285,6 +286,112 @@ class MoreQuestionnaireResponsesTest {
                 linkId = "nested-question"
                 addAnswer(
                   QuestionnaireResponseItemAnswerComponent().apply { value = BooleanType(false) }
+                )
+              }
+            )
+          }
+        )
+      }
+
+    questionnaireResponse.unpackRepeatedGroups(questionnaire)
+    assertResourceEquals(questionnaireResponse, unpackedQuestionnaireResponse)
+  }
+
+  @Test
+  fun `should unpack repeated groups correctly with missing questionnaire response items`() {
+    val questionnaire =
+      Questionnaire().apply {
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "simple-question-1"
+            type = Questionnaire.QuestionnaireItemType.STRING
+          }
+        )
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "repeated-group"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            repeats = true
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-question-1"
+                type = Questionnaire.QuestionnaireItemType.BOOLEAN
+              }
+            )
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-question-2"
+                type = Questionnaire.QuestionnaireItemType.REFERENCE
+              }
+            )
+          }
+        )
+      }
+    val questionnaireResponse =
+      QuestionnaireResponse().apply {
+        // linkId = "simple-question-1" not present due to enablement
+        addItem(
+          QuestionnaireResponseItemComponent().apply {
+            linkId = "repeated-group"
+            addAnswer(
+              QuestionnaireResponseItemAnswerComponent().apply {
+                // linkId = "nested-question-1" not present due to enablement
+                addItem(
+                  QuestionnaireResponseItemComponent().apply {
+                    linkId = "nested-question-2"
+                    addAnswer(
+                      QuestionnaireResponseItemAnswerComponent().apply {
+                        value = Reference().apply { reference = "Patient/123" }
+                      }
+                    )
+                  }
+                )
+              }
+            )
+            addAnswer(
+              QuestionnaireResponseItemAnswerComponent().apply {
+                addItem(
+                  QuestionnaireResponseItemComponent().apply {
+                    linkId = "nested-question-2"
+                    addAnswer(
+                      QuestionnaireResponseItemAnswerComponent().apply {
+                        value = Reference().apply { reference = "Patient/456" }
+                      }
+                    )
+                  }
+                )
+              }
+            )
+          }
+        )
+      }
+    val unpackedQuestionnaireResponse =
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponseItemComponent().apply {
+            linkId = "repeated-group"
+            addItem(
+              QuestionnaireResponseItemComponent().apply {
+                linkId = "nested-question-2"
+                addAnswer(
+                  QuestionnaireResponseItemAnswerComponent().apply {
+                    value = Reference().apply { reference = "Patient/123" }
+                  }
+                )
+              }
+            )
+          }
+        )
+        addItem(
+          QuestionnaireResponseItemComponent().apply {
+            linkId = "repeated-group"
+            addItem(
+              QuestionnaireResponseItemComponent().apply {
+                linkId = "nested-question-2"
+                addAnswer(
+                  QuestionnaireResponseItemAnswerComponent().apply {
+                    value = Reference().apply { reference = "Patient/456" }
+                  }
                 )
               }
             )


### PR DESCRIPTION
Fixes https://github.com/google/android-fhir/issues/1972

**Description**
The issue is that the zip index mapping for questionnaire and questionnaire-response item can not  be used when unpacking the items while generating questionnaire-response. If items before the group are missed due to enablement it just skip the data entered into item embedded into groups.

**Alternative(s) considered**
zip index mapping for questionnaire and questionnaire-response item can not  be used because there could be missing items from questionnaire-response due to enablement condition

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**
<img width="200" height="400" src="https://user-images.githubusercontent.com/4829880/231712362-c19bc5e7-cd33-4d41-aa94-267e41aa0258.gif"/>

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
