### PR TITLE
Added a default value of EPOCH if migration from string to timestamp fails

### DIFF
--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/ResourceDatabaseMigrationTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/ResourceDatabaseMigrationTest.kt
@@ -25,6 +25,7 @@ import com.google.android.fhir.db.impl.entities.LocalChangeEntity
 import com.google.android.fhir.toTimeZoneString
 import com.google.common.truth.Truth.assertThat
 import java.io.IOException
+import java.time.Instant
 import java.util.Date
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.HumanName
@@ -197,6 +198,10 @@ class ResourceDatabaseMigrationTest {
       execSQL(
         "INSERT INTO LocalChangeEntity (resourceType, resourceId, timestamp, type, payload) VALUES ('Task', 'bed-net-001', '${date.toTimeZoneString()}', '${DbTypeConverters.localChangeTypeToInt(LocalChangeEntity.Type.INSERT)}', '$bedNetTask'  );"
       )
+
+      execSQL(
+        "INSERT INTO LocalChangeEntity (resourceType, resourceId, timestamp, type, payload) VALUES ('Task', 'id-corrupted-timestamp', 'date-not-good', '${DbTypeConverters.localChangeTypeToInt(LocalChangeEntity.Type.INSERT)}', '$bedNetTask'  );"
+      )
       close()
     }
 
@@ -205,6 +210,8 @@ class ResourceDatabaseMigrationTest {
     val retrievedTask: String?
     val localChangeEntityTimeStamp: Long
     val resourceEntityLastUpdatedLocal: Long
+    val localChangeEntityCorruptedTimeStamp: Long
+
     getMigratedRoomDatabase().apply {
       retrievedTask = this.resourceDao().getResource(taskId, ResourceType.Task)
       resourceEntityLastUpdatedLocal =
@@ -212,17 +219,20 @@ class ResourceDatabaseMigrationTest {
           it.moveToFirst()
           it.getLong(0)
         }
-      localChangeEntityTimeStamp =
-        query("Select timestamp from LocalChangeEntity", null).let {
-          it.moveToFirst()
-          it.getLong(0)
-        }
+
+      query("Select timestamp from LocalChangeEntity", null).let {
+        it.moveToFirst()
+        localChangeEntityTimeStamp = it.getLong(0)
+        it.moveToNext()
+        localChangeEntityCorruptedTimeStamp = it.getLong(0)
+      }
 
       openHelper.writableDatabase.close()
     }
 
     assertThat(retrievedTask).isEqualTo(bedNetTask)
     assertThat(localChangeEntityTimeStamp).isEqualTo(resourceEntityLastUpdatedLocal)
+    assertThat(Instant.ofEpochMilli(localChangeEntityCorruptedTimeStamp)).isEqualTo(Instant.EPOCH)
   }
 
   private fun getMigratedRoomDatabase(): ResourceDatabase =

--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/ResourceDatabaseMigrationTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/ResourceDatabaseMigrationTest.kt
@@ -220,7 +220,7 @@ class ResourceDatabaseMigrationTest {
           it.getLong(0)
         }
 
-      query("Select timestamp from LocalChangeEntity", null).let {
+      query("SELECT timestamp FROM LocalChangeEntity", null).let {
         it.moveToFirst()
         localChangeEntityTimeStamp = it.getLong(0)
         it.moveToNext()

--- a/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
@@ -117,7 +117,7 @@ val MIGRATION_5_6 =
         "CREATE TABLE IF NOT EXISTS `_new_LocalChangeEntity` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceType` TEXT NOT NULL, `resourceId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `type` INTEGER NOT NULL, `payload` TEXT NOT NULL, `versionId` TEXT)"
       )
       database.execSQL(
-        "INSERT INTO `_new_LocalChangeEntity` (`id`,`resourceType`,`resourceId`,`timestamp`,`type`,`payload`,`versionId`) SELECT `id`,`resourceType`,`resourceId`, strftime('%s', `timestamp`) ||  substr(strftime('%f', `timestamp`), 4),`type`,`payload`,`versionId` FROM `LocalChangeEntity`"
+        "INSERT INTO `_new_LocalChangeEntity` (`id`,`resourceType`,`resourceId`,`timestamp`,`type`,`payload`,`versionId`) SELECT `id`,`resourceType`,`resourceId`, COALESCE(strftime('%s', `timestamp`) ||  substr(strftime('%f', `timestamp`), 4) , /* default is EPOCH*/ 0 ),`type`,`payload`,`versionId` FROM `LocalChangeEntity`"
       )
       database.execSQL("DROP TABLE `LocalChangeEntity`")
       database.execSQL("ALTER TABLE `_new_LocalChangeEntity` RENAME TO `LocalChangeEntity`")


### PR DESCRIPTION

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2116

**Description**
1. Added a default value of EPOCH if migration from string to timestamp fails using [COALESCE](https://www.sqlite.org/draft/lang_corefunc.html#coalesce) .
2. Updated Migration Test to check corrupted timestamp migrates to Instant.EPOCH . 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one:  Code health 

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
