### PR TITLE
Show dateformat text in lowercase for date and dateTime label.

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/QuestionnaireUiEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/QuestionnaireUiEspressoTest.kt
@@ -168,7 +168,7 @@ class QuestionnaireUiEspressoTest {
 
     onView(withId(R.id.date_input_layout)).check { view, _ ->
       val actualError = (view as TextInputLayout).error
-      assertThat(actualError).isEqualTo("Date format needs to be MM/dd/yyyy (e.g. 01/31/2023)")
+      assertThat(actualError).isEqualTo("Date format needs to be mm/dd/yyyy (e.g. 01/31/2023)")
     }
     onView(withId(R.id.time_input_layout)).check { view, _ -> assertThat(view.isEnabled).isFalse() }
   }
@@ -222,7 +222,7 @@ class QuestionnaireUiEspressoTest {
 
     onView(withId(R.id.text_input_layout)).check { view, _ ->
       val actualError = (view as TextInputLayout).error
-      assertThat(actualError).isEqualTo("Date format needs to be MM/dd/yyyy (e.g. 01/31/2023)")
+      assertThat(actualError).isEqualTo("Date format needs to be mm/dd/yyyy (e.g. 01/31/2023)")
     }
   }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
@@ -112,6 +112,8 @@ internal object DatePickerViewHolderFactory :
       override fun bind(questionnaireViewItem: QuestionnaireViewItem) {
         clearPreviousState()
         header.bind(questionnaireViewItem)
+        // Use 'mm' for month instead of 'MM' to avoid confusion.
+        // See https://developer.android.com/reference/kotlin/java/text/SimpleDateFormat.
         textInputLayout.hint = canonicalizedDatePattern.lowercase()
         textInputEditText.removeTextChangedListener(textWatcher)
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
@@ -112,7 +112,7 @@ internal object DatePickerViewHolderFactory :
       override fun bind(questionnaireViewItem: QuestionnaireViewItem) {
         clearPreviousState()
         header.bind(questionnaireViewItem)
-        textInputLayout.hint = canonicalizedDatePattern
+        textInputLayout.hint = canonicalizedDatePattern.lowercase()
         textInputEditText.removeTextChangedListener(textWatcher)
 
         val questionnaireItemViewItemDateAnswer =
@@ -325,6 +325,6 @@ internal fun Int.length() =
 internal fun invalidDateErrorText(context: Context, formatPattern: String) =
   context.getString(
     R.string.date_format_validation_error_msg,
-    formatPattern,
+    formatPattern.lowercase(),
     formatPattern.replace("dd", "31").replace("MM", "01").replace("yyyy", "2023")
   )

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
@@ -327,6 +327,8 @@ internal fun Int.length() =
 internal fun invalidDateErrorText(context: Context, formatPattern: String) =
   context.getString(
     R.string.date_format_validation_error_msg,
+    // Use 'mm' for month instead of 'MM' to avoid confusion.
+    // See https://developer.android.com/reference/kotlin/java/text/SimpleDateFormat.
     formatPattern.lowercase(),
     formatPattern.replace("dd", "31").replace("MM", "01").replace("yyyy", "2023")
   )

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactory.kt
@@ -125,6 +125,8 @@ internal object DateTimePickerViewHolderFactory :
       override fun bind(questionnaireViewItem: QuestionnaireViewItem) {
         clearPreviousState()
         header.bind(questionnaireViewItem)
+        // Use 'mm' for month instead of 'MM' to avoid confusion.
+        // See https://developer.android.com/reference/kotlin/java/text/SimpleDateFormat.
         dateInputLayout.hint = canonicalizedDatePattern.lowercase()
         dateInputEditText.removeTextChangedListener(textWatcher)
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactory.kt
@@ -125,7 +125,7 @@ internal object DateTimePickerViewHolderFactory :
       override fun bind(questionnaireViewItem: QuestionnaireViewItem) {
         clearPreviousState()
         header.bind(questionnaireViewItem)
-        dateInputLayout.hint = canonicalizedDatePattern
+        dateInputLayout.hint = canonicalizedDatePattern.lowercase()
         dateInputEditText.removeTextChangedListener(textWatcher)
 
         val questionnaireItemViewItemDateTimeAnswer =

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactoryTest.kt
@@ -109,6 +109,20 @@ class DatePickerViewHolderFactoryTest {
   }
 
   @Test
+  fun `show dateFormat label in lowerCase`() {
+    setLocale(Locale.US)
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+    )
+    assertThat(viewHolder.dateInputView.hint.toString()).isEqualTo("mm/dd/yyyy")
+  }
+
+  @Test
   fun shouldSetDateInput_localeJp() {
     setLocale(Locale.JAPAN)
     val viewHolder = DatePickerViewHolderFactory.create(parent)
@@ -369,6 +383,23 @@ class DatePickerViewHolderFactoryTest {
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
       .isEqualTo("Maximum value allowed is:2025-01-01")
+  }
+
+  @Test
+  fun `show dateFormat in lowerCase in the error message`() {
+    val itemViewItem =
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+        draftAnswer = "11/19/202"
+      )
+
+    viewHolder.bind(itemViewItem)
+
+    assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).error)
+      .isEqualTo("Date format needs to be mm/dd/yyyy (e.g. 01/31/2023)")
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactoryTest.kt
@@ -81,6 +81,19 @@ class DateTimePickerViewHolderFactoryTest {
   }
 
   @Test
+  fun `show dateFormat label in lowerCase`() {
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+    )
+    assertThat(viewHolder.dateInputView.hint.toString()).isEqualTo("mm/dd/yyyy")
+  }
+
+  @Test
   fun shouldSetDateTimeInput() {
     viewHolder.bind(
       QuestionnaireViewItem(
@@ -414,7 +427,24 @@ class DateTimePickerViewHolderFactoryTest {
     viewHolder.bind(itemViewItem)
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.date_input_layout).error)
-      .isEqualTo("Date format needs to be MM/dd/yyyy (e.g. 01/31/2023)")
+      .isEqualTo("Date format needs to be mm/dd/yyyy (e.g. 01/31/2023)")
+  }
+
+  @Test
+  fun `show dateFormat in lowerCase in the error message`() {
+    val itemViewItem =
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+        draftAnswer = "11/19/202"
+      )
+
+    viewHolder.bind(itemViewItem)
+
+    assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.date_input_layout).error)
+      .isEqualTo("Date format needs to be mm/dd/yyyy (e.g. 01/31/2023)")
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1969 

**Description**

- Show date pattern text in the lowerCase when get assigned as hint/label for Date and DateTime view. 
- Show date pattern text in the error text in the lowercase when error message get shown.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
