### PR TITLE
FHIRPath constant value null casting bug fix

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServices.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServices.kt
@@ -26,7 +26,8 @@ import org.hl7.fhir.r4.utils.FHIRPathEngine
  */
 internal object FHIRPathEngineHostServices : FHIRPathEngine.IEvaluationContext {
   override fun resolveConstant(appContext: Any?, name: String?, beforeContext: Boolean): Base? {
-    return if (appContext is Map<*, *> && appContext.containsKey(name)) appContext[name] as Base
+    return if (appContext is Map<*, *> && appContext.containsKey(name) && appContext[name] != null)
+      appContext[name] as Base
     else null
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServicesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServicesTest.kt
@@ -27,17 +27,24 @@ import org.junit.Test
 class FHIRPathEngineHostServicesTest {
 
   @Test
-  fun testFHIRPathHostServices_resolveConstantValueNotPresent_returnsNull() {
+  fun testFHIRPathHostServices_resolveConstantKeyNotPresent_returnsNull() {
     val answer = FHIRPathEngineHostServices.resolveConstant(mapOf("A" to IntegerType(1)), "B", true)
 
     assertThat(answer).isNull()
   }
 
   @Test
-  fun testFHIRPathHostServices_resolveConstantValuePresent_returnsNotNull() {
+  fun testFHIRPathHostServices_resolveConstantKeyAndValuePresent_returnsNotNull() {
     val answer = FHIRPathEngineHostServices.resolveConstant(mapOf("A" to IntegerType(1)), "A", true)
 
     assertThat((answer as Type).asStringValue()).isEqualTo("1")
+  }
+
+  @Test
+  fun testFHIRPathHostServices_resolveConstantKeyPresentAndValueNotPresent_returnsNull() {
+    val answer = FHIRPathEngineHostServices.resolveConstant(mapOf("A" to null), "A", true)
+
+    assertThat(answer).isNull()
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2011

**Description**
[Add null check for the retrieved value from a constant](https://github.com/google/android-fhir/commit/5552dac61de4e27def8b0ff4f17d6e2cccc9c0db)

**Alternative(s) considered**
N/A

**Type**
Bug fix

**Screenshots (if applicable)**
N/A

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
