### PR TITLE
Fix Date/DateTime and Token indexes to speed up Search 

### DIFF
--- a/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/4.json
+++ b/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/4.json
@@ -1,0 +1,954 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "bdc6b0b8f2bcb0fc1923be1cfde014cc",
+    "entities": [
+      {
+        "tableName": "ResourceEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `resourceId` TEXT NOT NULL, `serializedResource` TEXT NOT NULL, `versionId` TEXT, `lastUpdatedRemote` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceId",
+            "columnName": "resourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serializedResource",
+            "columnName": "serializedResource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedRemote",
+            "columnName": "lastUpdatedRemote",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_ResourceEntity_resourceUuid",
+            "unique": true,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ResourceEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          },
+          {
+            "name": "index_ResourceEntity_resourceType_resourceId",
+            "unique": true,
+            "columnNames": [
+              "resourceType",
+              "resourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ResourceEntity_resourceType_resourceId` ON `${TABLE_NAME}` (`resourceType`, `resourceId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "StringIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_StringIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StringIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_StringIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StringIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ReferenceIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_ReferenceIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReferenceIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_ReferenceIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReferenceIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TokenIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_system` TEXT, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.system",
+            "columnName": "index_system",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_TokenIndexEntity_resourceType_index_name_index_system_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_system",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceType_index_name_index_system_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_system`, `index_value`)"
+          },
+          {
+            "name": "index_TokenIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "QuantityIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_system` TEXT NOT NULL, `index_code` TEXT NOT NULL, `index_value` REAL NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.system",
+            "columnName": "index_system",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.code",
+            "columnName": "index_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_QuantityIndexEntity_resourceType_index_name_index_value_index_code",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value",
+              "index_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_QuantityIndexEntity_resourceType_index_name_index_value_index_code` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`, `index_code`)"
+          },
+          {
+            "name": "index_QuantityIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_QuantityIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "UriIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_UriIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_UriIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_UriIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_UriIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "DateIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_from` INTEGER NOT NULL, `index_to` INTEGER NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.from",
+            "columnName": "index_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.to",
+            "columnName": "index_to",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_DateIndexEntity_resourceType_index_name_index_from_index_to",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_from",
+              "index_to"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_index_name_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_from`, `index_to`)"
+          },
+          {
+            "name": "index_DateIndexEntity_resourceType_resourceUuid_index_name",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "resourceUuid",
+              "index_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_resourceUuid_index_name` ON `${TABLE_NAME}` (`resourceType`, `resourceUuid`, `index_name`)"
+          },
+          {
+            "name": "index_DateIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "DateTimeIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_from` INTEGER NOT NULL, `index_to` INTEGER NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.from",
+            "columnName": "index_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.to",
+            "columnName": "index_to",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_DateTimeIndexEntity_resourceType_index_name_index_from_index_to",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_from",
+              "index_to"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_index_name_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_from`, `index_to`)"
+          },
+          {
+            "name": "index_DateTimeIndexEntity_resourceType_resourceUuid_index_name",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "resourceUuid",
+              "index_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_resourceUuid_index_name` ON `${TABLE_NAME}` (`resourceType`, `resourceUuid`, `index_name`)"
+          },
+          {
+            "name": "index_DateTimeIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NumberIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` REAL NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_NumberIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NumberIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_NumberIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NumberIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LocalChangeEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceType` TEXT NOT NULL, `resourceId` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `type` INTEGER NOT NULL, `payload` TEXT NOT NULL, `versionId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceId",
+            "columnName": "resourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_LocalChangeEntity_resourceType_resourceId",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "resourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceId` ON `${TABLE_NAME}` (`resourceType`, `resourceId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PositionIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_latitude` REAL NOT NULL, `index_longitude` REAL NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.latitude",
+            "columnName": "index_latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.longitude",
+            "columnName": "index_longitude",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_PositionIndexEntity_resourceType_index_latitude_index_longitude",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_latitude",
+              "index_longitude"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PositionIndexEntity_resourceType_index_latitude_index_longitude` ON `${TABLE_NAME}` (`resourceType`, `index_latitude`, `index_longitude`)"
+          },
+          {
+            "name": "index_PositionIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PositionIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bdc6b0b8f2bcb0fc1923be1cfde014cc')"
+    ]
+  }
+}

--- a/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/4.json
+++ b/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/4.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "c1ad671e7e9d61e75954a423f1b6c458",
+    "identityHash": "8cb21e74ef8663b5dc48393c869b0714",
     "entities": [
       {
         "tableName": "ResourceEntity",
@@ -301,16 +301,17 @@
         },
         "indices": [
           {
-            "name": "index_TokenIndexEntity_resourceType_index_name_index_system_index_value",
+            "name": "index_TokenIndexEntity_resourceType_index_name_index_system_index_value_resourceUuid",
             "unique": false,
             "columnNames": [
               "resourceType",
               "index_name",
               "index_system",
-              "index_value"
+              "index_value",
+              "resourceUuid"
             ],
             "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceType_index_name_index_system_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_system`, `index_value`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceType_index_name_index_system_index_value_resourceUuid` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_system`, `index_value`, `resourceUuid`)"
           },
           {
             "name": "index_TokenIndexEntity_resourceUuid",
@@ -928,7 +929,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c1ad671e7e9d61e75954a423f1b6c458')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8cb21e74ef8663b5dc48393c869b0714')"
     ]
   }
 }

