### PR TITLE
Chunking local changes into INSERT-and-DELETE-changes and DELETE-change to upload both separately

### DIFF
--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/H_FhirSyncWorkerBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/H_FhirSyncWorkerBenchmark.kt
@@ -36,7 +36,7 @@ import com.google.android.fhir.sync.DownloadRequest
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.FhirSyncWorker
 import com.google.android.fhir.sync.UploadWorkManager
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
+import com.google.android.fhir.sync.upload.InsertUpdateSquashedChangesUploadWorkManager
 import com.google.common.truth.Truth.assertThat
 import java.math.BigDecimal
 import java.util.LinkedList
@@ -87,7 +87,8 @@ class H_FhirSyncWorkerBenchmark {
     }
     override fun getDownloadWorkManager(): DownloadWorkManager = BenchmarkTestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
+    override fun getUploadWorkManager(): UploadWorkManager =
+      InsertUpdateSquashedChangesUploadWorkManager()
   }
 
   open class BenchmarkTestDownloadManagerImpl(queries: List<String> = listOf("List/sync-list")) :

--- a/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
@@ -23,7 +23,7 @@ import com.google.android.fhir.sync.AcceptLocalConflictResolver
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.FhirSyncWorker
 import com.google.android.fhir.sync.UploadWorkManager
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
+import com.google.android.fhir.sync.upload.InsertUpdateSquashedChangesUploadWorkManager
 
 class DemoFhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
   FhirSyncWorker(appContext, workerParams) {
@@ -32,7 +32,8 @@ class DemoFhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
     return TimestampBasedDownloadWorkManagerImpl(FhirApplication.dataStore(applicationContext))
   }
 
-  override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
+  override fun getUploadWorkManager(): UploadWorkManager =
+    InsertUpdateSquashedChangesUploadWorkManager()
 
   override fun getConflictResolver() = AcceptLocalConflictResolver
 

--- a/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
@@ -25,7 +25,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.google.android.fhir.FhirEngine
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
+import com.google.android.fhir.sync.upload.InsertUpdateSquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
 import com.google.android.fhir.testing.TestFhirEngineImpl
