### PR TITLE
Refactor syncUpload method to utilise new ResultProcessor Interface

### DIFF
--- a/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/H_FhirSyncWorkerBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/H_FhirSyncWorkerBenchmark.kt
@@ -36,6 +36,8 @@ import com.google.android.fhir.sync.DownloadRequest
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.FhirSyncWorker
 import com.google.android.fhir.sync.UploadWorkManager
+import com.google.android.fhir.sync.upload.DefaultResultProcessor
+import com.google.android.fhir.sync.upload.ResultProcessor
 import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.common.truth.Truth.assertThat
 import java.math.BigDecimal
@@ -87,6 +89,7 @@ class H_FhirSyncWorkerBenchmark {
     }
     override fun getDownloadWorkManager(): DownloadWorkManager = BenchmarkTestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
+    override fun getResultProcessor(): ResultProcessor = DefaultResultProcessor
     override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
   }
 

--- a/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
@@ -23,6 +23,8 @@ import com.google.android.fhir.sync.AcceptLocalConflictResolver
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.FhirSyncWorker
 import com.google.android.fhir.sync.UploadWorkManager
+import com.google.android.fhir.sync.upload.DefaultResultProcessor
+import com.google.android.fhir.sync.upload.ResultProcessor
 import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 
 class DemoFhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
@@ -35,6 +37,8 @@ class DemoFhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
   override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
 
   override fun getConflictResolver() = AcceptLocalConflictResolver
+
+  override fun getResultProcessor(): ResultProcessor = DefaultResultProcessor
 
   override fun getFhirEngine() = FhirApplication.fhirEngine(applicationContext)
 }

--- a/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
@@ -25,6 +25,8 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.sync.upload.DefaultResultProcessor
+import com.google.android.fhir.sync.upload.ResultProcessor
 import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
@@ -55,6 +57,7 @@ class SyncInstrumentedTest {
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
     override fun getUploadWorkManager() = SquashedChangesUploadWorkManager()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
+    override fun getResultProcessor(): ResultProcessor = DefaultResultProcessor
   }
 
   @Test

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -20,6 +20,7 @@ import com.google.android.fhir.db.ResourceNotFoundException
 import com.google.android.fhir.db.impl.dao.LocalChangeToken
 import com.google.android.fhir.search.Search
 import com.google.android.fhir.sync.ConflictResolver
+import com.google.android.fhir.sync.upload.ResultProcessor
 import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.Flow
 import org.hl7.fhir.r4.model.Resource
