### PR TITLE
Support sending gzipped request body when uploading

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/FhirEngineProvider.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngineProvider.kt
@@ -161,5 +161,7 @@ data class NetworkConfiguration(
   /** Read timeout (in seconds) for network connection. The default is 10 seconds. */
   val readTimeOut: Long = 10,
   /** Write timeout (in seconds) for network connection. The default is 10 seconds. */
-  val writeTimeOut: Long = 10
+  val writeTimeOut: Long = 10,
+  /** Compresses requests when uploading to a server that supports gzip. */
+  val uploadWithGzip: Boolean = false
 )

--- a/engine/src/main/java/com/google/android/fhir/sync/remote/RetrofitHttpService.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/remote/RetrofitHttpService.kt
@@ -74,6 +74,9 @@ internal interface RetrofitHttpService : FhirHttpService {
                 }
               )
             }
+            if (networkConfiguration.uploadWithGzip) {
+              addInterceptor(GzipUploadInterceptor())
+            }
           }
           .build()
       return Retrofit.Builder()

--- a/engine/src/test/java/com/google/android/fhir/sync/remote/GzipUploadInterceptorTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/remote/GzipUploadInterceptorTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.sync.remote
+
+import com.google.android.fhir.MediaTypes
+import com.google.common.truth.Truth.assertThat
+import java.util.zip.GZIPInputStream
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GzipUploadInterceptorTest {
+
+  @JvmField @Rule val server = MockWebServer()
+  private val client = OkHttpClient.Builder().addInterceptor(GzipUploadInterceptor()).build()
+
+  @Test
+  fun `uncompressed request body received by server should match request body sent`() {
+    server.enqueue(MockResponse())
+
+    val request =
+      Request.Builder()
+        .url(server.url("/"))
+        .method("POST", "abc".toRequestBody(MediaTypes.MEDIA_TYPE_FHIR_JSON))
+        .build()
+
+    client.newCall(request).execute()
+
+    val recordedRequest = server.takeRequest()
+    val uncompressedBodyReceived =
+      String(GZIPInputStream(recordedRequest.body.inputStream()).use { it.readBytes() })
+    assertThat(uncompressedBodyReceived).isEqualTo("abc")
+    assertThat(recordedRequest.getHeader(CONTENT_ENCODING_HEADER_NAME)).isEqualTo("gzip")
+  }
+
+  @Test
+  fun `no compression happens if content header is not gzip`() {
+    server.enqueue(MockResponse())
+    val request =
+      Request.Builder()
+        .url(server.url("/"))
+        .addHeader(CONTENT_ENCODING_HEADER_NAME, "random")
+        .method("POST", "abc".toRequestBody(MediaTypes.MEDIA_TYPE_FHIR_JSON))
+        .build()
+
+    client.newCall(request).execute()
+
+    val recordedRequest = server.takeRequest()
+    assertThat(recordedRequest.getHeader(CONTENT_ENCODING_HEADER_NAME)).doesNotContain("gzip")
+  }
+}


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1988 

**Description**
Clear and concise code change description. 

* Support sending gzipped request body when uploading to the server
* Make uploading with gzip an option that developers can set
* No need to support download as OkHTTP does this for us automatically
* Tested on local HAPI server and it works



**Type**
Choose one: (Bug fix | **Feature** | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
