### PR TITLE
2096 variable for enable when expression

### DIFF
--- a/catalog/src/main/assets/component_dropdown.json
+++ b/catalog/src/main/assets/component_dropdown.json
@@ -1,8 +1,23 @@
 {
   "resourceType": "Questionnaire",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "fikri",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='1').answer.value"
+      }
+    }
+  ],
   "item": [
     {
       "linkId": "1",
+      "type": "boolean",
+      "text": "Choose one from the options below"
+    },
+    {
+      "linkId": "2",
       "type": "choice",
       "extension": [
         {
@@ -16,6 +31,13 @@
               }
             ],
             "text": "Drop down"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%fikri"
           }
         }
       ],

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -404,7 +404,9 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
     QuestionnaireResponseValidator.validateQuestionnaireResponse(
         questionnaire,
         questionnaireResponse,
-        getApplication()
+        getApplication(),
+        questionnaireItemParentMap,
+        questionnaireLaunchContextMap
       )
       .also { result ->
         if (result.values.flatten().filterIsInstance<Invalid>().isNotEmpty()) {
@@ -505,7 +507,8 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         updatedQuestionnaireResponseItem,
         questionnaire,
         questionnaireResponse,
-        questionnaireItemParentMap
+        questionnaireItemParentMap,
+        questionnaireLaunchContextMap
       )
       .forEach { (questionnaireItem, calculatedAnswers) ->
         // update all response item with updated values
@@ -544,7 +547,8 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
       questionnaireItem,
       questionnaireResponseItem,
       cqfExpression,
-      questionnaireItemParentMap
+      questionnaireItemParentMap,
+      questionnaireLaunchContextMap
     )
   }
 
@@ -654,7 +658,13 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
     if (questionnaireItem.isHidden) return emptyList()
     val enabled =
       EnablementEvaluator(questionnaireResponse)
-        .evaluate(questionnaireItem, questionnaireResponseItem)
+        .evaluate(
+          questionnaireItem,
+          questionnaireResponseItem,
+          questionnaire,
+          questionnaireItemParentMap,
+          questionnaireLaunchContextMap
+        )
     // Disabled questions should not get QuestionnaireItemViewItem instances
     if (!enabled) {
       cacheDisabledQuestionnaireItemAnswers(questionnaireResponseItem)
@@ -689,7 +699,8 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         questionnaireItem,
         questionnaireResponseItem,
         questionnaireResponse,
-        questionnaireItemParentMap
+        questionnaireItemParentMap,
+        questionnaireLaunchContextMap
       )
     if (disabledQuestionnaireResponseAnswers.isNotEmpty()) {
       removeDisabledAnswers(
@@ -713,7 +724,14 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
             enabledDisplayItems =
               questionnaireItem.item.filter {
                 it.isDisplayItem &&
-                  EnablementEvaluator(questionnaireResponse).evaluate(it, questionnaireResponseItem)
+                  EnablementEvaluator(questionnaireResponse)
+                    .evaluate(
+                      it,
+                      questionnaireResponseItem,
+                      questionnaire,
+                      questionnaireItemParentMap,
+                      questionnaireLaunchContextMap
+                    )
               },
             questionViewTextConfiguration =
               QuestionTextConfiguration(
@@ -800,6 +818,9 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         enablementEvaluator.evaluate(
           questionnaireItem,
           questionnaireResponseItem,
+          questionnaire,
+          questionnaireItemParentMap,
+          questionnaireLaunchContextMap
         )
       }
       .map { (questionnaireItem, questionnaireResponseItem) ->
@@ -832,6 +853,9 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
             .evaluate(
               questionnaireItem,
               questionnaireResponseItem,
+              questionnaire,
+              questionnaireItemParentMap,
+              questionnaireLaunchContextMap
             ),
           questionnaireItem.isHidden
         )

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/expressions/EnabledAnswerOptionsEvaluator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/expressions/EnabledAnswerOptionsEvaluator.kt
@@ -62,7 +62,8 @@ internal class EnabledAnswerOptionsEvaluator(
     questionnaireItem: QuestionnaireItemComponent,
     questionnaireResponseItem: QuestionnaireResponse.QuestionnaireResponseItemComponent,
     questionnaireResponse: QuestionnaireResponse,
-    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>
+    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>,
+    launchContextMap: Map<String, Resource>?
   ): Pair<
     List<Questionnaire.QuestionnaireItemAnswerOptionComponent>,
     List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>
@@ -80,7 +81,8 @@ internal class EnabledAnswerOptionsEvaluator(
         questionnaireResponseItem,
         questionnaireResponse,
         resolvedAnswerOptions,
-        questionnaireItemParentMap
+        questionnaireItemParentMap,
+        launchContextMap
       )
     val disabledAnswers =
       questionnaireResponseItem.answer
@@ -214,7 +216,8 @@ internal class EnabledAnswerOptionsEvaluator(
     questionnaireResponseItem: QuestionnaireResponse.QuestionnaireResponseItemComponent,
     questionnaireResponse: QuestionnaireResponse,
     answerOptions: List<Questionnaire.QuestionnaireItemAnswerOptionComponent>,
-    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>
+    questionnaireItemParentMap: Map<QuestionnaireItemComponent, QuestionnaireItemComponent>,
+    launchContextMap: Map<String, Resource>?
   ): List<Questionnaire.QuestionnaireItemAnswerOptionComponent> {
     val results =
       item.answerOptionsToggleExpressions
@@ -229,7 +232,8 @@ internal class EnabledAnswerOptionsEvaluator(
                   item,
                   questionnaireResponseItem,
                   expression,
-                  questionnaireItemParentMap
+                  questionnaireItemParentMap,
+                  launchContextMap
                 )
               )
             else

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/FhirPathUtil.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/FhirPathUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2022-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.google.android.fhir.datacapture.fhirpath
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext
+import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
 import org.hl7.fhir.r4.model.Resource
@@ -47,11 +48,15 @@ internal fun evaluateToDisplay(expressions: List<String>, data: Resource) =
 internal fun evaluateToBoolean(
   questionnaireResponse: QuestionnaireResponse,
   questionnaireResponseItemComponent: QuestionnaireResponseItemComponent,
-  expression: String
-) =
-  fhirPathEngine.evaluateToBoolean(
+  expression: String,
+  contextMap: Map<String, Base?>
+): Boolean {
+  val expressionNode = fhirPathEngine.parse(expression)
+  return fhirPathEngine.evaluateToBoolean(
+    contextMap,
     questionnaireResponse,
-    null,
     questionnaireResponseItemComponent,
-    expression
+    null,
+    expressionNode
   )
+}


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2096

**Description**
Provide proper contextMap when evaluating the following:

- enableWhenExpression can access variablesMap and launchContextMap
- variableExpression can access launchContextMap

**Alternative(s) considered**
N/A

**Type**
Feature

**Video**

[Demo.webm](https://github.com/google/android-fhir/assets/62053304/c4345b18-e72a-4263-881c-d235d29cde9d)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
