### PR TITLE
Dont use AGP RC as that needs a beta version of Android Studio :)

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -42,6 +42,10 @@ android {
     )
   }
   kotlin { jvmToolchain(11) }
+  compileOptions {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+  }
 }
 
 afterEvaluate { configureFirebaseTestLabForMicroBenchmark() }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 dependencies {
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.6.0")
 
-  implementation("com.android.tools.build:gradle:8.1.0-rc01")
+  implementation("com.android.tools.build:gradle:8.0.2")
 
   implementation("app.cash.licensee:licensee-gradle-plugin:1.3.0")
   implementation("com.osacky.flank.gradle:fladle:0.17.4")

--- a/buildSrc/src/main/kotlin/Java.kt
+++ b/buildSrc/src/main/kotlin/Java.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.JavaVersion
+
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Delete this file, and the sourceCompatibility and targetCompatibility blocks when we upgrade the
+AGP to 8.1. See: https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+ */
+val javaVersion = JavaVersion.VERSION_11

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -44,7 +44,7 @@ object Plugins {
   const val flankGradlePlugin = "com.osacky.flank.gradle:fladle:0.17.4"
 
   object Versions {
-    const val androidGradlePlugin = "8.1.0-rc01"
+    const val androidGradlePlugin = "8.0.2"
     const val benchmarkPlugin = "1.1.0"
     const val dokka = "1.7.20"
   }

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -30,6 +30,8 @@ android {
     // Flag to enable support for the new language APIs
     // See https://developer.android.com/studio/write/java8-support
     isCoreLibraryDesugaringEnabled = true
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
   }
 
   packaging {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -15,6 +15,10 @@ android {
   defaultConfig { minSdk = Sdk.minSdk }
   configureJacocoTestOptions()
   kotlin { jvmToolchain(11) }
+  compileOptions {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+  }
 }
 
 configurations { all { exclude(module = "xpp3") } }

--- a/contrib/barcode/build.gradle.kts
+++ b/contrib/barcode/build.gradle.kts
@@ -42,6 +42,10 @@ android {
 
   testOptions { animationsDisabled = true }
   kotlin { jvmToolchain(11) }
+  compileOptions {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+  }
 }
 
 configurations { all { exclude(module = "xpp3") } }

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -34,6 +34,8 @@ android {
     // Flag to enable support for the new language APIs
     // See https://developer.android.com/studio/write/java8-support
     isCoreLibraryDesugaringEnabled = true
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
   }
 
   packaging {

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -32,6 +32,8 @@ android {
     // Flag to enable support for the new language APIs
     // See https://developer.android.com/studio/write/java8-support
     isCoreLibraryDesugaringEnabled = true
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
   }
 
   packaging { resources.excludes.addAll(listOf("META-INF/ASL-2.0.txt", "META-INF/LGPL-3.0.txt")) }

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -66,6 +66,8 @@ android {
     // Flag to enable support for the new language APIs
     // See https = //developer.android.com/studio/write/java8-support
     isCoreLibraryDesugaringEnabled = true
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
   }
 
   packaging { resources.excludes.addAll(listOf("META-INF/ASL-2.0.txt", "META-INF/LGPL-3.0.txt")) }

--- a/knowledge/build.gradle.kts
+++ b/knowledge/build.gradle.kts
@@ -36,7 +36,11 @@ android {
     }
   }
 
-  compileOptions { isCoreLibraryDesugaringEnabled = true }
+  compileOptions {
+    isCoreLibraryDesugaringEnabled = true
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+  }
 
   packaging {
     resources.excludes.addAll(

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -9,6 +9,10 @@ android {
   defaultConfig { minSdk = Sdk.minSdk }
   packaging { resources.excludes.addAll(listOf("META-INF/ASL-2.0.txt", "META-INF/LGPL-3.0.txt")) }
   kotlin { jvmToolchain(11) }
+  compileOptions {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+  }
 }
 
 dependencies {

--- a/workflow-testing/build.gradle.kts
+++ b/workflow-testing/build.gradle.kts
@@ -11,6 +11,10 @@ android {
   compileSdk = Sdk.compileSdk
   defaultConfig { minSdk = Sdk.minSdkWorkflow }
   kotlin { jvmToolchain(11) }
+  compileOptions {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+  }
 }
 
 configurations {

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -69,6 +69,10 @@ android {
   }
   configureJacocoTestOptions()
   kotlin { jvmToolchain(11) }
+  compileOptions {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+  }
 }
 
 afterEvaluate { configureFirebaseTestLabForLibraries() }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2072

**Description**
We would have to use the beta (Giraffe) or Canary (Hedgehog) version of Android Studio to get 8.1.1 RC to work. Bump down to a version that is stable, which means adding the compileOptions block 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
