### PR TITLE
collect upload to get FhirSyncWorkerTest to work

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
+++ b/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
@@ -148,7 +148,7 @@ object TestFhirEngineImpl : FhirEngine {
   override suspend fun syncUpload(
     upload: suspend (List<LocalChange>) -> Flow<Pair<LocalChangeToken, Resource>>
   ) {
-    upload(getLocalChanges(ResourceType.Patient, "123"))
+    upload(getLocalChanges(ResourceType.Patient, "123")).collect()
   }
 
   override suspend fun syncDownload(
@@ -172,7 +172,7 @@ object TestFhirEngineImpl : FhirEngine {
       LocalChange(
         resourceType = type.name,
         resourceId = id,
-        payload = "{}",
+        payload = "{ 'resourceType' : 'Patient', 'id' : '123' }",
         token = LocalChangeToken(listOf()),
         type = LocalChange.Type.INSERT,
         timestamp = Instant.now()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Clear and concise code change description. 

FhirSyncWorkerTest all pass when they should not due to the JSON payload being empty when uploading localChanges. This is because we are not collecting the flow in upload. Fixed. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (**Bug fix** | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
