### PR TITLE
FHIR Sync worker benchmarking

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -85,6 +85,9 @@ dependencies {
   androidTestImplementation(Dependencies.junit)
   androidTestImplementation(Dependencies.Kotlin.kotlinCoroutinesAndroid)
   androidTestImplementation(Dependencies.truth)
+  androidTestImplementation(Dependencies.Androidx.workRuntimeKtx)
+  androidTestImplementation(Dependencies.AndroidxTest.workTestingRuntimeKtx)
+  androidTestImplementation(Dependencies.mockWebServer)
 
   androidTestImplementation(project(":engine"))
   androidTestImplementation(project(":knowledge"))

--- a/benchmark/src/androidTest/AndroidManifest.xml
+++ b/benchmark/src/androidTest/AndroidManifest.xml
@@ -13,9 +13,11 @@
     -->
     <application
         android:debuggable="false"
+        android:usesCleartextTraffic="true"
         tools:ignore="HardcodedDebugMode"
         tools:replace="android:debuggable"
     >
         <profileable android:shell="true" />
     </application>
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/D_FhirJsonParserBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/D_FhirJsonParserBenchmark.kt
@@ -66,15 +66,10 @@ class D_FhirJsonParserBenchmark {
 
       val library = runWithTimingDisabled { open("/immunity-check/ImmunityCheck.json") }
 
-      val libraryBundle = jsonParser.parseResource(library) as Bundle
-
-      val immunityCheckLibrary = libraryBundle.entry[0].resource as Library
-      val fhirHelpersLibrary = libraryBundle.entry[1].resource as Library
+      val immunityCheckLibrary = jsonParser.parseResource(library) as Library
 
       assertThat(immunityCheckLibrary.id).isEqualTo("Library/ImmunityCheck-1.0.0")
       assertThat(immunityCheckLibrary.content[0].data.size).isEqualTo(575)
-      assertThat(fhirHelpersLibrary.id).isEqualTo("Library/FHIRHelpers-4.0.1")
-      assertThat(fhirHelpersLibrary.content[0].data.size).isEqualTo(17845)
     }
   }
 }

--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/D_FhirJsonParserBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/D_FhirJsonParserBenchmark.kt
@@ -64,12 +64,15 @@ class D_FhirJsonParserBenchmark {
         fhirContext.newJsonParser()
       }
 
-      val library = runWithTimingDisabled { open("/immunity-check/ImmunityCheck.json") }
-
-      val immunityCheckLibrary = jsonParser.parseResource(library) as Library
+      val immunityCheckJson = runWithTimingDisabled { open("/immunity-check/ImmunityCheck.json") }
+      val immunityCheckLibrary = jsonParser.parseResource(immunityCheckJson) as Library
+      val fhirHelpersJson = runWithTimingDisabled { open("/immunity-check/FhirHelpers.json") }
+      val fhirHelpersLibrary = jsonParser.parseResource(fhirHelpersJson) as Library
 
       assertThat(immunityCheckLibrary.id).isEqualTo("Library/ImmunityCheck-1.0.0")
       assertThat(immunityCheckLibrary.content[0].data.size).isEqualTo(575)
+      assertThat(fhirHelpersLibrary.id).isEqualTo("Library/FHIRHelpers-4.0.1")
+      assertThat(fhirHelpersLibrary.content[0].data.size).isEqualTo(17845)
     }
   }
 }

