### PR TITLE
make maven publish work

### DIFF
--- a/buildSrc/src/main/kotlin/Releases.kt
+++ b/buildSrc/src/main/kotlin/Releases.kt
@@ -17,9 +17,7 @@
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
@@ -94,24 +92,18 @@ object Releases {
 }
 
 fun Project.publishArtifact(artifact: LibraryArtifact) {
+  val variantToPublish = "release"
+  project.extensions
+    .getByType<com.android.build.gradle.LibraryExtension>()
+    .publishing.singleVariant(variantToPublish) { withSourcesJar() }
   afterEvaluate {
     configure<PublishingExtension> {
       publications {
-        register("release", MavenPublication::class) {
-          from(components["release"])
+        register<MavenPublication>(variantToPublish) {
           groupId = Releases.groupId
           artifactId = artifact.artifactId
           version = artifact.version
-          // Also publish source code for developers' convenience
-          artifact(
-            tasks.create<Jar>("androidSourcesJar") {
-              archiveClassifier.set("sources")
-
-              val android =
-                project.extensions.getByType<com.android.build.gradle.LibraryExtension>()
-              from(android.sourceSets.getByName("main").java.srcDirs)
-            }
-          )
+          from(components[variantToPublish])
           pom {
             name.set(artifact.name)
             licenses {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2072 

**Description**
Clear and concise code change description. 

Starting AGP 8.0, automatic component creation is [disabled](https://developer.android.com/build/releases/past-releases/agp-7-1-0-release-notes#disable-component-creation), meaning we need to explicitly configure our publication variant: https://developer.android.com/build/publish-library/configure-pub-variants

Tested:
Ran `./gradlew publishToMavenLocal` and `./gradlew publishReleasePublicationToCIRepository` and they both now work again :) 

Content of command:
![image](https://github.com/google/android-fhir/assets/44980219/d2e9776a-28a5-4890-8cd8-88d98dc3dd8a)

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (**Bug fix** | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