@@ -51,10 +52,12 @@ interface FhirEngine {
   /**
    * Synchronizes the [upload] result in the database. [upload] operation may result in multiple
    * calls to the server to upload the data. Result of each call will be emitted by [upload] and the
-   * api caller should [Flow.collect] it.
+   * api caller should [Flow.collect] it. The [resultProcessor] is used to handle the processing of
+   * the upload results.
    */
   suspend fun syncUpload(
-    upload: (suspend (List<LocalChange>) -> Flow<Pair<LocalChangeToken, Resource>>)
+    upload: (suspend (List<LocalChange>) -> Flow<Pair<LocalChangeToken, Resource>>),
+    resultProcessor: ResultProcessor,
   )
 
   /**

--- a/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
@@ -25,6 +25,7 @@ import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.FhirEngineProvider
 import com.google.android.fhir.OffsetDateTimeTypeAdapter
 import com.google.android.fhir.sync.download.DownloaderImpl
+import com.google.android.fhir.sync.upload.ResultProcessor
 import com.google.android.fhir.sync.upload.UploaderImpl
 import com.google.gson.ExclusionStrategy
 import com.google.gson.FieldAttributes
@@ -34,7 +35,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -45,6 +45,7 @@ abstract class FhirSyncWorker(appContext: Context, workerParams: WorkerParameter
   abstract fun getDownloadWorkManager(): DownloadWorkManager
   abstract fun getUploadWorkManager(): UploadWorkManager
   abstract fun getConflictResolver(): ConflictResolver
+  abstract fun getResultProcessor(): ResultProcessor
 
   private val gson =
     GsonBuilder()
@@ -87,7 +88,8 @@ abstract class FhirSyncWorker(appContext: Context, workerParams: WorkerParameter
           getFhirEngine(),
           UploaderImpl(dataSource, getUploadWorkManager()),
           DownloaderImpl(dataSource, getDownloadWorkManager()),
-          getConflictResolver()
+          getConflictResolver(),
+          getResultProcessor(),
         )
         .apply { subscribe(flow) }
         .synchronize()

--- a/engine/src/main/java/com/google/android/fhir/sync/FhirSynchronizer.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/FhirSynchronizer.kt
@@ -19,9 +19,9 @@ package com.google.android.fhir.sync
 import android.content.Context
 import com.google.android.fhir.DatastoreUtil
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.sync.upload.ResultProcessor
 import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import org.hl7.fhir.r4.model.ResourceType
 
@@ -45,7 +45,8 @@ internal class FhirSynchronizer(
   private val fhirEngine: FhirEngine,
   private val uploader: Uploader,
   private val downloader: Downloader,
-  private val conflictResolver: ConflictResolver
+  private val conflictResolver: ConflictResolver,
+  private val resultProcessor: ResultProcessor,
 ) {
   private var syncState: MutableSharedFlow<SyncJobStatus>? = null
   private val datastoreUtil = DatastoreUtil(context)
@@ -83,7 +84,7 @@ internal class FhirSynchronizer(
   suspend fun synchronize(): SyncJobStatus {
     setSyncState(SyncJobStatus.Started())
 
-    return listOf(download(), upload())
+    return listOf(download(), upload(resultProcessor))
       .filterIsInstance<SyncResult.Error>()
       .flatMap { it.exceptions }
       .let {
@@ -123,25 +124,28 @@ internal class FhirSynchronizer(
     }
   }
 
-  private suspend fun upload(): SyncResult {
+  private suspend fun upload(resultProcessor: ResultProcessor): SyncResult {
     val exceptions = mutableListOf<ResourceSyncException>()
-    fhirEngine.syncUpload { list ->
-      flow {
-        uploader.upload(list).collect { result ->
-          when (result) {
-            is UploadState.Started ->
-              setSyncState(SyncJobStatus.InProgress(SyncOperation.UPLOAD, result.total))
-            is UploadState.Success ->
-              emit(result.localChangeToken to result.resource).also {
-                setSyncState(
-                  SyncJobStatus.InProgress(SyncOperation.UPLOAD, result.total, result.completed)
-                )
-              }
-            is UploadState.Failure -> exceptions.add(result.syncError)
+    fhirEngine.syncUpload(
+      { list ->
+        flow {
+          uploader.upload(list).collect { result ->
+            when (result) {
+              is UploadState.Started ->
+                setSyncState(SyncJobStatus.InProgress(SyncOperation.UPLOAD, result.total))
+              is UploadState.Success ->
+                emit(result.localChangeToken to result.resource).also {
+                  setSyncState(
+                    SyncJobStatus.InProgress(SyncOperation.UPLOAD, result.total, result.completed)
+                  )
+                }
+              is UploadState.Failure -> exceptions.add(result.syncError)
+            }
           }
         }
-      }
-    }
+      },
+      resultProcessor
+    )
     return if (exceptions.isEmpty()) {
       SyncResult.Success()
     } else {

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/ResultProcessor.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/ResultProcessor.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.sync.upload
+
+import java.time.Instant
+import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.Resource
+import org.hl7.fhir.r4.model.ResourceType
+import timber.log.Timber
+
+typealias VersionIdAndLastUpdatedUpdater =
+  suspend (id: String, type: ResourceType, version: String, lastUpdated: Instant) -> Unit
+
+/**
+ * Interface responsible for processing upload results. Provides a way to handle the processing
+ * logic and updating version ID and last updated timestamp.
+ */
+fun interface ResultProcessor {
+
+  /** Processes the upload result, performing necessary actions based on the data. */
+  suspend fun process(
+    resource: Resource,
+    performVersionIdAndLastUpdatedUpdate: VersionIdAndLastUpdatedUpdater
+  )
+}
+
+val DefaultResultProcessor = ResultProcessor { resource, performVersionIdAndLastUpdatedUpdate ->
+  when (resource) {
+    is Bundle -> updateVersionIdAndLastUpdated(resource, performVersionIdAndLastUpdatedUpdate)
+    else -> updateVersionIdAndLastUpdated(resource, performVersionIdAndLastUpdatedUpdate)
+  }
+}
+
+private suspend fun updateVersionIdAndLastUpdated(
+  bundle: Bundle,
+  performVersionIdAndLastUpdatedUpdate: VersionIdAndLastUpdatedUpdater
+) {
+  when (bundle.type) {
+    Bundle.BundleType.TRANSACTIONRESPONSE -> {
+      bundle.entry.forEach {
+        when {
+          it.hasResource() ->
+            updateVersionIdAndLastUpdated(it.resource, performVersionIdAndLastUpdatedUpdate)
+          it.hasResponse() ->
+            updateVersionIdAndLastUpdated(it.response, performVersionIdAndLastUpdatedUpdate)
+        }
+      }
+    }
+    else -> {
+      // Leave it for now.
+      Timber.i("Received request to update meta values for ${bundle.type}")
+    }
+  }
+}
+
+private suspend fun updateVersionIdAndLastUpdated(
+  response: Bundle.BundleEntryResponseComponent,
+  performVersionIdAndLastUpdatedUpdate: VersionIdAndLastUpdatedUpdater
+) {
+  if (response.hasEtag() && response.hasLastModified() && response.hasLocation()) {
+    response.resourceIdAndType?.let { (id, type) ->
+      performVersionIdAndLastUpdatedUpdate(
+        id,
+        type,
+        getVersionFromETag(response.etag),
+        response.lastModified.toInstant()
+      )
+    }
+  }
+}
+
+private suspend fun updateVersionIdAndLastUpdated(
+  resource: Resource,
+  performVersionIdAndLastUpdatedUpdate: VersionIdAndLastUpdatedUpdater
+) {
+  if (resource.hasMeta() && resource.meta.hasVersionId() && resource.meta.hasLastUpdated()) {
+    performVersionIdAndLastUpdatedUpdate(
+      resource.id,
+      resource.resourceType,
+      resource.meta.versionId,
+      resource.meta.lastUpdated.toInstant()
+    )
+  }
+}
+
+/**
+ * FHIR uses weak ETag that look something like W/"MTY4NDMyODE2OTg3NDUyNTAwMA", so we need to
+ * extract version from it. See https://hl7.org/fhir/http.html#Http-Headers.
+ */
+private fun getVersionFromETag(eTag: String) =
+  // The server should always return a weak etag that starts with W, but if it server returns a
+  // strong tag, we store it as-is. The http-headers for conditional upload like if-match will
+  // always add value as a weak tag.
+  if (eTag.startsWith("W/")) {
+    eTag.split("\"")[1]
+  } else {
+    eTag
+  }
+
+/**
+ * May return a Pair of versionId and resource type extracted from the
+ * [Bundle.BundleEntryResponseComponent.location].
+ *
+ * [Bundle.BundleEntryResponseComponent.location] may be:
+ *
+ * 1. absolute path: `<server-path>/<resource-type>/<resource-id>/_history/<version>`
+ *
+ * 2. relative path: `<resource-type>/<resource-id>/_history/<version>`
+ */
+private val Bundle.BundleEntryResponseComponent.resourceIdAndType: Pair<String, ResourceType>?
+  get() =
+    location
+      ?.split("/")
+      ?.takeIf { it.size > 3 }
+      ?.let { it[it.size - 3] to ResourceType.fromCode(it[it.size - 4]) }

--- a/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
+++ b/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
@@ -32,6 +32,7 @@ import com.google.android.fhir.sync.DownloadRequest
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.UploadRequest
 import com.google.android.fhir.sync.UrlDownloadRequest
+import com.google.android.fhir.sync.upload.ResultProcessor
 import com.google.common.truth.Truth.assertThat
 import java.net.SocketTimeoutException
 import java.time.Instant
@@ -146,7 +147,8 @@ object TestFhirEngineImpl : FhirEngine {
   }
 
   override suspend fun syncUpload(
-    upload: suspend (List<LocalChange>) -> Flow<Pair<LocalChangeToken, Resource>>
+    upload: suspend (List<LocalChange>) -> Flow<Pair<LocalChangeToken, Resource>>,
+    resultProcessor: ResultProcessor
   ) {
     upload(getLocalChanges(ResourceType.Patient, "123")).collect()
   }

--- a/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
@@ -29,6 +29,7 @@ import com.google.android.fhir.search.LOCAL_LAST_UPDATED_PARAM
 import com.google.android.fhir.search.search
 import com.google.android.fhir.sync.AcceptLocalConflictResolver
 import com.google.android.fhir.sync.AcceptRemoteConflictResolver
+import com.google.android.fhir.sync.upload.DefaultResultProcessor
 import com.google.android.fhir.testing.assertResourceEquals
 import com.google.android.fhir.testing.assertResourceNotEquals
 import com.google.android.fhir.testing.readFromFile
@@ -311,12 +312,15 @@ class FhirEngineImplTest {
   @Test
   fun syncUpload_uploadLocalChange() = runBlocking {
     val localChanges = mutableListOf<LocalChange>()
-    fhirEngine.syncUpload {
-      flow {
-        localChanges.addAll(it)
-        emit(LocalChangeToken(it.flatMap { it.token.ids }) to TEST_PATIENT_1)
-      }
-    }
+    fhirEngine.syncUpload(
+      {
+        flow {
+          localChanges.addAll(it)
+          emit(LocalChangeToken(it.flatMap { it.token.ids }) to TEST_PATIENT_1)
+        }
+      },
+      DefaultResultProcessor
+    )
 
     assertThat(localChanges).hasSize(1)
     // val localChange = localChanges[0].localChange

--- a/engine/src/test/java/com/google/android/fhir/sync/FhirSyncWorkerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/FhirSyncWorkerTest.kt
@@ -23,6 +23,8 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.sync.upload.DefaultResultProcessor
+import com.google.android.fhir.sync.upload.ResultProcessor
 import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
@@ -47,6 +49,7 @@ class FhirSyncWorkerTest {
     override fun getDataSource(): DataSource = TestDataSourceImpl
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
+    override fun getResultProcessor(): ResultProcessor = DefaultResultProcessor
     override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
   }
 
@@ -57,6 +60,7 @@ class FhirSyncWorkerTest {
     override fun getDataSource(): DataSource = TestFailingDatasource
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
+    override fun getResultProcessor(): ResultProcessor = DefaultResultProcessor
     override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
   }
 
@@ -70,6 +74,7 @@ class FhirSyncWorkerTest {
     override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
     override fun getDataSource(): DataSource? = null
     override fun getConflictResolver() = AcceptRemoteConflictResolver
+    override fun getResultProcessor(): ResultProcessor = DefaultResultProcessor
   }
 
   @Before

--- a/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import androidx.work.BackoffPolicy
 import androidx.work.WorkerParameters
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.sync.upload.DefaultResultProcessor
+import com.google.android.fhir.sync.upload.ResultProcessor
 import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
@@ -43,6 +45,8 @@ class SyncTest {
     override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
 
     override fun getConflictResolver() = AcceptRemoteConflictResolver
+
+    override fun getResultProcessor(): ResultProcessor = DefaultResultProcessor
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2103 

**Description**
Clear and concise code change description. 

Encapsulate the processing logic in syncUpload into a new interface called ResultProcessor. The new structure should enable future enhancements and custom processing logic without requiring modifications to the core syncUpload method.


**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | **Code health** | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
