### PR TITLE
Allow multiple resources to be set in context

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -304,7 +304,7 @@ class QuestionnaireFragment : Fragment() {
     }
 
     fun setQuestionnaireLaunchContexts(launchContexts: List<String>) = apply {
-      args.add(EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING to launchContexts)
+      args.add(EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRINGS to launchContexts)
     }
 
     /**
@@ -399,8 +399,8 @@ class QuestionnaireFragment : Fragment() {
     internal const val EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING = "questionnaire-response"
 
     /** A list of JSON encoded strings extra for each questionnaire context. */
-    internal const val EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING =
-      "list-of-questionnaire-launch-contexts"
+    internal const val EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRINGS =
+      "questionnaire-launch-contexts"
     /**
      * A [URI][android.net.Uri] extra for streaming a JSON encoded questionnaire response.
      *

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -303,6 +303,14 @@ class QuestionnaireFragment : Fragment() {
       args.add(EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI to questionnaireResponseUri)
     }
 
+    /**
+     * The launch context allows information to be passed into questionnaire based on the context in
+     * which the questionnaire is being evaluated. For example, what patient, what encounter, what
+     * user, etc. is "in context" at the time the questionnaire response is being completed:
+     * https://build.fhir.org/ig/HL7/sdc/StructureDefinition-sdc-questionnaire-launchContext.html
+     *
+     * @param launchContexts list of serialized resources
+     */
     fun setQuestionnaireLaunchContexts(launchContexts: List<String>) = apply {
       args.add(EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRINGS to launchContexts)
     }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -303,8 +303,8 @@ class QuestionnaireFragment : Fragment() {
       args.add(EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI to questionnaireResponseUri)
     }
 
