### PR TITLE
Evaluating variables in answerExpressions

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -633,9 +633,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         )
       }
     val options = item.extractAnswerOptions(data)
-    if (expression.isXFhirQuery) {
-      answerExpressionMap[xFhirExpressionString] = options
-    }
+    if (expression.isXFhirQuery) answerExpressionMap[xFhirExpressionString] = options
     return options
   }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -585,8 +585,8 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
               questionnaire,
               questionnaireResponse,
               item,
-              answerExpression,
               questionnaireItemParentMap,
+              answerExpression,
               questionnaireLaunchContextMap
             )
           if (answerExpressionMap.containsKey(xFhirExpressionString)) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluator.kt
@@ -279,7 +279,8 @@ object ExpressionEvaluator {
   }
 
   /**
-   * Creates an x-fhir-query string for evaluation
+   * Creates an x-fhir-query string for evaluation. For this, it evaluates both variables and
+   * fhir-paths in the expression.
    *
    * @param expression x-fhir-query expression
    * @param launchContextMap if passed, the launch context to evaluate the expression against
@@ -308,10 +309,8 @@ object ExpressionEvaluator {
         .filterKeys { expression.expression.contains("{{%$it}}") }
         .map { Pair("{{%${it.key}}}", it.value!!.primitiveValue()) }
 
-    var fhirPathsEvaluatedPairs = emptySequence<Pair<String, String>>()
-    if (launchContextMap != null) {
-      fhirPathsEvaluatedPairs = evaluateXFhirEnhancement(expression, launchContextMap)
-    }
+    val fhirPathsEvaluatedPairs =
+      launchContextMap?.let { evaluateXFhirEnhancement(expression, it) } ?: emptySequence()
     return (fhirPathsEvaluatedPairs + variablesEvaluatedPairs).fold(expression.expression) {
       acc: String,
       pair: Pair<String, String> ->

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluator.kt
@@ -281,16 +281,13 @@ object ExpressionEvaluator {
   /**
    * Creates an x-fhir-query string for evaluation. For this, it evaluates both variables and
    * fhir-paths in the expression.
-   *
-   * @param expression x-fhir-query expression
-   * @param launchContextMap if passed, the launch context to evaluate the expression against
    */
   internal fun createXFhirQueryFromExpression(
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
     questionnaireItem: QuestionnaireItemComponent,
-    expression: Expression,
     questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>,
+    expression: Expression,
     launchContextMap: Map<String, Resource>?
   ): String {
     // get all dependent variables and their evaluated values

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
@@ -875,6 +875,16 @@ class ExpressionEvaluatorTest {
                 }
               )
             }
+            addExtension().apply {
+              url = EXTENSION_VARIABLE_URL
+              setValue(
+                Expression().apply {
+                  name = "B"
+                  language = "text/fhirpath"
+                  expression = "2"
+                }
+              )
+            }
             addItem(
               Questionnaire.QuestionnaireItemComponent().apply {
                 linkId = "an-item"
@@ -885,7 +895,7 @@ class ExpressionEvaluatorTest {
                   setValue(
                     Expression().apply {
                       language = "application/x-fhir-query"
-                      expression = "Patient?address-city={{%A}}"
+                      expression = "Patient?address-city={{%A}}&gender={{%B}}"
                     }
                   )
                 }
@@ -905,6 +915,6 @@ class ExpressionEvaluatorTest {
         null
       )
 
-    assertThat(result).isEqualTo("Patient?address-city=1")
+    assertThat(result).isEqualTo("Patient?address-city=1&gender=2")
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
@@ -691,8 +691,8 @@ class ExpressionEvaluatorTest {
         Questionnaire(),
         QuestionnaireResponse(),
         Questionnaire.QuestionnaireItemComponent(),
-        expression,
         emptyMap(),
+        expression,
         mapOf(Practitioner().resourceType.name.lowercase() to Practitioner())
       )
 
@@ -719,8 +719,8 @@ class ExpressionEvaluatorTest {
         Questionnaire(),
         QuestionnaireResponse(),
         Questionnaire.QuestionnaireItemComponent(),
-        expression,
         emptyMap(),
+        expression,
         mapOf(practitioner.resourceType.name to practitioner)
       )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=")
@@ -747,8 +747,8 @@ class ExpressionEvaluatorTest {
         Questionnaire(),
         QuestionnaireResponse(),
         Questionnaire.QuestionnaireItemComponent(),
-        expression,
         emptyMap(),
+        expression,
         mapOf(practitioner.resourceType.name.lowercase() to practitioner)
       )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=male")
@@ -775,8 +775,8 @@ class ExpressionEvaluatorTest {
         Questionnaire(),
         QuestionnaireResponse(),
         Questionnaire.QuestionnaireItemComponent(),
-        expression,
         emptyMap(),
+        expression,
         mapOf(practitioner.resourceType.name to practitioner)
       )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=")
@@ -803,8 +803,8 @@ class ExpressionEvaluatorTest {
         Questionnaire(),
         QuestionnaireResponse(),
         Questionnaire.QuestionnaireItemComponent(),
-        expression,
         emptyMap(),
+        expression,
         mapOf(patient.resourceType.name.lowercase() to patient)
       )
     assertThat(expressionsToEvaluate).isEqualTo("Patient?family=John")
@@ -845,8 +845,8 @@ class ExpressionEvaluatorTest {
         Questionnaire(),
         QuestionnaireResponse(),
         Questionnaire.QuestionnaireItemComponent(),
-        expression,
         emptyMap(),
+        expression,
         mapOf(
           patient.resourceType.name.lowercase() to patient,
           location.resourceType.name.lowercase() to location
@@ -910,8 +910,8 @@ class ExpressionEvaluatorTest {
         questionnaire,
         QuestionnaireResponse(),
         questionnaire.item[0].item[0],
-        questionnaire.item[0].item[0].answerExpression!!,
         mapOf(questionnaire.item[0].item[0] to questionnaire.item[0]),
+        questionnaire.item[0].item[0].answerExpression!!,
         null
       )
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2052

**Description**
There are 2 errors:
1. answerExpressionMap incorrectly caches expressions
2. variables in x-fhir-query are not supported, only launchContext

Solution here is to 
1. refactor to cache only when the full `xFhirExpressionString` has been constructed
2. evaluate variables and their values in fhir-query expression


**Alternative(s) considered**
Removing caching of answer options but that makes it slow.

**Type**
Bug fix | Feature

**Screenshots (if applicable)**
[Used questionnaire json given in the issue linked]
![Screenshot 2023-07-07 at 8 09 33 PM](https://github.com/google/android-fhir/assets/22965002/421023cd-b2df-4a49-941b-cf7404ff34c5)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
