### PR TITLE
In the catalog app, load the questionnaire JSON file from the local device storage of the phone.

### DIFF
--- a/catalog/src/main/java/com/google/android/fhir/catalog/BehaviorListFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/BehaviorListFragment.kt
@@ -66,10 +66,9 @@ class BehaviorListFragment : Fragment(R.layout.behavior_list_fragment) {
     findNavController()
       .navigate(
         BehaviorListFragmentDirections.actionBehaviorsFragmentToGalleryQuestionnaireFragment(
-          context?.getString(behavior.textId) ?: "",
-          behavior.questionnaireFileName,
-          null,
-          behavior.workFlow
+          questionnaireTitleKey = context?.getString(behavior.textId) ?: "",
+          questionnaireFilePathKey = behavior.questionnaireFileName,
+          workflow = behavior.workFlow
         )
       )
   }

--- a/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireFragment.kt
@@ -135,6 +135,7 @@ class DemoQuestionnaireFragment : Fragment() {
         QUESTIONNAIRE_FILE_WITH_VALIDATION_PATH_KEY,
         args.questionnaireFileWithValidationPathKey
       )
+    requireArguments().putParcelable(QUESTIONNAIRE_FILE_URI_KEY, args.questionnaireFileUri)
   }
 
   private fun addQuestionnaireFragment() {
@@ -142,13 +143,18 @@ class DemoQuestionnaireFragment : Fragment() {
       if (childFragmentManager.findFragmentByTag(QUESTIONNAIRE_FRAGMENT_TAG) == null) {
         childFragmentManager.commit {
           setReorderingAllowed(true)
-          add(
-            R.id.container,
+          val questionnaireFragment =
             QuestionnaireFragment.builder()
-              .setQuestionnaire(viewModel.getQuestionnaireJson())
-              .build(),
-            QUESTIONNAIRE_FRAGMENT_TAG
-          )
+              .apply {
+                if (!args.questionnaireFilePathKey.isNullOrEmpty()) {
+                  setQuestionnaire(viewModel.getQuestionnaireJson())
+                }
+                if (args.questionnaireFileUri != null) {
+                  setQuestionnaire(args.questionnaireFileUri!!)
+                }
+              }
+              .build()
+          add(R.id.container, questionnaireFragment, QUESTIONNAIRE_FRAGMENT_TAG)
         }
       }
     }
@@ -228,6 +234,7 @@ class DemoQuestionnaireFragment : Fragment() {
     const val QUESTIONNAIRE_FILE_PATH_KEY = "questionnaire-file-path-key"
     const val QUESTIONNAIRE_FILE_WITH_VALIDATION_PATH_KEY =
       "questionnaire-file-with-validation-path-key"
+    const val QUESTIONNAIRE_FILE_URI_KEY = "questionnaire-file-uri-key"
   }
 }
 

--- a/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireViewModel.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/DemoQuestionnaireViewModel.kt
@@ -36,8 +36,10 @@ class DemoQuestionnaireViewModel(application: Application, private val state: Sa
 
   init {
     viewModelScope.launch {
-      getQuestionnaireJson()
-      // TODO remove check once all files are added
+      if (!state.get<String>(QUESTIONNAIRE_FILE_PATH_KEY).isNullOrEmpty()) {
+        getQuestionnaireJson()
+      }
+
       if (!state.get<String>(QUESTIONNAIRE_FILE_WITH_VALIDATION_PATH_KEY).isNullOrEmpty()) {
         getQuestionnaireWithValidationJson()
       }

--- a/catalog/src/main/java/com/google/android/fhir/catalog/LayoutListFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/LayoutListFragment.kt
@@ -70,10 +70,9 @@ class LayoutListFragment : Fragment(R.layout.layout_list_fragment) {
     findNavController()
       .navigate(
         LayoutListFragmentDirections.actionLayoutsFragmentToGalleryQuestionnaireFragment(
-          context?.getString(layout.textId) ?: "",
-          layout.questionnaireFileName,
-          null,
-          layout.workflow
+          questionnaireTitleKey = context?.getString(layout.textId) ?: "",
+          questionnaireFilePathKey = layout.questionnaireFileName,
+          workflow = layout.workflow
         )
       )
   }

--- a/catalog/src/main/res/navigation/nav_graph.xml
+++ b/catalog/src/main/res/navigation/nav_graph.xml
@@ -86,16 +86,31 @@
         android:name="com.google.android.fhir.catalog.DemoQuestionnaireFragment"
         tools:layout="@layout/fragment_demo_questionnaire"
     >
-    <argument android:name="questionnaireTitleKey" app:argType="string" />
-    <argument android:name="questionnaireFilePathKey" app:argType="string" />
+    <argument
+            android:name="questionnaireTitleKey"
+            app:argType="string"
+            android:defaultValue=""
+        />
+    <argument
+            android:name="questionnaireFilePathKey"
+            app:argType="string"
+            android:defaultValue=""
+        />
     <argument
             android:name="questionnaireFileWithValidationPathKey"
             app:argType="string"
             app:nullable="true"
+            android:defaultValue="@null"
         />
     <argument
             android:name="workflow"
             app:argType="com.google.android.fhir.catalog.WorkflowType"
+        />
+    <argument
+            android:name="questionnaireFileUri"
+            app:argType="android.net.Uri"
+            app:nullable="true"
+            android:defaultValue="@null"
         />
     <action
             android:id="@+id/action_galleryQuestionnaireFragment_to_questionnaireResponseFragment"


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2081 

**Description**
Use storage access framework to load/open the questionnaire json file from local storage of the phone. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