-    fun setQuestionnaireLaunchContext(questionnaireLaunchContext: String) = apply {
-      args.add(EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRING to questionnaireLaunchContext)
+    fun setQuestionnaireLaunchContext(launchContexts: List<String>) = apply {
+      args.add(EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING to launchContexts)
     }
 
     /**
@@ -389,9 +389,9 @@ class QuestionnaireFragment : Fragment() {
      */
     internal const val EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING = "questionnaire-response"
 
-    /** A JSON encoded string extra for questionnaire context. */
-    internal const val EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRING =
-      "questionnaire-launch-context"
+    /** A list of JSON encoded strings extra for each questionnaire context. */
+    internal const val EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING =
+      "list-of-questionnaire-launch-contexts"
     /**
      * A [URI][android.net.Uri] extra for streaming a JSON encoded questionnaire response.
      *

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -303,7 +303,7 @@ class QuestionnaireFragment : Fragment() {
       args.add(EXTRA_QUESTIONNAIRE_RESPONSE_JSON_URI to questionnaireResponseUri)
     }
 
-    fun setQuestionnaireLaunchContext(launchContexts: List<String>) = apply {
+    fun setQuestionnaireLaunchContexts(launchContexts: List<String>) = apply {
       args.add(EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING to launchContexts)
     }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -26,7 +26,6 @@ import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import ca.uhn.fhir.parser.IParser
 import com.google.android.fhir.datacapture.enablement.EnablementEvaluator
-import com.google.android.fhir.datacapture.extensions.EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT
 import com.google.android.fhir.datacapture.extensions.EntryMode
 import com.google.android.fhir.datacapture.extensions.addNestedItemsToAnswer
 import com.google.android.fhir.datacapture.extensions.allItems
@@ -44,6 +43,7 @@ import com.google.android.fhir.datacapture.extensions.isPaginated
 import com.google.android.fhir.datacapture.extensions.isXFhirQuery
 import com.google.android.fhir.datacapture.extensions.localizedTextSpanned
 import com.google.android.fhir.datacapture.extensions.packRepeatedGroups
+import com.google.android.fhir.datacapture.extensions.questionnaireLaunchContexts
 import com.google.android.fhir.datacapture.extensions.shouldHaveNestedItemsUnderAnswers
 import com.google.android.fhir.datacapture.extensions.unpackRepeatedGroups
 import com.google.android.fhir.datacapture.extensions.validateLaunchContextExtensions
@@ -168,22 +168,19 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
 
   init {
     questionnaireLaunchContextMap =
-      if (state.contains(
-          QuestionnaireFragment.EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING
-        )
-      ) {
+      if (state.contains(QuestionnaireFragment.EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRINGS)) {
 
-        val launchContextsAsStrings: List<String> =
-          state[QuestionnaireFragment.EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING]!!
+        val launchContextJsonStrings: List<String> =
+          state[QuestionnaireFragment.EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRINGS]!!
 
-        val launchContexts = launchContextsAsStrings.map { parser.parseResource(it) as Resource }
-        questionnaire.extension
-          .filter { it.url == EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT }
-          .takeIf { it.isNotEmpty() }
-          ?.let { extensions ->
-            validateLaunchContextExtensions(extensions, launchContexts.map { it.resourceType.name })
-            launchContexts.associateBy { it.resourceType.name.lowercase() }
-          }
+        val launchContexts = launchContextJsonStrings.map { parser.parseResource(it) as Resource }
+        questionnaire.questionnaireLaunchContexts?.let { launchContextExtensions ->
+          validateLaunchContextExtensions(
+            launchContextExtensions,
+            launchContexts.map { it.resourceType.name }
+          )
+          launchContexts.associateBy { it.resourceType.name.lowercase() }
+        }
       } else {
         null
       }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -175,10 +175,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
 
         val launchContexts = launchContextJsonStrings.map { parser.parseResource(it) as Resource }
         questionnaire.questionnaireLaunchContexts?.let { launchContextExtensions ->
-          validateLaunchContextExtensions(
-            launchContextExtensions,
-            launchContexts.map { it.resourceType.name }
-          )
+          validateLaunchContextExtensions(launchContextExtensions)
           launchContexts.associateBy { it.resourceType.name.lowercase() }
         }
       } else {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaires.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaires.kt
@@ -51,7 +51,16 @@ internal fun Questionnaire.findVariableExpression(variableName: String): Express
  * Validates the questionnaire launch context extension, if it exists, and well formed, and
  * validates if the resource type is applicable as a launch context.
  */
-internal fun validateLaunchContext(extension: Extension, resourceType: String) {
+internal fun validateLaunchContextExtensions(
+  launchContextExtensions: List<Extension>,
+  launchContextResourceTypes: List<String>
+) =
+  launchContextExtensions.forEach { validateLaunchContextExtension(it, launchContextResourceTypes) }
+
+private fun validateLaunchContextExtension(
+  extension: Extension,
+  launchContextResourceTypes: List<String>
+) {
   val nameExtension =
     extension.extension
       .firstOrNull { it.url == "name" }
@@ -65,7 +74,7 @@ internal fun validateLaunchContext(extension: Extension, resourceType: String) {
   val typeExtension =
     extension.extension
       .firstOrNull { it.url == "type" }
-      ?.takeIf { it.valueAsPrimitive.valueAsString == resourceType }
+      ?.takeIf { launchContextResourceTypes.contains(it.valueAsPrimitive.valueAsString) }
 
   if (nameExtension == null) {
     error(
@@ -78,8 +87,8 @@ internal fun validateLaunchContext(extension: Extension, resourceType: String) {
   if (typeExtension == null) {
     error(
       "The resource type set in the extension:type field in " +
-        "$EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT does not match the resource type of the " +
-        "context passed in: $resourceType."
+        "$EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT does not match any of the resource types of the " +
+        "context passed in: $launchContextResourceTypes."
     )
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaires.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaires.kt
@@ -77,11 +77,10 @@ internal fun validateLaunchContextExtensions(launchContextExtensions: List<Exten
  * [QuestionnaireLaunchContextSet]
  */
 private fun validateLaunchContextExtension(launchExtension: Extension) {
-  if (launchExtension.extension.size != 2) {
-    error(
-      "The extension:name or extension:type extension is missing in $EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT"
-    )
+  check(launchExtension.extension.size == 2) {
+    "The extension:name or extension:type extension is missing in $EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT"
   }
+
   val isValidExtension =
     QuestionnaireLaunchContextSet.values().any {
       launchExtension.equalsDeep(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -27,7 +27,7 @@ import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.FhirEngineProvider
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_ENABLE_REVIEW_PAGE
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_JSON_STRING
-import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRINGS
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_READ_ONLY
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_SHOW_REVIEW_PAGE_FIRST
@@ -86,7 +86,6 @@ import org.hl7.fhir.r4.model.Practitioner
 import org.hl7.fhir.r4.model.Quantity
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
-import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
 import org.hl7.fhir.r4.model.StringType
 import org.hl7.fhir.r4.model.ValueSet
 import org.hl7.fhir.r4.utils.ToolingExtensions
@@ -3962,7 +3961,7 @@ class QuestionnaireViewModelTest {
         }
       state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, printer.encodeResourceToString(questionnaire))
       state.set(
-        EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING,
+        EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRINGS,
         listOf(printer.encodeResourceToString(patient))
       )
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -27,7 +27,7 @@ import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.FhirEngineProvider
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_ENABLE_REVIEW_PAGE
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_JSON_STRING
-import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRING
+import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_READ_ONLY
 import com.google.android.fhir.datacapture.QuestionnaireFragment.Companion.EXTRA_SHOW_REVIEW_PAGE_FIRST
@@ -3916,13 +3916,7 @@ class QuestionnaireViewModelTest {
         )
 
       val patientId = "123"
-      val patient =
-        Patient().apply {
-          id = patientId
-          active = true
-          gender = Enumerations.AdministrativeGender.MALE
-          addName(HumanName().apply { this.family = "Johnny" })
-        }
+      val patient = Patient().apply { id = patientId }
 
       val questionnaire =
         Questionnaire().apply {
@@ -3963,8 +3957,8 @@ class QuestionnaireViewModelTest {
         }
       state.set(EXTRA_QUESTIONNAIRE_JSON_STRING, printer.encodeResourceToString(questionnaire))
       state.set(
-        EXTRA_QUESTIONNAIRE_LAUNCH_CONTEXT_JSON_STRING,
-        printer.encodeResourceToString(patient)
+        EXTRA_QUESTIONNAIRE_LIST_OF_LAUNCH_CONTEXTS_JSON_STRING,
+        listOf(printer.encodeResourceToString(patient))
       )
 
       val viewModel = QuestionnaireViewModel(context, state)

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
@@ -190,7 +190,31 @@ class MoreQuestionnairesTest {
   }
 
   @Test
-  fun `should throw exception if both name and type extension are not present`() {
+  fun `should throw exception if the type extension is not present`() {
+    val launchContextExtension =
+      Extension("http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext")
+        .apply {
+          addExtension(
+            "name",
+            Coding("http://hl7.org/fhir/uv/sdc/CodeSystem/launchContext", "user", "User")
+          )
+        }
+
+    val errorMessage =
+      assertFailsWith<IllegalStateException> {
+          validateLaunchContextExtensions(listOf(launchContextExtension))
+        }
+        .localizedMessage
+
+    assertThat(errorMessage)
+      .isEqualTo(
+        "The extension:name or extension:type extension is missing in " +
+          EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT
+      )
+  }
+
+  @Test
+  fun `should throw exception if the name extension is not present`() {
     val launchContextExtension =
       Extension("http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext")
         .apply {

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
@@ -128,7 +128,7 @@ class MoreQuestionnairesTest {
 
     val errorMessage =
       assertFailsWith<IllegalStateException> {
-          validateLaunchContext(launchContextExtension, "Patient")
+          validateLaunchContextExtensions(listOf(launchContextExtension), listOf("Patient"))
         }
         .localizedMessage
 
@@ -154,7 +154,7 @@ class MoreQuestionnairesTest {
 
     val errorMessage =
       assertFailsWith<IllegalStateException> {
-          validateLaunchContext(launchContextExtension, "Patient")
+          validateLaunchContextExtensions(listOf(launchContextExtension), listOf("Patient"))
         }
         .localizedMessage
 
@@ -162,7 +162,7 @@ class MoreQuestionnairesTest {
       .isEqualTo(
         "The resource type set in the extension:type field in " +
           "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext does " +
-          "not match the resource type of the context passed in: Patient."
+          "not match any of the resource types of the context passed in: [Patient]."
       )
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
@@ -134,7 +134,7 @@ class MoreQuestionnairesTest {
 
     assertThat(errorMessage)
       .isEqualTo(
-        "The value of the extension:name field in " +
+        "The value of the extension:name extension in " +
           "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext is " +
           "not one of the ones defined in http://hl7.org/fhir/uv/sdc/CodeSystem/launchContext."
       )
@@ -160,7 +160,7 @@ class MoreQuestionnairesTest {
 
     assertThat(errorMessage)
       .isEqualTo(
-        "The resource type set in the extension:type field in " +
+        "The launch contexts' resource types are not set in the extension:type extension in " +
           "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext does " +
           "not match any of the resource types of the context passed in: [Patient]."
       )

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnairesTest.kt
@@ -134,9 +134,8 @@ class MoreQuestionnairesTest {
 
     assertThat(errorMessage)
       .isEqualTo(
-        "The value of the extension:name extension in " +
-          "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext is " +
-          "not a valid code in http://hl7.org/fhir/uv/sdc/CodeSystem/launchContext."
+        "The extension:name extension and/or extension:type extension do not follow " +
+          "the format specified in http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext"
       )
   }
 
@@ -160,8 +159,8 @@ class MoreQuestionnairesTest {
 
     assertThat(errorMessage)
       .isEqualTo(
-        "The resource type, Patient, in the extension:type extension is not the same as " +
-          "the value set defined in the extension:name extension"
+        "The extension:name extension and/or extension:type extension do not follow " +
+          "the format specified in http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext"
       )
   }
 
@@ -185,8 +184,32 @@ class MoreQuestionnairesTest {
 
     assertThat(errorMessage)
       .isEqualTo(
-        "Types must be from the specified value set of resource types based on User: " +
-          "[Patient, Practitioner, PractitionerRole, RelatedPerson]"
+        "The extension:name extension and/or extension:type extension do not follow " +
+          "the format specified in http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext"
+      )
+  }
+
+  @Test
+  fun `should throw exception if both name and type extension are not present`() {
+    val launchContextExtension =
+      Extension("http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext")
+        .apply {
+          addExtension(
+            "name",
+            Coding("http://hl7.org/fhir/uv/sdc/CodeSystem/launchContext", "user", "User")
+          )
+        }
+
+    val errorMessage =
+      assertFailsWith<IllegalStateException> {
+          validateLaunchContextExtensions(listOf(launchContextExtension))
+        }
+        .localizedMessage
+
+    assertThat(errorMessage)
+      .isEqualTo(
+        "The extension:name or extension:type extension is missing in " +
+          EXTENSION_SDC_QUESTIONNAIRE_LAUNCH_CONTEXT
       )
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
@@ -683,7 +683,10 @@ class ExpressionEvaluatorTest {
       }
 
     val expressionsToEvaluate =
-      ExpressionEvaluator.createXFhirQueryFromExpression(expression, Practitioner())
+      ExpressionEvaluator.createXFhirQueryFromExpression(
+        expression,
+        mapOf("Practitioner" to Practitioner())
+      )
 
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?var1=&var2=&var3=&var4=")
   }
@@ -704,7 +707,10 @@ class ExpressionEvaluatorTest {
       }
 
     val expressionsToEvaluate =
-      ExpressionEvaluator.createXFhirQueryFromExpression(expression, practitioner)
+      ExpressionEvaluator.createXFhirQueryFromExpression(
+        expression,
+        mapOf(practitioner.resourceType.name to practitioner)
+      )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=")
   }
 
@@ -725,7 +731,10 @@ class ExpressionEvaluatorTest {
       }
 
     val expressionsToEvaluate =
-      ExpressionEvaluator.createXFhirQueryFromExpression(expression, practitioner)
+      ExpressionEvaluator.createXFhirQueryFromExpression(
+        expression,
+        mapOf(practitioner.resourceType.name.lowercase() to practitioner)
+      )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=male")
   }
 
@@ -746,7 +755,10 @@ class ExpressionEvaluatorTest {
       }
 
     val expressionsToEvaluate =
-      ExpressionEvaluator.createXFhirQueryFromExpression(expression, practitioner)
+      ExpressionEvaluator.createXFhirQueryFromExpression(
+        expression,
+        mapOf(practitioner.resourceType.name to practitioner)
+      )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=")
   }
 
@@ -768,7 +780,10 @@ class ExpressionEvaluatorTest {
       }
 
     val expressionsToEvaluate =
-      ExpressionEvaluator.createXFhirQueryFromExpression(expression, patient)
+      ExpressionEvaluator.createXFhirQueryFromExpression(
+        expression,
+        mapOf(patient.resourceType.name.lowercase() to patient)
+      )
     assertThat(expressionsToEvaluate).isEqualTo("Patient?maritalStatus-display=Single")
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes: #1658

**Description**
Clear and concise code change description. 

Allow multiple resources to be set in context

In the resource table, it says: 

```
Context resources needed for Questionnaire
```
 https://build.fhir.org/ig/HL7/sdc/StructureDefinition-sdc-questionnaire-launchContext.html



**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
