### PR TITLE
WorkFlow Performance: Adds a compiled Library cache that survives multiple executions of the evaluator.

### DIFF
--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
@@ -137,7 +137,9 @@ internal constructor(
   private val endpointConverter = EndpointConverter(adapterFactory)
 
   // Keeps a cached copy of all **compiled** libraries.
-  // TODO: Migrate upstream's CQL Evaluator to a hashmap interface and then use an LruCache here.
+  // TODO: Migrate the upstream's CqlEvaluatorBuilder.withLibraryCache code, where this variable
+  //  is used, to an interface and then this HashMap to a lifecycle-aware caching data structure
+  //  (e.g. LruCache).
   val compiledLibraryCache =
     HashMap<
       org.cqframework.cql.elm.execution.VersionedIdentifier,

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
@@ -136,11 +136,20 @@ internal constructor(
     )
   private val endpointConverter = EndpointConverter(adapterFactory)
 
+  // Keeps a cached copy of all **compiled** libraries.
+  // TODO: Migrate upstream's CQL Evaluator to a hashmap interface and then use an LruCache here.
+  val compiledLibraryCache =
+    HashMap<
+      org.cqframework.cql.elm.execution.VersionedIdentifier,
+      org.cqframework.cql.elm.execution.Library
+    >()
+
   private val evaluatorBuilderSupplier = Supplier {
     CqlEvaluatorBuilder()
       .withLibrarySourceProvider(libraryContentProvider)
       .withCqlOptions(CqlOptions.defaultOptions())
       .withTerminologyProvider(fhirEngineTerminologyProvider)
+      .withLibraryCache(compiledLibraryCache)
   }
 
   private val libraryProcessor =


### PR DESCRIPTION
Fixes #[issue number]

**Description**
Current FhirOperator reloads (and then recompiles) all libraries in every evaluate call, which includes each of the multiple initial expressions in a single questionnaire page. This leads to slow processing of CQL. 

This PR adds a basic **compiled** Library cache that survives multiple executions of the evaluator.

**Alternative(s) considered**
None

**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