@@ -53,7 +53,7 @@ class SyncInstrumentedTest {
     override fun getFhirEngine(): FhirEngine = TestFhirEngineImpl
     override fun getDataSource(): DataSource = TestDataSourceImpl
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
-    override fun getUploadWorkManager() = SquashedChangesUploadWorkManager()
+    override fun getUploadWorkManager() = InsertUpdateSquashedChangesUploadWorkManager()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
   }
 

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/SquashedChangesUploadWorkManager.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/SquashedChangesUploadWorkManager.kt
@@ -30,8 +30,9 @@ class SquashedChangesUploadWorkManager : UploadWorkManager {
   private val bundleUploadRequestGenerator = TransactionBundleGenerator.getDefault()
 
   /**
-   * The implementation is to squash all the changes by resource type so that there is at most one
-   * local change to be uploaded per resource
+   * The implementation is to squash all the changes by {resourceId, resourceType}. If a resource is
+   * INSERTED and DELETED locally then the list of local changes are split to squash all INSERT AND
+   * UPDATE changes into 1 LocalChange and the last DELETE change into 1 LocalChange.
    */
   override fun prepareChangesForUpload(localChanges: List<LocalChange>): List<LocalChange> {
     val localChangeValuesInOrder = mutableListOf<List<LocalChange>>()

--- a/engine/src/test/java/com/google/android/fhir/sync/FhirSyncWorkerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/FhirSyncWorkerTest.kt
@@ -23,7 +23,7 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.google.android.fhir.FhirEngine
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
+import com.google.android.fhir.sync.upload.InsertUpdateSquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
 import com.google.android.fhir.testing.TestFailingDatasource
@@ -47,7 +47,8 @@ class FhirSyncWorkerTest {
     override fun getDataSource(): DataSource = TestDataSourceImpl
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
+    override fun getUploadWorkManager(): UploadWorkManager =
+      InsertUpdateSquashedChangesUploadWorkManager()
   }
 
   class FailingPeriodicSyncWorker(appContext: Context, workerParams: WorkerParameters) :
@@ -57,7 +58,8 @@ class FhirSyncWorkerTest {
     override fun getDataSource(): DataSource = TestFailingDatasource
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
+    override fun getUploadWorkManager(): UploadWorkManager =
+      InsertUpdateSquashedChangesUploadWorkManager()
   }
 
   class FailingPeriodicSyncWorkerWithoutDataSource(
@@ -67,7 +69,8 @@ class FhirSyncWorkerTest {
 
     override fun getFhirEngine(): FhirEngine = TestFhirEngineImpl
     override fun getDownloadWorkManager() = TestDownloadManagerImpl()
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
+    override fun getUploadWorkManager(): UploadWorkManager =
+      InsertUpdateSquashedChangesUploadWorkManager()
     override fun getDataSource(): DataSource? = null
     override fun getConflictResolver() = AcceptRemoteConflictResolver
   }

--- a/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import androidx.work.BackoffPolicy
 import androidx.work.WorkerParameters
 import com.google.android.fhir.FhirEngine
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
+import com.google.android.fhir.sync.upload.InsertUpdateSquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
 import com.google.android.fhir.testing.TestFhirEngineImpl
@@ -40,7 +40,8 @@ class SyncTest {
     override fun getFhirEngine(): FhirEngine = TestFhirEngineImpl
     override fun getDataSource(): DataSource = TestDataSourceImpl
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
+    override fun getUploadWorkManager(): UploadWorkManager =
+      InsertUpdateSquashedChangesUploadWorkManager()
 
     override fun getConflictResolver() = AcceptRemoteConflictResolver
   }

--- a/engine/src/test/java/com/google/android/fhir/sync/upload/InsertUpdateSquashedChangesUploadWorkManagerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/upload/InsertUpdateSquashedChangesUploadWorkManagerTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.sync.upload
+
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
+import com.google.android.fhir.db.impl.dao.LocalChangeToken
+import com.google.android.fhir.db.impl.dao.toLocalChange
+import com.google.android.fhir.db.impl.entities.LocalChangeEntity
+import com.google.common.truth.Truth.assertThat
+import java.time.Instant
+import org.hl7.fhir.r4.model.HumanName
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.ResourceType
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InsertUpdateSquashedChangesUploadWorkManagerTest {
+  @Test
+  fun `prepareChangesForUpload should return two LocalChanges for same resource locally inserted and deleted`() {
+    val insertAndDeleteLocalChanges = insertLocalChanges + deleteLocalChanges
+
+    val localChanges =
+      InsertUpdateSquashedChangesUploadWorkManager()
+        .prepareChangesForUpload(insertAndDeleteLocalChanges)
+
+    assertThat(localChanges).hasSize(2)
+  }
+
+  companion object {
+    val insertLocalChanges =
+      listOf(
+        LocalChangeEntity(
+            id = 1,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.INSERT,
+            payload =
+              FhirContext.forCached(FhirVersionEnum.R4)
+                .newJsonParser()
+                .encodeResourceToString(
+                  Patient().apply {
+                    id = "Patient-001"
+                    addName(
+                      HumanName().apply {
+                        addGiven("John")
+                        family = "Doe"
+                      }
+                    )
+                  }
+                ),
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(1)) }
+      )
+
+    val deleteLocalChanges =
+      listOf(
+        LocalChangeEntity(
+            id = 2,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.DELETE,
+            payload = "",
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(2)) }
+      )
+  }
+}

--- a/engine/src/test/java/com/google/android/fhir/sync/upload/UploaderImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/upload/UploaderImplTest.kt
@@ -45,7 +45,7 @@ class UploaderImplTest {
     val result =
       UploaderImpl(
           BundleDataSource { Bundle().apply { type = Bundle.BundleType.TRANSACTIONRESPONSE } },
-          SquashedChangesUploadWorkManager()
+          InsertUpdateSquashedChangesUploadWorkManager()
         )
         .upload(localChanges)
         .toList()
@@ -62,7 +62,7 @@ class UploaderImplTest {
   @Test
   fun `upload Bundle transaction should emit Started state`() = runBlocking {
     val result =
-      UploaderImpl(BundleDataSource { Bundle() }, SquashedChangesUploadWorkManager())
+      UploaderImpl(BundleDataSource { Bundle() }, InsertUpdateSquashedChangesUploadWorkManager())
         .upload(localChanges)
         .toList()
 
@@ -84,7 +84,7 @@ class UploaderImplTest {
               )
             }
           },
-          SquashedChangesUploadWorkManager()
+          InsertUpdateSquashedChangesUploadWorkManager()
         )
         .upload(localChanges)
         .toList()
@@ -98,7 +98,7 @@ class UploaderImplTest {
     val result =
       UploaderImpl(
           BundleDataSource { throw ConnectException("Failed to connect to server.") },
-          SquashedChangesUploadWorkManager()
+          InsertUpdateSquashedChangesUploadWorkManager()
         )
         .upload(localChanges)
         .toList()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2031 

**Description**
Modifying squashing by chunking local changes into insert-and-update-changes AND delete-change (if present) to be able to upload both separately.

**Alternative(s) considered**
Providing following configuration for developers 
1. SQUASH_EVERYTHING, i.e., Not upload local insert + delete operation 
2. UPLOAD_EVERYTHING, i.e., Upload every local operation
For this we need more implementation hence this is a temporary fix for Issue #2031 

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
