### PR TITLE
X-FHIR-Query support for variable extension

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluator.kt
@@ -16,13 +16,18 @@
 
 package com.google.android.fhir.datacapture.fhirpath
 
+import com.google.android.fhir.datacapture.XFhirQueryResolver
 import com.google.android.fhir.datacapture.extensions.calculatedExpression
 import com.google.android.fhir.datacapture.extensions.findVariableExpression
 import com.google.android.fhir.datacapture.extensions.flattened
+import com.google.android.fhir.datacapture.extensions.isFhirPath
 import com.google.android.fhir.datacapture.extensions.isReferencedBy
+import com.google.android.fhir.datacapture.extensions.isXFhirQuery
 import com.google.android.fhir.datacapture.extensions.variableExpressions
 import org.hl7.fhir.exceptions.FHIRException
 import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent
 import org.hl7.fhir.r4.model.Expression
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
@@ -91,27 +96,29 @@ object ExpressionEvaluator {
    *
    * %resource = [QuestionnaireResponse] %context = [QuestionnaireResponseItemComponent]
    */
-  fun evaluateExpression(
+  suspend fun evaluateExpression(
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
     questionnaireItem: QuestionnaireItemComponent,
     questionnaireResponseItem: QuestionnaireResponseItemComponent?,
     expression: Expression,
-    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>
+    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>,
+    variablesMap: MutableMap<String, Base?> = mutableMapOf(),
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    xFhirQueryResolver: XFhirQueryResolver? = null
   ): List<Base> {
-    val appContext =
-      mutableMapOf<String, Base?>().apply {
-        extractDependentVariables(
-          expression,
-          questionnaire,
-          questionnaireResponse,
-          questionnaireItemParentMap,
-          questionnaireItem,
-          this
-        )
-      }
+    extractDependentVariables(
+      expression,
+      questionnaire,
+      questionnaireResponse,
+      questionnaireItemParentMap,
+      questionnaireItem,
+      variablesMap,
+      launchContextMap,
+      xFhirQueryResolver
+    )
     return fhirPathEngine.evaluate(
-      appContext,
+      variablesMap,
       questionnaireResponse,
       null,
       questionnaireResponseItem,
@@ -123,12 +130,15 @@ object ExpressionEvaluator {
    * Returns a list of pair of item and the calculated and evaluated value for all items with
    * calculated expression extension, which is dependent on value of updated response
    */
-  fun evaluateCalculatedExpressions(
+  suspend fun evaluateCalculatedExpressions(
     updatedQuestionnaireItem: QuestionnaireItemComponent,
     updatedQuestionnaireResponseItemComponent: QuestionnaireResponseItemComponent?,
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
-    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>
+    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>,
+    variablesMap: MutableMap<String, Base?> = mutableMapOf(),
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    xFhirQueryResolver: XFhirQueryResolver? = null
   ): List<ItemToAnswersPair> {
     return questionnaire.item
       .flattened()
@@ -147,7 +157,10 @@ object ExpressionEvaluator {
               questionnaireItem,
               updatedQuestionnaireResponseItemComponent,
               questionnaireItem.calculatedExpression!!,
-              questionnaireItemParentMap
+              questionnaireItemParentMap,
+              variablesMap,
+              launchContextMap,
+              xFhirQueryResolver
             )
             .map { it.castToType(it) }
         questionnaireItem to updatedAnswer
@@ -177,14 +190,16 @@ object ExpressionEvaluator {
    *
    * @return [Base] the result of expression
    */
-  internal fun evaluateQuestionnaireItemVariableExpression(
+  internal suspend fun evaluateQuestionnaireItemVariableExpression(
     expression: Expression,
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
     questionnaireItemParentMap:
       Map<Questionnaire.QuestionnaireItemComponent, Questionnaire.QuestionnaireItemComponent>,
     questionnaireItem: Questionnaire.QuestionnaireItemComponent,
-    variablesMap: MutableMap<String, Base?> = mutableMapOf()
+    variablesMap: MutableMap<String, Base?> = mutableMapOf(),
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    xFhirQueryResolver: XFhirQueryResolver? = null
   ): Base? {
     require(
       questionnaireItem.variableExpressions.any {
@@ -197,10 +212,18 @@ object ExpressionEvaluator {
       questionnaireResponse,
       questionnaireItemParentMap,
       questionnaireItem,
-      variablesMap
+      variablesMap,
+      launchContextMap,
+      xFhirQueryResolver
     )
 
-    return evaluateVariable(expression, questionnaireResponse, variablesMap)
+    return evaluateVariable(
+      expression,
+      questionnaireResponse,
+      variablesMap,
+      launchContextMap,
+      xFhirQueryResolver
+    )
   }
 
   /**
@@ -216,14 +239,16 @@ object ExpressionEvaluator {
    * @param variablesMap the [Map<String, Base>] of variables, the default value is empty map is
    * defined
    */
-  private fun extractDependentVariables(
+  internal suspend fun extractDependentVariables(
     expression: Expression,
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
     questionnaireItemParentMap:
       Map<Questionnaire.QuestionnaireItemComponent, Questionnaire.QuestionnaireItemComponent>,
     questionnaireItem: Questionnaire.QuestionnaireItemComponent,
-    variablesMap: MutableMap<String, Base?> = mutableMapOf()
+    variablesMap: MutableMap<String, Base?> = mutableMapOf(),
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    xFhirQueryResolver: XFhirQueryResolver? = null
   ) =
     findDependentVariables(expression).forEach { variableName ->
       if (variablesMap[variableName] == null) {
@@ -233,7 +258,9 @@ object ExpressionEvaluator {
           questionnaire,
           questionnaireResponse,
           questionnaireItemParentMap,
-          variablesMap
+          variablesMap,
+          launchContextMap,
+          xFhirQueryResolver
         )
       }
     }
@@ -255,11 +282,13 @@ object ExpressionEvaluator {
    *
    * @return [Base] the result of expression
    */
-  internal fun evaluateQuestionnaireVariableExpression(
+  internal suspend fun evaluateQuestionnaireVariableExpression(
     expression: Expression,
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
-    variablesMap: MutableMap<String, Base?> = mutableMapOf()
+    variablesMap: MutableMap<String, Base?> = mutableMapOf(),
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    xFhirQueryResolver: XFhirQueryResolver? = null
   ): Base? {
     findDependentVariables(expression).forEach { variableName ->
       questionnaire.findVariableExpression(variableName)?.let { expression ->
@@ -269,13 +298,21 @@ object ExpressionEvaluator {
               expression,
               questionnaire,
               questionnaireResponse,
-              variablesMap
+              variablesMap,
+              launchContextMap,
+              xFhirQueryResolver
             )
         }
       }
     }
 
-    return evaluateVariable(expression, questionnaireResponse, variablesMap)
+    return evaluateVariable(
+      expression,
+      questionnaireResponse,
+      variablesMap,
+      launchContextMap,
+      xFhirQueryResolver
+    )
   }
 
   /**
@@ -286,12 +323,20 @@ object ExpressionEvaluator {
    */
   internal fun createXFhirQueryFromExpression(
     expression: Expression,
-    launchContextMap: Map<String, Resource>?
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    variablesMap: Map<String, Base?>
   ): String {
-    if (launchContextMap == null) {
-      return expression.expression
+    // get all dependent variables and their evaluated values
+    val variablesEvaluatedPairs =
+      variablesMap
+        .filterKeys { expression.expression.contains("{{%$it}}") }
+        .map { Pair("{{%${it.key}}}", it.value!!.primitiveValue()) }
+
+    var fhirPathsEvaluatedPairs = emptySequence<Pair<String, String>>()
+    if (launchContextMap != null) {
+      fhirPathsEvaluatedPairs = evaluateXFhirEnhancement(expression, launchContextMap)
     }
-    return evaluateXFhirEnhancement(expression, launchContextMap).fold(expression.expression) {
+    return (fhirPathsEvaluatedPairs + variablesEvaluatedPairs).fold(expression.expression) {
       acc: String,
       pair: Pair<String, String> ->
       acc.replace(pair.first, pair.second)
@@ -365,14 +410,16 @@ object ExpressionEvaluator {
    * Questionnaire.QuestionnaireItemComponent>] of child to parent
    * @param variablesMap the [Map<String, Base>] of variables
    */
-  private fun findAndEvaluateVariable(
+  private suspend fun findAndEvaluateVariable(
     variableName: String,
     questionnaireItem: Questionnaire.QuestionnaireItemComponent,
     questionnaire: Questionnaire,
     questionnaireResponse: QuestionnaireResponse,
     questionnaireItemParentMap:
       Map<Questionnaire.QuestionnaireItemComponent, Questionnaire.QuestionnaireItemComponent>,
-    variablesMap: MutableMap<String, Base?>
+    variablesMap: MutableMap<String, Base?>,
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    xFhirQueryResolver: XFhirQueryResolver? = null
   ) {
     // First, check the questionnaire item itself
     val evaluatedValue =
@@ -383,7 +430,9 @@ object ExpressionEvaluator {
           questionnaireResponse,
           questionnaireItemParentMap,
           questionnaireItem,
-          variablesMap
+          variablesMap,
+          launchContextMap,
+          xFhirQueryResolver
         )
       } // Secondly, check the ancestors of the questionnaire item
         ?: findVariableInAncestors(variableName, questionnaireItemParentMap, questionnaireItem)
@@ -394,7 +443,9 @@ object ExpressionEvaluator {
               questionnaireResponse,
               questionnaireItemParentMap,
               questionnaireItem,
-              variablesMap
+              variablesMap,
+              launchContextMap,
+              xFhirQueryResolver
             )
           } // Finally, check the variables defined on the questionnaire itself
           ?: questionnaire.findVariableExpression(variableName)?.let { expression ->
@@ -402,7 +453,9 @@ object ExpressionEvaluator {
             expression,
             questionnaire,
             questionnaireResponse,
-            variablesMap
+            variablesMap,
+            launchContextMap,
+            xFhirQueryResolver
           )
         }
 
@@ -445,23 +498,53 @@ object ExpressionEvaluator {
    *
    * @return [Base] the result of an expression
    */
-  private fun evaluateVariable(
+  private suspend fun evaluateVariable(
     expression: Expression,
     questionnaireResponse: QuestionnaireResponse,
-    dependentVariables: Map<String, Base?> = mapOf()
-  ) =
+    dependentVariables: Map<String, Base?> = mapOf(),
+    launchContextMap: Map<String, Resource>? = mapOf(),
+    xFhirQueryResolver: XFhirQueryResolver? = null
+  ): Base? =
     try {
-      require(expression.name?.isNotBlank() == true) {
-        "Expression name should be a valid expression name"
+      require(expression.name?.isNotBlank() == true) { "Expression name should not be blank" }
+
+      require(expression.language?.isNotBlank() == true) {
+        "Expression language should not be blank"
       }
 
-      require(expression.hasLanguage() && expression.language == "text/fhirpath") {
-        "Unsupported expression language, language should be text/fhirpath"
-      }
+      if (expression.isXFhirQuery) {
+        checkNotNull(xFhirQueryResolver) {
+          "XFhirQueryResolver cannot be null. Please provide the XFhirQueryResolver via DataCaptureConfig."
+        }
 
-      fhirPathEngine
-        .evaluate(dependentVariables, questionnaireResponse, null, null, expression.expression)
-        .firstOrNull()
+        val xFhirExpressionString =
+          createXFhirQueryFromExpression(expression, launchContextMap, dependentVariables)
+
+        if (dependentVariables.contains(expression.name)) dependentVariables[expression.name]!!
+
+        val resources =
+          xFhirQueryResolver.resolve(xFhirExpressionString).map {
+            BundleEntryComponent().apply { resource = it }
+          }
+        val bundle = Bundle().apply { entry = resources }
+        bundle
+      } else if (expression.isFhirPath) {
+        val contextMap =
+          mutableMapOf<String, Base?>().apply {
+            putAll(dependentVariables)
+            if (launchContextMap != null) {
+              putAll(launchContextMap)
+            }
+          }
+
+        fhirPathEngine
+          .evaluate(contextMap, questionnaireResponse, null, null, expression.expression)
+          .firstOrNull()
+      } else {
+        throw UnsupportedOperationException(
+          "${expression.language} not supported for variable-expression yet"
+        )
+      }
     } catch (exception: FHIRException) {
       Timber.w("Could not evaluate expression with FHIRPathEngine", exception)
       null

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.fhir.datacapture.fhirpath
 
+import com.google.android.fhir.datacapture.XFhirQueryResolver
 import com.google.android.fhir.datacapture.extensions.EXTENSION_CALCULATED_EXPRESSION_URL
 import com.google.android.fhir.datacapture.extensions.EXTENSION_VARIABLE_URL
 import com.google.android.fhir.datacapture.extensions.asStringValue
@@ -28,6 +29,7 @@ import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.Address
+import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.DateType
 import org.hl7.fhir.r4.model.Enumerations
 import org.hl7.fhir.r4.model.Expression
@@ -319,6 +321,38 @@ class ExpressionEvaluatorTest {
     }
 
   @Test
+  fun `resource should exists with variable expression that uses x-fhir-query`() = runBlocking {
+    val questionnaire =
+      Questionnaire().apply {
+        addExtension().apply {
+          url = EXTENSION_VARIABLE_URL
+          setValue(
+            Expression().apply {
+              name = "A"
+              language = "application/x-fhir-query"
+              expression = "Patient?name=fikri"
+            }
+          )
+        }
+      }
+
+    val patient = Patient().apply { addName().apply { addGiven("fikri") } }
+    val result =
+      ExpressionEvaluator.evaluateQuestionnaireVariableExpression(
+        questionnaire.variableExpressions.first(),
+        questionnaire,
+        QuestionnaireResponse(),
+        xFhirQueryResolver =
+          XFhirQueryResolver {
+            return@XFhirQueryResolver listOf(patient)
+          }
+      )
+
+    val resultAsResourceList = (result as Bundle).entry.map { it.resource }
+    assertThat(resultAsResourceList).contains(patient)
+  }
+
+  @Test
   fun `should throw illegal argument exception with missing expression name for questionnaire variables`() {
     assertThrows(IllegalArgumentException::class.java) {
       runBlocking {
@@ -346,7 +380,7 @@ class ExpressionEvaluatorTest {
   }
 
   @Test
-  fun `should throw illegal argument exception with missing exception language for questionnaire variables`() {
+  fun `should throw illegal argument exception with missing language for questionnaire variables`() {
     assertThrows(IllegalArgumentException::class.java) {
       runBlocking {
         val questionnaire =
@@ -373,8 +407,36 @@ class ExpressionEvaluatorTest {
   }
 
   @Test
-  fun `should throw illegal argument exception with unsupported expression language for questionnaire variables`() {
-    assertThrows(IllegalArgumentException::class.java) {
+  fun `should throw illegal state exception with missing x-fhir-query resolver for questionnaire variables`() {
+    assertThrows(IllegalStateException::class.java) {
+      runBlocking {
+        val questionnaire =
+          Questionnaire().apply {
+            id = "a-questionnaire"
+            addExtension().apply {
+              url = EXTENSION_VARIABLE_URL
+              setValue(
+                Expression().apply {
+                  name = "X"
+                  expression = "Patient?name=fikri"
+                  language = "application/x-fhir-query"
+                }
+              )
+            }
+          }
+
+        ExpressionEvaluator.evaluateQuestionnaireVariableExpression(
+          questionnaire.variableExpressions.first(),
+          questionnaire,
+          QuestionnaireResponse()
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `should throw unsupported operation exception with cql expression language for questionnaire variables`() {
+    assertThrows(UnsupportedOperationException::class.java) {
       runBlocking {
         val questionnaire =
           Questionnaire().apply {
@@ -385,7 +447,7 @@ class ExpressionEvaluatorTest {
                 Expression().apply {
                   name = "X"
                   expression = "1"
-                  language = "application/x-fhir-query"
+                  language = "text/cql"
                 }
               )
             }
@@ -687,7 +749,8 @@ class ExpressionEvaluatorTest {
     val expressionsToEvaluate =
       ExpressionEvaluator.createXFhirQueryFromExpression(
         expression,
-        mapOf(Practitioner().resourceType.name.lowercase() to Practitioner())
+        mapOf(Practitioner().resourceType.name.lowercase() to Practitioner()),
+        emptyMap(),
       )
 
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?var1=&var2=&var3=&var4=")
@@ -711,7 +774,8 @@ class ExpressionEvaluatorTest {
     val expressionsToEvaluate =
       ExpressionEvaluator.createXFhirQueryFromExpression(
         expression,
-        mapOf(practitioner.resourceType.name to practitioner)
+        mapOf(practitioner.resourceType.name to practitioner),
+        emptyMap(),
       )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=")
   }
@@ -735,7 +799,8 @@ class ExpressionEvaluatorTest {
     val expressionsToEvaluate =
       ExpressionEvaluator.createXFhirQueryFromExpression(
         expression,
-        mapOf(practitioner.resourceType.name.lowercase() to practitioner)
+        mapOf(practitioner.resourceType.name.lowercase() to practitioner),
+        emptyMap(),
       )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=male")
   }
@@ -759,7 +824,8 @@ class ExpressionEvaluatorTest {
     val expressionsToEvaluate =
       ExpressionEvaluator.createXFhirQueryFromExpression(
         expression,
-        mapOf(practitioner.resourceType.name to practitioner)
+        mapOf(practitioner.resourceType.name to practitioner),
+        emptyMap(),
       )
     assertThat(expressionsToEvaluate).isEqualTo("Practitioner?gender=")
   }
@@ -783,7 +849,8 @@ class ExpressionEvaluatorTest {
     val expressionsToEvaluate =
       ExpressionEvaluator.createXFhirQueryFromExpression(
         expression,
-        mapOf(patient.resourceType.name.lowercase() to patient)
+        mapOf(patient.resourceType.name.lowercase() to patient),
+        emptyMap(),
       )
     assertThat(expressionsToEvaluate).isEqualTo("Patient?family=John")
   }
@@ -824,7 +891,8 @@ class ExpressionEvaluatorTest {
         mapOf(
           patient.resourceType.name.lowercase() to patient,
           location.resourceType.name.lowercase() to location
-        )
+        ),
+        emptyMap()
       )
     assertThat(expressionsToEvaluate).isEqualTo("Patient?family=John&address-city=NAIROBI")
   }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2075

**Description**
Clear and concise code change description. 
- Add X-FHIR-Query support for variable extension
- Gives access to launchContext to variable extension

**Alternative(s) considered**
N/A

**Type**
Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