--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/E_ElmJsonLibraryLoaderBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/E_ElmJsonLibraryLoaderBenchmark.kt
@@ -43,7 +43,7 @@ class E_ElmJsonLibraryLoaderBenchmark {
   fun parseImmunityCheckCqlFromFhirLibrary() {
     benchmarkRule.measureRepeated {
       val immunityCheckLibrary = runWithTimingDisabled {
-        var fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
+        val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
         val jsonParser = fhirContext.newJsonParser()
         jsonParser.parseResource(open("/immunity-check/ImmunityCheck.json")) as Library
       }

--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/E_ElmJsonLibraryLoaderBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/E_ElmJsonLibraryLoaderBenchmark.kt
@@ -24,7 +24,6 @@ import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.common.truth.Truth.assertThat
 import java.io.InputStream
 import java.io.StringReader
-import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.Library
 import org.junit.Rule
 import org.junit.Test

--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/E_ElmJsonLibraryLoaderBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/E_ElmJsonLibraryLoaderBenchmark.kt
@@ -43,13 +43,12 @@ class E_ElmJsonLibraryLoaderBenchmark {
   @Test
   fun parseImmunityCheckCqlFromFhirLibrary() {
     benchmarkRule.measureRepeated {
-      val libraryBundle = runWithTimingDisabled {
+      val immunityCheckLibrary = runWithTimingDisabled {
         var fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
         val jsonParser = fhirContext.newJsonParser()
-        jsonParser.parseResource(open("/immunity-check/ImmunityCheck.json")) as Bundle
+        jsonParser.parseResource(open("/immunity-check/ImmunityCheck.json")) as Library
       }
 
-      val immunityCheckLibrary = libraryBundle.entry[0].resource as Library
       val jsonLib = immunityCheckLibrary.content.first { it.contentType == "application/elm+json" }
 
       val immunityCheckCqlLibrary = JsonCqlLibraryReader().read(StringReader(String(jsonLib.data)))
@@ -61,13 +60,12 @@ class E_ElmJsonLibraryLoaderBenchmark {
   @Test
   fun parseFhirHelpersCqlFromFhirLibrary() {
     benchmarkRule.measureRepeated {
-      val libraryBundle = runWithTimingDisabled {
-        var fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
+      val fhirHelpersLibrary = runWithTimingDisabled {
+        val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
         val jsonParser = fhirContext.newJsonParser()
-        jsonParser.parseResource(open("/immunity-check/ImmunityCheck.json")) as Bundle
+        jsonParser.parseResource(open("/immunity-check/FhirHelpers.json")) as Library
       }
 
-      val fhirHelpersLibrary = libraryBundle.entry[1].resource as Library
       val jsonLib = fhirHelpersLibrary.content.first { it.contentType == "application/elm+json" }
 
       val fhirHelpersCqlLibrary = JsonCqlLibraryReader().read(StringReader(String(jsonLib.data)))

--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/H_FhirSyncWorkerBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/H_FhirSyncWorkerBenchmark.kt
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.benchmark
+
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
+import ca.uhn.fhir.parser.IParser
+import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.FhirEngineConfiguration
+import com.google.android.fhir.FhirEngineProvider
+import com.google.android.fhir.ServerConfiguration
+import com.google.android.fhir.sync.AcceptRemoteConflictResolver
+import com.google.android.fhir.sync.DownloadWorkManager
+import com.google.android.fhir.sync.FhirSyncWorker
+import com.google.android.fhir.sync.Request
+import com.google.common.truth.Truth.assertThat
+import java.math.BigDecimal
+import java.util.LinkedList
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.hl7.fhir.instance.model.api.IBaseResource
+import org.hl7.fhir.r4.model.Address
+import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.CodeableConcept
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.ContactPoint
+import org.hl7.fhir.r4.model.Encounter
+import org.hl7.fhir.r4.model.Encounter.EncounterParticipantComponent
+import org.hl7.fhir.r4.model.Enumerations
+import org.hl7.fhir.r4.model.HumanName
+import org.hl7.fhir.r4.model.ListResource
+import org.hl7.fhir.r4.model.Observation
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.Quantity
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.Resource
+import org.hl7.fhir.r4.model.ResourceType
+import org.hl7.fhir.r4.model.StringType
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class H_FhirSyncWorkerBenchmark {
+
+  @get:Rule val benchmarkRule = BenchmarkRule()
+
+  private lateinit var fhirJsonParser: IParser
+
+  private lateinit var mockWebServer: MockWebServer
+
+  companion object {
+
+    private const val mockServerPort = 8080
+
+    @JvmStatic
+    @BeforeClass
+    fun oneTimeSetup() {
+      FhirEngineProvider.init(
+        FhirEngineConfiguration(
+          serverConfiguration = ServerConfiguration("http://127.0.0.1:$mockServerPort/fhir/"),
+          testMode = true
+        )
+      )
+    }
+  }
+
+  class BenchmarkTestOneTimeSyncWorker(
+    private val appContext: Context,
+    workerParams: WorkerParameters
+  ) : FhirSyncWorker(appContext, workerParams) {
+
+    override fun getFhirEngine(): FhirEngine {
+      return FhirEngineProvider.getInstance(appContext)
+    }
+    override fun getDownloadWorkManager(): DownloadWorkManager = BenchmarkTestDownloadManagerImpl()
+    override fun getConflictResolver() = AcceptRemoteConflictResolver
+  }
+
+  open class BenchmarkTestDownloadManagerImpl(queries: List<String> = listOf("List/sync-list")) :
+    DownloadWorkManager {
+    private val urls = LinkedList(queries)
+
+    override suspend fun getNextRequest(): Request? {
+      val url = urls.poll()?.let { Request.of(it) }
+      return url
+    }
+    override suspend fun getSummaryRequestUrls(): Map<ResourceType, String> {
+      return emptyMap()
+    }
+
+    override suspend fun processResponse(response: Resource): Collection<Resource> {
+      if (response is ListResource) {
+        for (entry in response.entry) {
+          val reference = Reference(entry.item.reference)
+          if (reference.referenceElement.resourceType.equals("Patient")) {
+            urls.add(entry.item.reference)
+            urls.add("Observation?subject=${entry.item.referenceElement.idPart}")
+            urls.add("Encounter?subject=${entry.item.referenceElement.idPart}")
+          }
+        }
+        return emptyList()
+      }
+
+      if (response is Patient) {
+        return listOf(response)
+      }
+
+      if (response is Bundle && response.type == Bundle.BundleType.SEARCHSET) {
+        return response.entry.map { it.resource }
+      }
+      return emptyList()
+    }
+  }
+
+  @Before
+  fun setup() {
+    fhirJsonParser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
+    mockWebServer = MockWebServer()
+    mockWebServer.start(mockServerPort)
+  }
+
+  @After
+  fun teardown() {
+    mockWebServer.shutdown()
+  }
+
+  @Test fun oneTimeSync_10patients() = oneTimeSync(10, 10, 10)
+
+  @Test fun oneTimeSync_100patients() = oneTimeSync(100, 10, 10)
+
+  @Test fun oneTimeSync_1000patients() = oneTimeSync(1000, 10, 10)
+
+  private fun oneTimeSync(numberPatients: Int, numberObservations: Int, numberEncounters: Int) =
+    runBlocking {
+      val context: Context = ApplicationProvider.getApplicationContext()
+      val worker = TestListenableWorkerBuilder<BenchmarkTestOneTimeSyncWorker>(context).build()
+      setupMockServerDispatcher(numberPatients, numberObservations, numberEncounters)
+      benchmarkRule.measureRepeated {
+        runBlocking {
+          val result = worker.doWork()
+          assertThat(result).isInstanceOf(ListenableWorker.Result.Success::class.java)
+        }
+      }
+    }
+
+  private fun setupMockServerDispatcher(
+    numberPatients: Int,
+    numberObservations: Int,
+    numberEncounters: Int
+  ) {
+    mockWebServer.dispatcher =
+      object : Dispatcher() {
+        @Throws(InterruptedException::class)
+        override fun dispatch(request: RecordedRequest): MockResponse {
+          if (request.path == "/fhir/List/sync-list") {
+            val list =
+              ListResource().apply {
+                entry =
+                  (1..numberPatients).map { _ ->
+                    ListResource.ListEntryComponent().apply {
+                      item =
+                        (Reference().apply {
+                          setReferenceElement(StringType("Patient/${UUID.randomUUID()}"))
+                        })
+                    }
+                  }
+              }
+            return createResourceResponse(list)
+          }
+
+          if (request.path!!.startsWith("/fhir/Patient")) {
+            val patientId = request.path!!.split("//").last()
+            return createResourceResponse(createMockPatient(patientId))
+          }
+
+          if (request.path!!.startsWith("/fhir/Observation")) {
+            val patientId = request.requestUrl!!.queryParameter("subject")!!
+            val bundle =
+              Bundle().apply {
+                type = Bundle.BundleType.SEARCHSET
+                id = UUID.randomUUID().toString()
+                entry =
+                  (1..numberObservations).map {
+                    Bundle.BundleEntryComponent().setResource(createMockObservation(patientId))
+                  }
+              }
+            return createResourceResponse(bundle)
+          }
+
+          if (request.path!!.startsWith("/fhir/Encounter")) {
+            val patientId = request.requestUrl!!.queryParameter("subject")!!
+            val bundle =
+              Bundle().apply {
+                type = Bundle.BundleType.SEARCHSET
+                entry =
+                  (1..numberEncounters).map {
+                    Bundle.BundleEntryComponent().setResource(createMockEncounter(patientId))
+                  }
+              }
+            return createResourceResponse(bundle)
+          }
+          return MockResponse().setResponseCode(404)
+        }
+      }
+  }
+
+  private fun createResourceResponse(resource: IBaseResource): MockResponse {
+    val response = MockResponse().addHeader("Content-Type", "application/json; charset=utf-8")
+    return response.setBody(fhirJsonParser.encodeResourceToString(resource)).setResponseCode(200)
+  }
+
+  private fun createMockObservation(patientId: String): Observation {
+    return Observation().apply {
+      id = UUID.randomUUID().toString()
+      status = Observation.ObservationStatus.FINAL
+      subject = Reference("Patient/$patientId")
+      performer = listOf(Reference("Practitioner/${UUID.randomUUID()}"))
+      value =
+        Quantity().apply {
+          value = BigDecimal.valueOf(6.2)
+          unit = "kPa"
+          code = "kPa"
+          system = "http://unitsofmeasure.org"
+        }
+      code =
+        CodeableConcept().apply {
+          coding = listOf(Coding("http://unitsofmeasure.org", "kPa", "kPa"))
+        }
+      referenceRange =
+        listOf(
+          Observation.ObservationReferenceRangeComponent().apply {
+            low =
+              Quantity().apply {
+                value = BigDecimal.valueOf(4.8)
+                unit = "kPa"
+                code = "kPa"
+                system = "http://unitsofmeasure.org"
+              }
+            high =
+              Quantity().apply {
+                value = BigDecimal.valueOf(6.0)
+                unit = "kPa"
+                code = "kPa"
+                system = "http://unitsofmeasure.org"
+              }
+          }
+        )
+      interpretation =
+        listOf(
+          CodeableConcept(
+            Coding(
+              "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+              "H",
+              "high"
+            )
+          )
+        )
+    }
+  }
+
+  private fun createMockEncounter(patientId: String): Encounter {
+    return Encounter().apply {
+      id = UUID.randomUUID().toString()
+      status = Encounter.EncounterStatus.FINISHED
+      class_ =
+        Coding("http://terminology.hl7.org/CodeSystem/v3-ActCode", "IMP", "inpatient encounter")
+      priority =
+        CodeableConcept().apply {
+          coding = listOf(Coding("http://snomed.info/sct", "394849002", "High priority"))
+        }
+      type =
+        listOf(
+          CodeableConcept().apply {
+            coding =
+              listOf(Coding("http://snomed.info/sct", "183807002", "Inpatient stay for nine days"))
+          }
+        )
+      subject = Reference("Patient/$patientId")
+      episodeOfCare = listOf(Reference("Episode/${UUID.randomUUID()}"))
+      serviceProvider = Reference("Organization/123")
+      participant =
+        listOf(
+          EncounterParticipantComponent().apply {
+            individual = Reference("Practitioner/${UUID.randomUUID()}")
+            type =
+              listOf(
+                CodeableConcept().apply {
+                  coding =
+                    listOf(
+                      Coding(
+                        "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                        "PART",
+                        "Participant"
+                      )
+                    )
+                }
+              )
+          }
+        )
+      diagnosis =
+        listOf(
+          Encounter.DiagnosisComponent().apply {
+            condition = Reference("Condition/stroke")
+            use =
+              CodeableConcept().apply {
+                coding =
+                  listOf(
+                    Coding(
+                      "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+                      "AD",
+                      "Admission diagnosis"
+                    )
+                  )
+              }
+          },
+          Encounter.DiagnosisComponent().apply {
+            condition = Reference("Condition/f201")
+            use =
+              CodeableConcept().apply {
+                coding =
+                  listOf(
+                    Coding(
+                      "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+                      "DD",
+                      "Discharge diagnosis"
+                    )
+                  )
+              }
+          }
+        )
+    }
+  }
+
+  private fun createMockPatient(patientId: String): Patient {
+    return Patient().apply {
+      id = patientId
+      gender =
+        if (patientId.last().isDigit()) Enumerations.AdministrativeGender.FEMALE
+        else Enumerations.AdministrativeGender.MALE
+      name =
+        listOf(
+          HumanName().apply {
+            given = listOf(StringType("Test patient Name $patientId"))
+            family = "Patient Family"
+          }
+        )
+      address =
+        listOf(
+          Address().apply {
+            text = "534 Erewhon St PeasantVille, Rainbow, Vic  3999"
+            city = "PleasantVille"
+            district = "Rainbow"
+            state = "Vic"
+            postalCode = "postalCode"
+            line = listOf(StringType("534 Erewhon St"))
+          }
+        )
+      contact =
+        listOf(
+          Patient.ContactComponent().apply {
+            relationship =
+              listOf(
+                CodeableConcept().apply {
+                  coding = listOf(Coding("http://terminology.hl7.org/CodeSystem/v2-0131", "N", ""))
+                  name =
+                    HumanName().apply {
+                      given = listOf(StringType("Test patient rep Name $patientId"))
+                      family = "Patient Family"
+                    }
+                  gender =
+                    if (patientId.last().isDigit()) Enumerations.AdministrativeGender.MALE
+                    else Enumerations.AdministrativeGender.FEMALE
+                }
+              )
+          }
+        )
+      telecom =
+        listOf(
+          ContactPoint().apply {
+            system = ContactPoint.ContactPointSystem.PHONE
+            value = "(03) 5555 6473"
+            use = ContactPoint.ContactPointUse.HOME
+          },
+          ContactPoint().apply {
+            system = ContactPoint.ContactPointSystem.PHONE
+            value = "(03) 3410 5613"
+            use = ContactPoint.ContactPointUse.WORK
+          }
+        )
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -289,7 +289,7 @@ object Dependencies {
     // Test dependencies
 
     object AndroidxTest {
-      const val benchmarkJUnit = "1.1.0"
+      const val benchmarkJUnit = "1.1.0-alpha12"
       const val core = "1.4.0"
       const val archCore = "2.1.0"
       const val extJunit = "1.1.5"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -289,7 +289,7 @@ object Dependencies {
     // Test dependencies
 
     object AndroidxTest {
-      const val benchmarkJUnit = "1.1.0-alpha12"
+      const val benchmarkJUnit = "1.1.1"
       const val core = "1.4.0"
       const val archCore = "2.1.0"
       const val extJunit = "1.1.5"


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1996 

**Description**
- Added benchmark test for `FHIRSyncWorker` which tests a sample sync pattern for downloading `Patient`s and its related resources (`Observation` and `Encounter`)
- Fixed some broken existing benchmarks

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
NA

**Type**
Choose one: Testing

**Screenshots (if applicable)**
5,409,320,711   ns    H_FhirSyncWorkerBenchmark.oneTimeSync_100patients
41,061,074,228   ns    H_FhirSyncWorkerBenchmark.oneTimeSync_1000patients
443,757,834   ns    H_FhirSyncWorkerBenchmark.oneTimeSync_10patients

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
