### PR TITLE
Include the corresponding questionnaireResponseItemComponents for nested items in the group.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -129,6 +129,10 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
           parser.parseResource(application.contentResolver.openInputStream(uri))
             as QuestionnaireResponse
         checkQuestionnaireResponse(questionnaire, questionnaireResponse)
+        addQuestionnaireResponseItemComponentToQuestionnaireResponse(
+          questionnaire.item,
+          questionnaireResponse.item
+        )
       }
       state.contains(QuestionnaireFragment.EXTRA_QUESTIONNAIRE_RESPONSE_JSON_STRING) -> {
         val questionnaireResponseJson: String =
@@ -136,6 +140,10 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         questionnaireResponse =
           parser.parseResource(questionnaireResponseJson) as QuestionnaireResponse
         checkQuestionnaireResponse(questionnaire, questionnaireResponse)
+        addQuestionnaireResponseItemComponentToQuestionnaireResponse(
+          questionnaire.item,
+          questionnaireResponse.item
+        )
       }
       else -> {
         questionnaireResponse =
@@ -150,6 +158,31 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
       }
     }
     questionnaireResponse.packRepeatedGroups()
+  }
+
+  private fun addQuestionnaireResponseItemComponentToQuestionnaireResponse(
+    questionnaireItemComponents: List<QuestionnaireItemComponent>,
+    responseItemComponents: MutableList<QuestionnaireResponseItemComponent>
+  ) {
+    questionnaireItemComponents.forEachIndexed { index, questionnaireItemComponent ->
+      when {
+        index >= responseItemComponents.size -> {
+          responseItemComponents.add(questionnaireItemComponent.createQuestionnaireResponseItem())
+        }
+        questionnaireItemComponent.linkId != responseItemComponents[index].linkId -> {
+          responseItemComponents.add(
+            index,
+            questionnaireItemComponent.createQuestionnaireResponseItem()
+          )
+        }
+      }
+      if (!questionnaireItemComponent.shouldHaveNestedItemsUnderAnswers) {
+        addQuestionnaireResponseItemComponentToQuestionnaireResponse(
+          questionnaireItemComponent.item,
+          responseItemComponents[index].item
+        )
+      }
+    }
   }
 
   /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -448,7 +448,10 @@ internal val Questionnaire.QuestionnaireItemComponent.sliderStepValue: Int?
  * For background, see https://build.fhir.org/questionnaireresponse.html#link.
  */
 internal val Questionnaire.QuestionnaireItemComponent.shouldHaveNestedItemsUnderAnswers: Boolean
-  get() = item.isNotEmpty() && (type != Questionnaire.QuestionnaireItemType.GROUP || !repeats)
+  get() =
+    item.isNotEmpty() &&
+      ((type != Questionnaire.QuestionnaireItemType.GROUP && !repeats) ||
+        (type == Questionnaire.QuestionnaireItemType.GROUP && repeats))
 
 /**
  * Creates a list of [QuestionnaireResponse.QuestionnaireResponseItemComponent]s from the nested


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1998

**Description**
The issue was reproducible itself when the QuestionnaireResponse did not include questionnaireResponseItemComponents for nested items within the group type item.
To resolve this issue, it is necessary to include the corresponding questionnaireResponseItemComponents for nested items in the group type during initialization of questionnaire view model. This ensures that the corresponding view item will be created.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix 
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