--- a/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/4.json
+++ b/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/4.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "bdc6b0b8f2bcb0fc1923be1cfde014cc",
+    "identityHash": "c1ad671e7e9d61e75954a423f1b6c458",
     "entities": [
       {
         "tableName": "ResourceEntity",
@@ -570,27 +570,17 @@
         },
         "indices": [
           {
-            "name": "index_DateIndexEntity_resourceType_index_name_index_from_index_to",
+            "name": "index_DateIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to",
             "unique": false,
             "columnNames": [
               "resourceType",
               "index_name",
+              "resourceUuid",
               "index_from",
               "index_to"
             ],
             "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_index_name_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_from`, `index_to`)"
-          },
-          {
-            "name": "index_DateIndexEntity_resourceType_resourceUuid_index_name",
-            "unique": false,
-            "columnNames": [
-              "resourceType",
-              "resourceUuid",
-              "index_name"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_resourceUuid_index_name` ON `${TABLE_NAME}` (`resourceType`, `resourceUuid`, `index_name`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
           },
           {
             "name": "index_DateIndexEntity_resourceUuid",
@@ -671,27 +661,17 @@
         },
         "indices": [
           {
-            "name": "index_DateTimeIndexEntity_resourceType_index_name_index_from_index_to",
+            "name": "index_DateTimeIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to",
             "unique": false,
             "columnNames": [
               "resourceType",
               "index_name",
+              "resourceUuid",
               "index_from",
               "index_to"
             ],
             "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_index_name_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_from`, `index_to`)"
-          },
-          {
-            "name": "index_DateTimeIndexEntity_resourceType_resourceUuid_index_name",
-            "unique": false,
-            "columnNames": [
-              "resourceType",
-              "resourceUuid",
-              "index_name"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_resourceUuid_index_name` ON `${TABLE_NAME}` (`resourceType`, `resourceUuid`, `index_name`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
           },
           {
             "name": "index_DateTimeIndexEntity_resourceUuid",
@@ -948,7 +928,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bdc6b0b8f2bcb0fc1923be1cfde014cc')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c1ad671e7e9d61e75954a423f1b6c458')"
     ]
   }
 }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
@@ -93,7 +93,7 @@ internal class DatabaseImpl(
             }
           }
 
-          addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+          addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
         }
         .build()
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
@@ -50,7 +50,7 @@ import com.google.android.fhir.db.impl.entities.UriIndexEntity
       LocalChangeEntity::class,
       PositionIndexEntity::class
     ],
-  version = 3,
+  version = 4,
   exportSchema = true
 )
 @TypeConverters(DbTypeConverters::class)
@@ -72,5 +72,18 @@ val MIGRATION_2_3 =
       database.execSQL(
         "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_index_from` ON `DateTimeIndexEntity` (`index_from`)"
       )
+    }
+  }
+
+val MIGRATION_3_4 =
+  object : Migration(/* startVersion = */ 3, /* endVersion = */ 4) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+      database.execSQL(
+        "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_resourceUuid_index_name` ON `DateTimeIndexEntity` (`resourceType`, `resourceUuid`, `index_name` )"
+      )
+      database.execSQL(
+        "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_resourceUuid_index_name` ON `DateIndexEntity` (`resourceType`, `resourceUuid`, `index_name` )"
+      )
+      database.execSQL("DROP INDEX IF EXISTS `index_DateTimeIndexEntity_index_from`")
     }
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
@@ -78,18 +78,24 @@ val MIGRATION_2_3 =
 val MIGRATION_3_4 =
   object : Migration(/* startVersion = */ 3, /* endVersion = */ 4) {
     override fun migrate(database: SupportSQLiteDatabase) {
+      database.execSQL("DROP INDEX IF EXISTS `index_DateTimeIndexEntity_index_from`")
       database.execSQL(
         "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `DateTimeIndexEntity` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
       )
       database.execSQL(
         "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `DateIndexEntity` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
       )
-      database.execSQL("DROP INDEX IF EXISTS `index_DateTimeIndexEntity_index_from`")
+      database.execSQL(
+        "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceType_index_name_index_system_index_value_resourceUuid` ON `TokenIndexEntity` (`resourceType`, `index_name`, `index_system`, `index_value`, `resourceUuid`)"
+      )
       database.execSQL(
         "DROP INDEX IF EXISTS `index_DateTimeIndexEntity_resourceType_index_name_index_from_index_to`"
       )
       database.execSQL(
         "DROP INDEX IF EXISTS `index_DateIndexEntity_resourceType_index_name_index_from_index_to`"
+      )
+      database.execSQL(
+        "DROP INDEX IF EXISTS `index_TokenIndexEntity_resourceType_index_name_index_system_index_value`"
       )
     }
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
@@ -78,7 +78,6 @@ val MIGRATION_2_3 =
 val MIGRATION_3_4 =
   object : Migration(/* startVersion = */ 3, /* endVersion = */ 4) {
     override fun migrate(database: SupportSQLiteDatabase) {
-      database.execSQL("DROP INDEX IF EXISTS `index_DateTimeIndexEntity_index_from`")
       database.execSQL(
         "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `DateTimeIndexEntity` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
       )
@@ -88,6 +87,7 @@ val MIGRATION_3_4 =
       database.execSQL(
         "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceType_index_name_index_system_index_value_resourceUuid` ON `TokenIndexEntity` (`resourceType`, `index_name`, `index_system`, `index_value`, `resourceUuid`)"
       )
+      database.execSQL("DROP INDEX IF EXISTS `index_DateTimeIndexEntity_index_from`")
       database.execSQL(
         "DROP INDEX IF EXISTS `index_DateTimeIndexEntity_resourceType_index_name_index_from_index_to`"
       )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
@@ -79,11 +79,17 @@ val MIGRATION_3_4 =
   object : Migration(/* startVersion = */ 3, /* endVersion = */ 4) {
     override fun migrate(database: SupportSQLiteDatabase) {
       database.execSQL(
-        "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_resourceUuid_index_name` ON `DateTimeIndexEntity` (`resourceType`, `resourceUuid`, `index_name` )"
+        "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `DateTimeIndexEntity` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
       )
       database.execSQL(
-        "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_resourceUuid_index_name` ON `DateIndexEntity` (`resourceType`, `resourceUuid`, `index_name` )"
+        "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `DateIndexEntity` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
       )
       database.execSQL("DROP INDEX IF EXISTS `index_DateTimeIndexEntity_index_from`")
+      database.execSQL(
+        "DROP INDEX IF EXISTS `index_DateTimeIndexEntity_resourceType_index_name_index_from_index_to`"
+      )
+      database.execSQL(
+        "DROP INDEX IF EXISTS `index_DateIndexEntity_resourceType_index_name_index_from_index_to`"
+      )
     }
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
@@ -28,9 +28,12 @@ import org.hl7.fhir.r4.model.ResourceType
 @Entity(
   indices =
     [
+      // Covering index for optimizing query performance by minimizing disk I/O and eliminating the
+      // need for accessing underlying table data.
+      // Column ordered to minimise time to run sortJoinStatement in [MoreSearch]
       Index(value = ["resourceType", "index_name", "resourceUuid", "index_from", "index_to"]),
-      // keep this index for faster foreign lookup
-      Index(value = ["resourceUuid"])
+      // Keep this index for faster foreign lookup
+      Index(value = ["resourceUuid"]),
     ],
   foreignKeys =
     [
@@ -40,7 +43,7 @@ import org.hl7.fhir.r4.model.ResourceType
         childColumns = ["resourceUuid"],
         onDelete = ForeignKey.CASCADE,
         onUpdate = ForeignKey.NO_ACTION,
-        deferred = true
+        deferred = true,
       )
     ]
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,10 @@ import org.hl7.fhir.r4.model.ResourceType
   indices =
     [
       Index(value = ["resourceType", "index_name", "index_from", "index_to"]),
+      Index(value = ["resourceType", "resourceUuid", "index_name"]),
       // keep this index for faster foreign lookup
-      Index(value = ["resourceUuid"])],
+      Index(value = ["resourceUuid"])
+    ],
   foreignKeys =
     [
       ForeignKey(
@@ -40,7 +42,8 @@ import org.hl7.fhir.r4.model.ResourceType
         onDelete = ForeignKey.CASCADE,
         onUpdate = ForeignKey.NO_ACTION,
         deferred = true
-      )]
+      )
+    ]
 )
 internal data class DateIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
