### PR TITLE
Fixed Bearer authentication method format issue

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/sync/HttpAuthenticator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/HttpAuthenticator.kt
@@ -50,6 +50,6 @@ sealed interface HttpAuthenticationMethod {
 
   /** See https://datatracker.ietf.org/doc/html/rfc6750. */
   data class Bearer(val token: String) : HttpAuthenticationMethod {
-    override fun getAuthorizationHeader() = "Bearer: $token"
+    override fun getAuthorizationHeader() = "Bearer $token"
   }
 }

--- a/engine/src/test/java/com/google/android/fhir/sync/HttpAuthenticatorTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/HttpAuthenticatorTest.kt
@@ -32,6 +32,6 @@ class HttpAuthenticatorTest {
   @Test
   fun `should generate bearer authentication token`() {
     assertThat(HttpAuthenticationMethod.Bearer("token").getAuthorizationHeader())
-      .isEqualTo("Bearer: token")
+      .isEqualTo("Bearer token")
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Fixed Bearer authentication method format issue in HttpAuthenticator.

**Type**
Bug fix 

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
