### PR TITLE
Give unique name for periodic and oneTime sync worker

### DIFF
--- a/demo/src/main/java/com/google/android/fhir/demo/FhirApplication.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/FhirApplication.kt
@@ -18,6 +18,7 @@ package com.google.android.fhir.demo
 
 import android.app.Application
 import android.content.Context
+import androidx.work.WorkManager
 import com.google.android.fhir.DatabaseErrorStrategy.RECREATE_AT_OPEN
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.FhirEngineConfiguration
@@ -63,7 +64,7 @@ class FhirApplication : Application(), DataCaptureConfig.Provider {
         )
       )
     )
-    Sync.oneTimeSync<FhirSyncWorker>(this)
+    Sync(WorkManager.getInstance(this)).oneTimeSync<FhirSyncWorker>()
 
     dataCaptureConfig =
       DataCaptureConfig().apply {

--- a/demo/src/main/java/com/google/android/fhir/demo/FhirApplication.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/FhirApplication.kt
@@ -18,7 +18,6 @@ package com.google.android.fhir.demo
 
 import android.app.Application
 import android.content.Context
-import androidx.work.WorkManager
 import com.google.android.fhir.DatabaseErrorStrategy.RECREATE_AT_OPEN
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.FhirEngineConfiguration
@@ -27,11 +26,8 @@ import com.google.android.fhir.NetworkConfiguration
 import com.google.android.fhir.ServerConfiguration
 import com.google.android.fhir.datacapture.DataCaptureConfig
 import com.google.android.fhir.datacapture.XFhirQueryResolver
-import com.google.android.fhir.demo.data.FhirSyncWorker
 import com.google.android.fhir.search.search
-import com.google.android.fhir.sync.Sync
 import com.google.android.fhir.sync.remote.HttpLogger
-import org.hl7.fhir.r4.model.Patient
 import timber.log.Timber
 
 class FhirApplication : Application(), DataCaptureConfig.Provider {
@@ -47,7 +43,6 @@ class FhirApplication : Application(), DataCaptureConfig.Provider {
     if (BuildConfig.DEBUG) {
       Timber.plant(Timber.DebugTree())
     }
-    Patient.IDENTIFIER
     FhirEngineProvider.init(
       FhirEngineConfiguration(
         enableEncryptionIfSupported = true,
@@ -64,7 +59,6 @@ class FhirApplication : Application(), DataCaptureConfig.Provider {
         )
       )
     )
-    Sync(WorkManager.getInstance(this)).oneTimeSync<FhirSyncWorker>()
 
     dataCaptureConfig =
       DataCaptureConfig().apply {

--- a/demo/src/main/java/com/google/android/fhir/demo/MainActivityViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/MainActivityViewModel.kt
@@ -23,8 +23,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.work.Constraints
-import androidx.work.WorkManager
-import com.google.android.fhir.demo.data.FhirSyncWorker
+import com.google.android.fhir.demo.data.DemoFhirSyncWorker
 import com.google.android.fhir.sync.PeriodicSyncConfiguration
 import com.google.android.fhir.sync.RepeatInterval
 import com.google.android.fhir.sync.Sync
@@ -51,12 +50,13 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
 
   init {
     viewModelScope.launch {
-      Sync(WorkManager.getInstance(application.applicationContext))
-        .periodicSync<FhirSyncWorker>(
-          PeriodicSyncConfiguration(
-            syncConstraints = Constraints.Builder().build(),
-            repeat = RepeatInterval(interval = 15, timeUnit = TimeUnit.MINUTES)
-          )
+      Sync.periodicSync<DemoFhirSyncWorker>(
+          application.applicationContext,
+          periodicSyncConfiguration =
+            PeriodicSyncConfiguration(
+              syncConstraints = Constraints.Builder().build(),
+              repeat = RepeatInterval(interval = 15, timeUnit = TimeUnit.MINUTES)
+            )
         )
         .shareIn(this, SharingStarted.Eagerly, 10)
         .collect { _pollState.emit(it) }
@@ -65,8 +65,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
 
   fun triggerOneTimeSync() {
     viewModelScope.launch {
-      Sync(WorkManager.getInstance(getApplication()))
-        .oneTimeSync<FhirSyncWorker>()
+      Sync.oneTimeSync<DemoFhirSyncWorker>(getApplication())
         .shareIn(this, SharingStarted.Eagerly, 10)
         .collect { _pollState.emit(it) }
     }

--- a/demo/src/main/java/com/google/android/fhir/demo/MainActivityViewModel.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/MainActivityViewModel.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.work.Constraints
+import androidx.work.WorkManager
 import com.google.android.fhir.demo.data.FhirSyncWorker
 import com.google.android.fhir.sync.PeriodicSyncConfiguration
 import com.google.android.fhir.sync.RepeatInterval
@@ -50,8 +51,8 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
 
   init {
     viewModelScope.launch {
-      Sync.periodicSync<FhirSyncWorker>(
-          application.applicationContext,
+      Sync(WorkManager.getInstance(application.applicationContext))
+        .periodicSync<FhirSyncWorker>(
           PeriodicSyncConfiguration(
             syncConstraints = Constraints.Builder().build(),
             repeat = RepeatInterval(interval = 15, timeUnit = TimeUnit.MINUTES)
@@ -64,7 +65,8 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
 
   fun triggerOneTimeSync() {
     viewModelScope.launch {
-      Sync.oneTimeSync<FhirSyncWorker>(getApplication())
+      Sync(WorkManager.getInstance(getApplication()))
+        .oneTimeSync<FhirSyncWorker>()
         .shareIn(this, SharingStarted.Eagerly, 10)
         .collect { _pollState.emit(it) }
     }

--- a/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
@@ -23,7 +23,7 @@ import com.google.android.fhir.sync.AcceptLocalConflictResolver
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.FhirSyncWorker
 
-class FhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
+class DemoFhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
   FhirSyncWorker(appContext, workerParams) {
 
   override fun getDownloadWorkManager(): DownloadWorkManager {

--- a/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.sync
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.work.Constraints
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.testing.TestDataSourceImpl
+import com.google.android.fhir.testing.TestDownloadManagerImpl
+import com.google.android.fhir.testing.TestFhirEngineImpl
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class SyncInstrumentedTest {
+
+  private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+  private lateinit var workManager: WorkManager
+
+  class TestSyncWorker(appContext: Context, workerParams: WorkerParameters) :
+    FhirSyncWorker(appContext, workerParams) {
+
+    override fun getFhirEngine(): FhirEngine = TestFhirEngineImpl
+    override fun getDataSource(): DataSource = TestDataSourceImpl
+    override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
+    override fun getConflictResolver() = AcceptRemoteConflictResolver
+  }
+
+  @Before
+  fun setUp() {
+    WorkManagerTestInitHelper.initializeTestWorkManager(context)
+    workManager = WorkManager.getInstance(context)
+  }
+
+  @Test
+  fun oneTime_worker_runs() {
+    runBlocking {
+      Sync(workManager)
+        .oneTimeSync<TestSyncWorker>()
+        .transformWhile {
+          emit(it is SyncJobStatus.Finished)
+          it !is SyncJobStatus.Finished
+        }
+        .shareIn(this, SharingStarted.Eagerly, 5)
+    }
+
+    assertThat(workManager.getWorkInfosByTag(TestSyncWorker::class.java.name).get().first().state)
+      .isEqualTo(WorkInfo.State.SUCCEEDED)
+  }
+
+  @Test
+  fun periodic_worker_still_queued_to_run_after_oneTime_worker_started() {
+    // run and wait for periodic worker to finish
+    runBlocking {
+      Sync(workManager)
+        .periodicSync<TestSyncWorker>(
+          periodicSyncConfiguration =
+            PeriodicSyncConfiguration(
+              syncConstraints = Constraints.Builder().build(),
+              repeat = RepeatInterval(interval = 15, timeUnit = TimeUnit.MINUTES)
+            ),
+        )
+        .transformWhile {
+          emit(it)
+          it !is SyncJobStatus.Finished
+        }
+        .shareIn(this, SharingStarted.Eagerly, 5)
+    }
+
+    // Verify the periodic worker completed the run, and is queued to run again
+    val periodicWorkerId =
+      workManager.getWorkInfosByTag(TestSyncWorker::class.java.name).get().first().id
+    assertThat(workManager.getWorkInfoById(periodicWorkerId).get().state)
+      .isEqualTo(WorkInfo.State.ENQUEUED)
+
+    // Start and complete a oneTime job, and verify it does not remove the periodic worker
+    runBlocking {
+      Sync(workManager)
+        .oneTimeSync<TestSyncWorker>()
+        .transformWhile {
+          emit(it)
+          it !is SyncJobStatus.Finished
+        }
+        .shareIn(this, SharingStarted.Eagerly, 5)
+    }
+    assertThat(workManager.getWorkInfosByTag(TestSyncWorker::class.java.name).get().size)
+      .isEqualTo(2)
+
+    // Move forward to the next epoch to trigger the periodic sync
+    val testDriver = WorkManagerTestInitHelper.getTestDriver(context)
+    testDriver?.setPeriodDelayMet(periodicWorkerId)
+
+    assertThat(workManager.getWorkInfoById(periodicWorkerId).get().state)
+      .isEqualTo(WorkInfo.State.RUNNING)
+  }
+}

--- a/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
@@ -17,18 +17,14 @@
 package com.google.android.fhir.sync
 
 import android.content.Context
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.BackoffPolicy
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import androidx.work.testing.WorkManagerTestInitHelper
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
 import com.google.android.fhir.testing.TestFhirEngineImpl
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.TimeUnit
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -37,10 +33,6 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class SyncTest {
-
-  private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-  private lateinit var workManager: WorkManager
-
   class PassingPeriodicSyncWorker(appContext: Context, workerParams: WorkerParameters) :
     FhirSyncWorker(appContext, workerParams) {
 
@@ -50,19 +42,13 @@ class SyncTest {
     override fun getConflictResolver() = AcceptRemoteConflictResolver
   }
 
-  @Before
-  fun setUp() {
-    WorkManagerTestInitHelper.initializeTestWorkManager(context)
-    workManager = WorkManager.getInstance(context)
-  }
   @Test
   fun createOneTimeWorkRequestWithRetryConfiguration_shouldHave3MaxTries() {
     val workRequest =
-      Sync(workManager)
-        .createOneTimeWorkRequest(
-          RetryConfiguration(BackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.SECONDS), 3),
-          PassingPeriodicSyncWorker::class.java
-        )
+      Sync.createOneTimeWorkRequest(
+        RetryConfiguration(BackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.SECONDS), 3),
+        PassingPeriodicSyncWorker::class.java
+      )
     assertThat(workRequest.workSpec.backoffPolicy).isEqualTo(BackoffPolicy.LINEAR)
     assertThat(workRequest.workSpec.backoffDelayDuration).isEqualTo(TimeUnit.SECONDS.toMillis(30))
     assertThat(workRequest.workSpec.input.getInt(MAX_RETRIES_ALLOWED, 0)).isEqualTo(3)
@@ -70,8 +56,7 @@ class SyncTest {
 
   @Test
   fun createOneTimeWorkRequest_withoutRetryConfiguration_shouldHaveZeroMaxTries() {
-    val workRequest =
-      Sync(workManager).createOneTimeWorkRequest(null, PassingPeriodicSyncWorker::class.java)
+    val workRequest = Sync.createOneTimeWorkRequest(null, PassingPeriodicSyncWorker::class.java)
     assertThat(workRequest.workSpec.input.getInt(MAX_RETRIES_ALLOWED, 0)).isEqualTo(0)
     //    Not checking [workRequest.workSpec.backoffPolicy] and
     // [workRequest.workSpec.backoffDelayDuration] as they have default values.
@@ -80,15 +65,14 @@ class SyncTest {
   @Test
   fun createPeriodicWorkRequest_withRetryConfiguration_shouldHave3MaxTries() {
     val workRequest =
-      Sync(workManager)
-        .createPeriodicWorkRequest(
-          PeriodicSyncConfiguration(
-            repeat = RepeatInterval(20, TimeUnit.MINUTES),
-            retryConfiguration =
-              RetryConfiguration(BackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.SECONDS), 3)
-          ),
-          PassingPeriodicSyncWorker::class.java
-        )
+      Sync.createPeriodicWorkRequest(
+        PeriodicSyncConfiguration(
+          repeat = RepeatInterval(20, TimeUnit.MINUTES),
+          retryConfiguration =
+            RetryConfiguration(BackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.SECONDS), 3)
+        ),
+        PassingPeriodicSyncWorker::class.java
+      )
     assertThat(workRequest.workSpec.intervalDuration).isEqualTo(TimeUnit.MINUTES.toMillis(20))
     assertThat(workRequest.workSpec.backoffPolicy).isEqualTo(BackoffPolicy.LINEAR)
     assertThat(workRequest.workSpec.backoffDelayDuration).isEqualTo(TimeUnit.SECONDS.toMillis(30))
@@ -98,14 +82,13 @@ class SyncTest {
   @Test
   fun createPeriodicWorkRequest_withoutRetryConfiguration_shouldHaveZeroMaxRetries() {
     val workRequest =
-      Sync(workManager)
-        .createPeriodicWorkRequest(
-          PeriodicSyncConfiguration(
-            repeat = RepeatInterval(20, TimeUnit.MINUTES),
-            retryConfiguration = null
-          ),
-          PassingPeriodicSyncWorker::class.java
-        )
+      Sync.createPeriodicWorkRequest(
+        PeriodicSyncConfiguration(
+          repeat = RepeatInterval(20, TimeUnit.MINUTES),
+          retryConfiguration = null
+        ),
+        PassingPeriodicSyncWorker::class.java
+      )
     assertThat(workRequest.workSpec.intervalDuration).isEqualTo(TimeUnit.MINUTES.toMillis(20))
     assertThat(workRequest.workSpec.input.getInt(MAX_RETRIES_ALLOWED, 0)).isEqualTo(0)
   }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**


**Description**
Clear and concise code change description. 

Give a unique name for the one time sync worker and the periodic worker. Currently, If we have a periodic worker set up, then trigger a oneTime, the periodic worker does not run after as it's over-written due to having the same name. This PR fixes that.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