@@ -30,7 +30,8 @@ import org.hl7.fhir.r4.model.ResourceType
     [
       // Covering index for optimizing query performance by minimizing disk I/O and eliminating the
       // need for accessing underlying table data.
-      // Column ordered to minimise time to run sortJoinStatement in [MoreSearch]
+      // Column ordered to minimise time to run sortJoinStatement in [MoreSearch], and to resolve:
+      // https://github.com/google/android-fhir/issues/2040
       Index(value = ["resourceType", "index_name", "resourceUuid", "index_from", "index_to"]),
       // Keep this index for faster foreign lookup
       Index(value = ["resourceUuid"]),

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateIndexEntity.kt
@@ -28,8 +28,7 @@ import org.hl7.fhir.r4.model.ResourceType
 @Entity(
   indices =
     [
-      Index(value = ["resourceType", "index_name", "index_from", "index_to"]),
-      Index(value = ["resourceType", "resourceUuid", "index_name"]),
+      Index(value = ["resourceType", "index_name", "resourceUuid", "index_from", "index_to"]),
       // keep this index for faster foreign lookup
       Index(value = ["resourceUuid"])
     ],

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
@@ -28,8 +28,8 @@ import org.hl7.fhir.r4.model.ResourceType
 @Entity(
   indices =
     [
-      Index(value = ["index_from"]),
       Index(value = ["resourceType", "index_name", "index_from", "index_to"]),
+      Index(value = ["resourceType", "resourceUuid", "index_name"]),
       // keep this index for faster foreign lookup
       Index(value = ["resourceUuid"]),
     ],

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
@@ -30,7 +30,8 @@ import org.hl7.fhir.r4.model.ResourceType
     [
       // Covering index for optimizing query performance by minimizing disk I/O and eliminating the
       // need for accessing underlying table data.
-      // Column ordered to minimise time to run sortJoinStatement in [MoreSearch]
+      // Column ordered to minimise time to run sortJoinStatement in [MoreSearch], and to resolve:
+      // https://github.com/google/android-fhir/issues/2040
       Index(value = ["resourceType", "index_name", "resourceUuid", "index_from", "index_to"]),
       // Keep this index for faster foreign lookup
       Index(value = ["resourceUuid"]),

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
@@ -28,8 +28,7 @@ import org.hl7.fhir.r4.model.ResourceType
 @Entity(
   indices =
     [
-      Index(value = ["resourceType", "index_name", "index_from", "index_to"]),
-      Index(value = ["resourceType", "resourceUuid", "index_name"]),
+      Index(value = ["resourceType", "index_name", "resourceUuid", "index_from", "index_to"]),
       // keep this index for faster foreign lookup
       Index(value = ["resourceUuid"]),
     ],

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/DateTimeIndexEntity.kt
@@ -28,8 +28,11 @@ import org.hl7.fhir.r4.model.ResourceType
 @Entity(
   indices =
     [
+      // Covering index for optimizing query performance by minimizing disk I/O and eliminating the
+      // need for accessing underlying table data.
+      // Column ordered to minimise time to run sortJoinStatement in [MoreSearch]
       Index(value = ["resourceType", "index_name", "resourceUuid", "index_from", "index_to"]),
-      // keep this index for faster foreign lookup
+      // Keep this index for faster foreign lookup
       Index(value = ["resourceUuid"]),
     ],
   foreignKeys =
@@ -40,7 +43,7 @@ import org.hl7.fhir.r4.model.ResourceType
         childColumns = ["resourceUuid"],
         onDelete = ForeignKey.CASCADE,
         onUpdate = ForeignKey.NO_ACTION,
-        deferred = true
+        deferred = true,
       )
     ]
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/TokenIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/TokenIndexEntity.kt
@@ -29,8 +29,8 @@ import org.hl7.fhir.r4.model.ResourceType
   indices =
     [
       Index(value = ["resourceType", "index_name", "index_system", "index_value", "resourceUuid"]),
-      // keep this index for faster foreign lookup
-      Index(value = ["resourceUuid"])
+      // Keep this index for faster foreign lookup
+      Index(value = ["resourceUuid"]),
     ],
   foreignKeys =
     [
@@ -40,7 +40,7 @@ import org.hl7.fhir.r4.model.ResourceType
         childColumns = ["resourceUuid"],
         onDelete = ForeignKey.CASCADE,
         onUpdate = ForeignKey.NO_ACTION,
-        deferred = true
+        deferred = true,
       )
     ]
 )

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/TokenIndexEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/TokenIndexEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,10 @@ import org.hl7.fhir.r4.model.ResourceType
 @Entity(
   indices =
     [
-      Index(value = ["resourceType", "index_name", "index_system", "index_value"]),
+      Index(value = ["resourceType", "index_name", "index_system", "index_value", "resourceUuid"]),
       // keep this index for faster foreign lookup
-      Index(value = ["resourceUuid"])],
+      Index(value = ["resourceUuid"])
+    ],
   foreignKeys =
     [
       ForeignKey(
@@ -40,7 +41,8 @@ import org.hl7.fhir.r4.model.ResourceType
         onDelete = ForeignKey.CASCADE,
         onUpdate = ForeignKey.NO_ACTION,
         deferred = true
-      )]
+      )
+    ]
 )
 internal data class TokenIndexEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2040

**Description**
Clear and concise code change description. 

In the Search API, we perform a LEFT JOIN when sorting:

```
LEFT JOIN ${sortTableName.tableName} $tableAlias
      ON a.resourceType = $tableAlias.resourceType AND a.resourceUuid = $tableAlias.resourceUuid AND $tableAlias.index_name = ?
```

this join uses the resourceType, resourceUuid and index_name columns. To speed this up, we should create a composite index made up of these 3 columns. We also do the same for the TokenIndexTable


TESTED:
Downloaded 7000 households. Opened App Inspector and ran query generated. Returned results almost instantaneously as opposed to many seconds 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (**Bug fix** | Feature | Documentation | Testing | Code health | Builds | Releases | Other)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
