### PR TITLE
Repeating initial values fix

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -551,11 +551,11 @@ private fun Questionnaire.QuestionnaireItemComponent.createQuestionnaireResponse
     )
   }
 
-  return mutableListOf(
-    QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-      value = initial[0].value
+  return initial
+    .map {
+      QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply { value = it.value }
     }
-  )
+    .toMutableList()
 }
 
 internal val Questionnaire.QuestionnaireItemComponent.answerExpression: Expression?

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponentsTest.kt
@@ -1654,6 +1654,78 @@ class MoreQuestionnaireItemComponentsTest {
   }
 
   @Test
+  fun `createQuestionnaireResponseItem should set answer for non repeating question initial value`() {
+    val question =
+      Questionnaire.QuestionnaireItemComponent(
+          StringType("phone"),
+          Enumeration(
+            Questionnaire.QuestionnaireItemTypeEnumFactory(),
+            Questionnaire.QuestionnaireItemType.STRING
+          )
+        )
+        .apply {
+          initial = listOf(Questionnaire.QuestionnaireItemInitialComponent(StringType("000011111")))
+        }
+
+    val responseItem = question.createQuestionnaireResponseItem()
+
+    assertThat(responseItem.answer.map { it.value.primitiveValue() }).containsExactly("000011111")
+  }
+
+  @Test
+  fun `createQuestionnaireResponseItem should set answer for repeating question initial values`() {
+    val question =
+      Questionnaire.QuestionnaireItemComponent(
+          StringType("phones"),
+          Enumeration(
+            Questionnaire.QuestionnaireItemTypeEnumFactory(),
+            Questionnaire.QuestionnaireItemType.STRING
+          )
+        )
+        .apply {
+          repeats = true
+          initial =
+            listOf(
+              Questionnaire.QuestionnaireItemInitialComponent(StringType("000011111")),
+              Questionnaire.QuestionnaireItemInitialComponent(StringType("000022222"))
+            )
+        }
+
+    val responseItem = question.createQuestionnaireResponseItem()
+
+    assertThat(responseItem.answer.map { it.value.primitiveValue() })
+      .containsExactly("000011111", "000022222")
+  }
+
+  @Test
+  fun `createQuestionnaireResponseItem should throw exception for non repeating question with multiple initial values `() {
+    val question =
+      Questionnaire.QuestionnaireItemComponent(
+          StringType("phones"),
+          Enumeration(
+            Questionnaire.QuestionnaireItemTypeEnumFactory(),
+            Questionnaire.QuestionnaireItemType.STRING
+          )
+        )
+        .apply {
+          initial =
+            listOf(
+              Questionnaire.QuestionnaireItemInitialComponent(StringType("000011111")),
+              Questionnaire.QuestionnaireItemInitialComponent(StringType("000022222"))
+            )
+        }
+    assertThrows(IllegalArgumentException::class.java) {
+        question.createQuestionnaireResponseItem()
+      }
+      .run {
+        assertThat(this.message)
+          .isEqualTo(
+            "Questionnaire item ${question.linkId} can only have multiple initial values for repeating items. See rule que-13 at https://www.hl7.org/fhir/questionnaire-definitions.html#Questionnaire.item.initial."
+          )
+      }
+  }
+
+  @Test
   fun `fetchBitmapFromUrl() should return Bitmap from url`() {
     val attachment =
       Attachment().apply {


### PR DESCRIPTION
**Description**
Code was wrongfully setting only first item as initial value for repeating questions with multiple items in list

**Type**
Choose one: Bug fix

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
