### PR TITLE
Changes to make boolean type options full screen width while horizont…

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/BooleanChoiceViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/BooleanChoiceViewHolderFactory.kt
@@ -136,11 +136,11 @@ internal object BooleanChoiceViewHolderFactory :
         layoutParams =
           LinearLayout.LayoutParams(
             when (choiceOrientation) {
-              ChoiceOrientationTypes.HORIZONTAL -> 0
+              ChoiceOrientationTypes.HORIZONTAL -> /* width= */ 0
               ChoiceOrientationTypes.VERTICAL -> ViewGroup.LayoutParams.MATCH_PARENT
             },
             ViewGroup.LayoutParams.WRAP_CONTENT,
-            1.0f
+            /* weight= */ 1.0f
           )
       }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/BooleanChoiceViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/BooleanChoiceViewHolderFactory.kt
@@ -18,6 +18,7 @@ package com.google.android.fhir.datacapture.views.factories
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.RadioButton
 import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -133,12 +134,13 @@ internal object BooleanChoiceViewHolderFactory :
         choiceOrientation: ChoiceOrientationTypes
       ) {
         layoutParams =
-          ViewGroup.LayoutParams(
+          LinearLayout.LayoutParams(
             when (choiceOrientation) {
-              ChoiceOrientationTypes.HORIZONTAL -> ViewGroup.LayoutParams.WRAP_CONTENT
+              ChoiceOrientationTypes.HORIZONTAL -> 0
               ChoiceOrientationTypes.VERTICAL -> ViewGroup.LayoutParams.MATCH_PARENT
             },
-            ViewGroup.LayoutParams.WRAP_CONTENT
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            1.0f
           )
       }
 


### PR DESCRIPTION
…ally aligned

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1968 

**Description**
Change the alignment to make boolean type options full screen width while horizontally aligned

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature

**Screenshots (if applicable)**
![Screenshot_20230424_183545](https://user-images.githubusercontent.com/121015652/234005106-6aff1bcd-8b77-4174-bb92-0f22f39e9486.png)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
