### PR TITLE
Support for headers in the http requests.

### DIFF
--- a/demo/src/main/java/com/google/android/fhir/demo/FhirApplication.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/FhirApplication.kt
@@ -30,6 +30,7 @@ import com.google.android.fhir.demo.data.FhirSyncWorker
 import com.google.android.fhir.search.search
 import com.google.android.fhir.sync.Sync
 import com.google.android.fhir.sync.remote.HttpLogger
+import org.hl7.fhir.r4.model.Patient
 import timber.log.Timber
 
 class FhirApplication : Application(), DataCaptureConfig.Provider {
@@ -45,6 +46,7 @@ class FhirApplication : Application(), DataCaptureConfig.Provider {
     if (BuildConfig.DEBUG) {
       Timber.plant(Timber.DebugTree())
     }
+    Patient.IDENTIFIER
     FhirEngineProvider.init(
       FhirEngineConfiguration(
         enableEncryptionIfSupported = true,

--- a/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -184,6 +184,9 @@ internal class FhirEngineImpl(private val database: Database, private val contex
    * extract version from it. See https://hl7.org/fhir/http.html#Http-Headers.
    */
   private fun getVersionFromETag(eTag: String) =
+    // The server should always return a weak etag that starts with W, but if it server returns a
+    // strong tag, we store it as-is. The http-headers for conditional upload like if-match will
+    // always add value as a weak tag.
     if (eTag.startsWith("W/")) {
       eTag.split("\"")[1]
     } else {

--- a/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -161,7 +161,7 @@ internal class FhirEngineImpl(private val database: Database, private val contex
         database.updateVersionIdAndLastUpdated(
           id,
           type,
-          response.etag,
+          getVersionFromETag(response.etag),
           response.lastModified.toInstant()
         )
       }
@@ -178,6 +178,17 @@ internal class FhirEngineImpl(private val database: Database, private val contex
       )
     }
   }
+
+  /**
+   * FHIR uses weak ETag that look something like W/"MTY4NDMyODE2OTg3NDUyNTAwMA", so we need to
+   * extract version from it. See https://hl7.org/fhir/http.html#Http-Headers.
+   */
+  private fun getVersionFromETag(eTag: String) =
+    if (eTag.startsWith("W/")) {
+      eTag.split("\"")[1]
+    } else {
+      eTag
+    }
 
   /**
    * May return a Pair of versionId and resource type extracted from the

--- a/engine/src/main/java/com/google/android/fhir/sync/Config.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/Config.kt
@@ -112,12 +112,19 @@ data class BackoffCriteria(
 
 /**
  * Configuration for max number of resources to be uploaded in a Bundle.The default size is
- * [DEFAULT_BUNDLE_SIZE].
+ * [DEFAULT_BUNDLE_SIZE]. The application developer may also configure if the eTag should be used
+ * for edit and delete requests during the upload. Default is to use the eTag.
  */
 data class UploadConfiguration(
   /**
    * Number of [Resource]s to be added in a singe [Bundle] for upload and default is
    * [DEFAULT_BUNDLE_SIZE]
    */
-  val uploadBundleSize: Int = DEFAULT_BUNDLE_SIZE
+  val uploadBundleSize: Int = DEFAULT_BUNDLE_SIZE,
+
+  /**
+   * Use if-match http header with e-tag for upload requests. See ETag
+   * [section](https://hl7.org/fhir/http.html#Http-Headers) for more details.
+   */
+  val useETagForUpload: Boolean = true,
 )

--- a/engine/src/main/java/com/google/android/fhir/sync/DataSource.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/DataSource.kt
@@ -26,23 +26,13 @@ import org.hl7.fhir.r4.model.Resource
  * operations are [Bundle] based to optimize network traffic.
  */
 internal interface DataSource {
-  /**
-   * @return [Bundle] of type [BundleType.SEARCHSET] for a successful operation, [OperationOutcome]
-   * otherwise. Call this api with the relative path of the resource search url to be downloaded.
-   */
-  suspend fun download(path: String): Resource
-
-  /**
-   * @return [Bundle] on a successful operation, [OperationOutcome] otherwise. Call this api with
-   * the [Bundle] that contains individual requests bundled together to be downloaded from the
-   * server. (e.g. https://www.hl7.org/fhir/bundle-request-medsallergies.json.html)
-   */
-  suspend fun download(bundle: Bundle): Resource
+  /** @return [Bundle] on a successful operation, [OperationOutcome] otherwise. */
+  suspend fun download(request: Request): Resource
 
   /**
    * @return [Bundle] of type [BundleType.TRANSACTIONRESPONSE] for a successful operation,
    * [OperationOutcome] otherwise. Call this api with the [Bundle] that needs to be uploaded to the
    * server.
    */
-  suspend fun upload(bundle: Bundle): Resource
+  suspend fun upload(request: BundleRequest): Resource
 }

--- a/engine/src/main/java/com/google/android/fhir/sync/DownloadWorkManager.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/DownloadWorkManager.kt
@@ -45,13 +45,14 @@ interface DownloadWorkManager {
   suspend fun processResponse(response: Resource): Collection<Resource>
 }
 
-sealed class Request {
+sealed class Request(open val headers: Map<String, String>) {
   companion object {
     /** @return [UrlRequest] for a FHIR search [url]. */
-    fun of(url: String) = UrlRequest(url)
+    fun of(url: String, headers: Map<String, String> = emptyMap()) = UrlRequest(url, headers)
 
     /** @return [BundleRequest] for a FHIR search [bundle]. */
-    fun of(bundle: Bundle) = BundleRequest(bundle)
+    fun of(bundle: Bundle, headers: Map<String, String> = emptyMap()) =
+      BundleRequest(bundle, headers)
   }
 }
 
@@ -59,11 +60,15 @@ sealed class Request {
  * A [url] based FHIR request to download resources from the server. e.g.
  * `Patient?given=valueGiven&family=valueFamily`
  */
-data class UrlRequest(val url: String) : Request()
+data class UrlRequest(val url: String, override val headers: Map<String, String> = emptyMap()) :
+  Request(headers)
 
 /**
  * A [bundle] based FHIR request to download resources from the server. For an example, see
  * [bundle-request-medsallergies.json](https://www.hl7.org/fhir/bundle-request-medsallergies.json.html)
  * .
  */
-data class BundleRequest(val bundle: Bundle) : Request()
+data class BundleRequest(
+  val bundle: Bundle,
+  override val headers: Map<String, String> = emptyMap()
+) : Request(headers)

--- a/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
@@ -89,18 +89,20 @@ abstract class FhirSyncWorker(appContext: Context, workerParams: WorkerParameter
 
     Timber.v("Subscribed to flow for progress")
     val result =
-      FhirSynchronizer(
-          applicationContext,
-          getFhirEngine(),
-          BundleUploader(
-            dataSource,
-            TransactionBundleGenerator.getDefault(),
-            LocalChangesPaginator.create(getUploadConfiguration())
-          ),
-          DownloaderImpl(dataSource, getDownloadWorkManager()),
-          getConflictResolver()
-        )
-        .apply { subscribe(flow) }
+      with(getUploadConfiguration()) {
+          FhirSynchronizer(
+              applicationContext,
+              getFhirEngine(),
+              BundleUploader(
+                dataSource,
+                TransactionBundleGenerator.getDefault(useETagForUpload),
+                LocalChangesPaginator.create(this)
+              ),
+              DownloaderImpl(dataSource, getDownloadWorkManager()),
+              getConflictResolver()
+            )
+            .apply { subscribe(flow) }
+        }
         .synchronize()
     val output = buildWorkData(result)
 

--- a/engine/src/main/java/com/google/android/fhir/sync/remote/FhirHttpDataSource.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/remote/FhirHttpDataSource.kt
@@ -16,8 +16,10 @@
 
 package com.google.android.fhir.sync.remote
 
+import com.google.android.fhir.sync.BundleRequest
 import com.google.android.fhir.sync.DataSource
-import org.hl7.fhir.r4.model.Bundle
+import com.google.android.fhir.sync.Request
+import com.google.android.fhir.sync.UrlRequest
 
 /**
  * Implementation of [DataSource] to sync data with the FHIR server using HTTP method calls.
@@ -25,9 +27,12 @@ import org.hl7.fhir.r4.model.Bundle
  */
 internal class FhirHttpDataSource(private val fhirHttpService: FhirHttpService) : DataSource {
 
-  override suspend fun download(path: String) = fhirHttpService.get(path)
+  override suspend fun download(request: Request) =
+    when (request) {
+      is UrlRequest -> fhirHttpService.get(request.url, request.headers)
+      is BundleRequest -> fhirHttpService.post(request.bundle, request.headers)
+    }
 
-  override suspend fun download(bundle: Bundle) = fhirHttpService.post(bundle)
-
-  override suspend fun upload(bundle: Bundle) = fhirHttpService.post(bundle)
+  override suspend fun upload(request: BundleRequest) =
+    fhirHttpService.post(request.bundle, request.headers)
 }

--- a/engine/src/main/java/com/google/android/fhir/sync/remote/FhirHttpService.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/remote/FhirHttpService.kt
@@ -28,11 +28,11 @@ internal interface FhirHttpService {
    * @return The server may return a particular [Resource], [Bundle] or [OperationOutcome] based on
    * the request processing.
    */
-  suspend fun get(path: String): Resource
+  suspend fun get(path: String, headers: Map<String, String>): Resource
 
   /**
    * Makes a HTTP-POST method request to the server with the [Bundle] as request-body.
    * @return The server may return [Bundle] or [OperationOutcome] based on the request processing.
    */
-  suspend fun post(bundle: Bundle): Resource
+  suspend fun post(bundle: Bundle, headers: Map<String, String>): Resource
 }

--- a/engine/src/main/java/com/google/android/fhir/sync/remote/RetrofitHttpService.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/remote/RetrofitHttpService.kt
@@ -27,15 +27,18 @@ import org.hl7.fhir.r4.model.Resource
 import retrofit2.Retrofit
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.HeaderMap
 import retrofit2.http.POST
 import retrofit2.http.Url
 
 /** Retrofit service to make http requests to the FHIR server. */
 internal interface RetrofitHttpService : FhirHttpService {
 
-  @GET override suspend fun get(@Url path: String): Resource
+  @GET
+  override suspend fun get(@Url path: String, @HeaderMap headers: Map<String, String>): Resource
 
-  @POST(".") override suspend fun post(@Body bundle: Bundle): Resource
+  @POST(".")
+  override suspend fun post(@Body bundle: Bundle, @HeaderMap headers: Map<String, String>): Resource
 
   class Builder(
     private val baseUrl: String,

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/BundleUploader.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/BundleUploader.kt
@@ -19,6 +19,7 @@ package com.google.android.fhir.sync.upload
 import com.google.android.fhir.LocalChange
 import com.google.android.fhir.db.impl.dao.LocalChangeToken
 import com.google.android.fhir.sync.DataSource
+import com.google.android.fhir.sync.Request
 import com.google.android.fhir.sync.ResourceSyncException
 import com.google.android.fhir.sync.UploadResult
 import com.google.android.fhir.sync.Uploader
@@ -47,7 +48,7 @@ internal class BundleUploader(
     bundleGenerator.generate(localChangesPaginator.page(localChanges)).forEach {
       (bundle, localChangeTokens) ->
       try {
-        val response = dataSource.upload(bundle)
+        val response = dataSource.upload(Request.of(bundle))
 
         completed += bundle.entry.size
         emit(getUploadResult(response, localChangeTokens, total, completed))

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentGenerator.kt
@@ -32,7 +32,8 @@ import org.hl7.fhir.r4.model.UriType
  * more info regarding the supported [Bundle.HTTPVerb].
  */
 internal abstract class HttpVerbBasedBundleEntryComponentGenerator(
-  private val httpVerb: Bundle.HTTPVerb
+  private val httpVerb: Bundle.HTTPVerb,
+  private val useETagForUpload: Boolean,
 ) {
 
   /**
@@ -60,11 +61,13 @@ internal abstract class HttpVerbBasedBundleEntryComponentGenerator(
         UriType("${localChange.resourceType}/${localChange.resourceId}")
       )
       .apply {
-        // FHIR supports weak Etag, See ETag section https://hl7.org/fhir/http.html#Http-Headers
-        when (localChange.type) {
-          LocalChange.Type.UPDATE,
-          LocalChange.Type.DELETE -> ifMatch = "W/\"${localChange.versionId}\""
-          LocalChange.Type.INSERT -> {}
+        if (useETagForUpload) {
+          // FHIR supports weak Etag, See ETag section https://hl7.org/fhir/http.html#Http-Headers
+          when (localChange.type) {
+            LocalChange.Type.UPDATE,
+            LocalChange.Type.DELETE -> ifMatch = "W/\"${localChange.versionId}\""
+            LocalChange.Type.INSERT -> {}
+          }
         }
       }
 }

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentGenerator.kt
@@ -56,7 +56,15 @@ internal abstract class HttpVerbBasedBundleEntryComponentGenerator(
 
   private fun getEntryRequest(localChange: LocalChange) =
     Bundle.BundleEntryRequestComponent(
-      Enumeration(Bundle.HTTPVerbEnumFactory()).apply { value = httpVerb },
-      UriType("${localChange.resourceType}/${localChange.resourceId}")
-    )
+        Enumeration(Bundle.HTTPVerbEnumFactory()).apply { value = httpVerb },
+        UriType("${localChange.resourceType}/${localChange.resourceId}")
+      )
+      .apply {
+        // FHIR supports weak Etag, See ETag section https://hl7.org/fhir/http.html#Http-Headers
+        when (localChange.type) {
+          LocalChange.Type.UPDATE,
+          LocalChange.Type.DELETE -> ifMatch = "W/\"${localChange.versionId}\""
+          LocalChange.Type.INSERT -> {}
+        }
+      }
 }

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentGenerator.kt
@@ -61,7 +61,7 @@ internal abstract class HttpVerbBasedBundleEntryComponentGenerator(
         UriType("${localChange.resourceType}/${localChange.resourceId}")
       )
       .apply {
-        if (useETagForUpload) {
+        if (useETagForUpload && !localChange.versionId.isNullOrEmpty()) {
           // FHIR supports weak Etag, See ETag section https://hl7.org/fhir/http.html#Http-Headers
           when (localChange.type) {
             LocalChange.Type.UPDATE,

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentImplementations.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/HttpVerbBasedBundleEntryComponentImplementations.kt
@@ -24,8 +24,8 @@ import org.hl7.fhir.instance.model.api.IBaseResource
 import org.hl7.fhir.r4.model.Binary
 import org.hl7.fhir.r4.model.Bundle
 
-internal object HttpPutForCreateEntryComponentGenerator :
-  HttpVerbBasedBundleEntryComponentGenerator(Bundle.HTTPVerb.PUT) {
+internal class HttpPutForCreateEntryComponentGenerator(useETagForUpload: Boolean) :
+  HttpVerbBasedBundleEntryComponentGenerator(Bundle.HTTPVerb.PUT, useETagForUpload) {
   override fun getEntryResource(localChange: LocalChange): IBaseResource {
     return FhirContext.forCached(FhirVersionEnum.R4)
       .newJsonParser()
@@ -33,8 +33,8 @@ internal object HttpPutForCreateEntryComponentGenerator :
   }
 }
 
-internal object HttpPatchForUpdateEntryComponentGenerator :
-  HttpVerbBasedBundleEntryComponentGenerator(Bundle.HTTPVerb.PATCH) {
+internal class HttpPatchForUpdateEntryComponentGenerator(useETagForUpload: Boolean) :
+  HttpVerbBasedBundleEntryComponentGenerator(Bundle.HTTPVerb.PATCH, useETagForUpload) {
   override fun getEntryResource(localChange: LocalChange): IBaseResource {
     return Binary().apply {
       contentType = ContentTypes.APPLICATION_JSON_PATCH
@@ -43,7 +43,7 @@ internal object HttpPatchForUpdateEntryComponentGenerator :
   }
 }
 
-internal object HttpDeleteEntryComponentGenerator :
-  HttpVerbBasedBundleEntryComponentGenerator(Bundle.HTTPVerb.DELETE) {
+internal class HttpDeleteEntryComponentGenerator(useETagForUpload: Boolean) :
+  HttpVerbBasedBundleEntryComponentGenerator(Bundle.HTTPVerb.DELETE, useETagForUpload) {
   override fun getEntryResource(localChange: LocalChange): IBaseResource? = null
 }

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/TransactionBundleGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/TransactionBundleGenerator.kt
@@ -51,7 +51,8 @@ internal open class TransactionBundleGenerator(
 
   companion object Factory {
 
-    fun getDefault() = PutForCreateAndPatchForUpdateBasedTransactionGenerator
+    fun getDefault(useETagForUpload: Boolean = true) =
+      PutForCreateAndPatchForUpdateBasedTransactionGenerator(useETagForUpload)
 
     /**
      * Returns a [TransactionBundleGenerator] based on the provided [Bundle.HTTPVerb]s for creating
@@ -60,13 +61,14 @@ internal open class TransactionBundleGenerator(
      */
     fun getGenerator(
       httpVerbToUseForCreate: Bundle.HTTPVerb,
-      httpVerbToUseForUpdate: Bundle.HTTPVerb
+      httpVerbToUseForUpdate: Bundle.HTTPVerb,
+      useETagForUpload: Boolean,
     ): TransactionBundleGenerator {
 
       return if (httpVerbToUseForCreate == Bundle.HTTPVerb.PUT &&
           httpVerbToUseForUpdate == Bundle.HTTPVerb.PATCH
       ) {
-        PutForCreateAndPatchForUpdateBasedTransactionGenerator
+        PutForCreateAndPatchForUpdateBasedTransactionGenerator(useETagForUpload)
       } else {
         throw IllegalArgumentException(
           "Engine currently supports creation using [PUT] and updates using [PATCH]"
@@ -76,11 +78,11 @@ internal open class TransactionBundleGenerator(
   }
 }
 
-internal object PutForCreateAndPatchForUpdateBasedTransactionGenerator :
+internal class PutForCreateAndPatchForUpdateBasedTransactionGenerator(useETagForUpload: Boolean) :
   TransactionBundleGenerator({ type ->
     when (type) {
-      Type.INSERT -> HttpPutForCreateEntryComponentGenerator
-      Type.UPDATE -> HttpPatchForUpdateEntryComponentGenerator
-      Type.DELETE -> HttpDeleteEntryComponentGenerator
+      Type.INSERT -> HttpPutForCreateEntryComponentGenerator(useETagForUpload)
+      Type.UPDATE -> HttpPatchForUpdateEntryComponentGenerator(useETagForUpload)
+      Type.DELETE -> HttpDeleteEntryComponentGenerator(useETagForUpload)
     }
   })

--- a/engine/src/test/java/com/google/android/fhir/sync/download/DownloaderImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/download/DownloaderImplTest.kt
@@ -17,10 +17,12 @@
 package com.google.android.fhir.sync.download
 
 import com.google.android.fhir.logicalId
+import com.google.android.fhir.sync.BundleRequest
 import com.google.android.fhir.sync.DataSource
 import com.google.android.fhir.sync.DownloadState
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.Request
+import com.google.android.fhir.sync.UrlRequest
 import com.google.common.truth.Truth.assertThat
 import java.util.LinkedList
 import java.util.Queue
@@ -55,7 +57,7 @@ class DownloaderImplTest {
 
     val testDataSource: DataSource =
       object : DataSource {
-        override suspend fun download(path: String): Resource {
+        private fun download(path: String): Resource {
           return when (path) {
             "Patient" ->
               Bundle().apply {
@@ -92,7 +94,7 @@ class DownloaderImplTest {
           }
         }
 
-        override suspend fun download(bundle: Bundle): Resource {
+        private fun download(bundle: Bundle): Resource {
           return Bundle().apply {
             type = Bundle.BundleType.BATCHRESPONSE
             addEntry(
@@ -116,7 +118,13 @@ class DownloaderImplTest {
           }
         }
 
-        override suspend fun upload(bundle: Bundle): Resource {
+        override suspend fun download(request: Request) =
+          when (request) {
+            is UrlRequest -> download(request.url)
+            is BundleRequest -> download(request.bundle)
+          }
+
+        override suspend fun upload(request: BundleRequest): Resource {
           throw UnsupportedOperationException()
         }
       }
@@ -148,7 +156,7 @@ class DownloaderImplTest {
 
       val testDataSource: DataSource =
         object : DataSource {
-          override suspend fun download(path: String): Resource {
+          private fun download(path: String): Resource {
             return when (path) {
               "Patient" ->
                 Bundle().apply {
@@ -185,7 +193,7 @@ class DownloaderImplTest {
             }
           }
 
-          override suspend fun download(bundle: Bundle): Resource {
+          private fun download(bundle: Bundle): Resource {
             return Bundle().apply {
               type = Bundle.BundleType.BATCHRESPONSE
               addEntry(
@@ -209,7 +217,13 @@ class DownloaderImplTest {
             }
           }
 
-          override suspend fun upload(bundle: Bundle): Resource {
+          override suspend fun download(request: Request) =
+            when (request) {
+              is UrlRequest -> download(request.url)
+              is BundleRequest -> download(request.bundle)
+            }
+
+          override suspend fun upload(request: BundleRequest): Resource {
             throw UnsupportedOperationException()
           }
         }

--- a/engine/src/test/java/com/google/android/fhir/sync/remote/RetrofitHttpServiceTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/remote/RetrofitHttpServiceTest.kt
@@ -76,8 +76,10 @@ class RetrofitHttpServiceTest {
       }
     mockWebServer.enqueue(mockResponse)
 
-    val result = retrofitHttpService.get("Patient/patient-001")
-
+    val result =
+      retrofitHttpService.get("Patient/patient-001", mapOf("If-Match" to "randomResourceVersionID"))
+    val serverRequest = mockWebServer.takeRequest()
+    assertThat(serverRequest.headers).contains("If-Match" to "randomResourceVersionID")
     // No exception should occur
     assertThat(result).isInstanceOf(Patient::class.java)
   }
@@ -104,8 +106,9 @@ class RetrofitHttpServiceTest {
         type = Bundle.BundleType.TRANSACTION
       }
 
-    val result = retrofitHttpService.post(request)
-
+    val result = retrofitHttpService.post(request, mapOf("If-Match" to "randomResourceVersionID"))
+    val serverRequest = mockWebServer.takeRequest()
+    assertThat(serverRequest.headers["If-Match"]).isEqualTo("randomResourceVersionID")
     // No exception has occurred
     assertThat(result).isInstanceOf(Bundle::class.java)
   }
@@ -132,7 +135,7 @@ class RetrofitHttpServiceTest {
           type = Bundle.BundleType.TRANSACTION
         }
 
-      val result = retrofitHttpService.post(request)
+      val result = retrofitHttpService.post(request, emptyMap())
 
       assertThat(result).isInstanceOf(Bundle::class.java)
       assertThat((result as Bundle).type).isEqualTo(Bundle.BundleType.TRANSACTIONRESPONSE)

--- a/engine/src/test/java/com/google/android/fhir/sync/upload/TransactionBundleGeneratorTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/upload/TransactionBundleGeneratorTest.kt
@@ -184,7 +184,8 @@ class TransactionBundleGeneratorTest {
                     )
                   }
                 )
-                .toString()
+                .toString(),
+            versionId = "v-p002-01"
           )
           .toLocalChange()
           .apply { LocalChangeToken(listOf(2)) },
@@ -204,7 +205,8 @@ class TransactionBundleGeneratorTest {
                     }
                   )
                 }
-              )
+              ),
+            versionId = "v-p003-01"
           )
           .toLocalChange()
           .apply { LocalChangeToken(listOf(3)) }
@@ -220,6 +222,10 @@ class TransactionBundleGeneratorTest {
     assertThat(result.all { it.first.entry.size == 1 }).isTrue()
     assertThat(result.map { it.first.entry.first().request.method })
       .containsExactly(Bundle.HTTPVerb.PUT, Bundle.HTTPVerb.PATCH, Bundle.HTTPVerb.DELETE)
+      .inOrder()
+    // Insert has no etag related header, update and delete have etag in the request.
+    assertThat(result.map { it.first.entry.first().request.ifMatch })
+      .containsExactly(null, "W/\"v-p002-01\"", "W/\"v-p003-01\"")
       .inOrder()
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1989 

**Description**
1. Added a way for users to specify http headers in DownloadWorkManager requests. 
2. Update and Delete requests now use If-Match Http header with [weak Etag](https://hl7.org/fhir/http.html#Http-Headers).

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
