### PR TITLE
Handle local insert-delete sequence as no-op when squashing

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/LocalChange.kt
+++ b/engine/src/main/java/com/google/android/fhir/LocalChange.kt
@@ -43,7 +43,8 @@ data class LocalChange(
   enum class Type(val value: Int) {
     INSERT(1), // create a new resource. payload is the entire resource json.
     UPDATE(2), // patch. payload is the json patch.
-    DELETE(3); // delete. payload is empty string.
+    DELETE(3), // delete. payload is empty string.
+    NO_OP(4); // no-op. Discard
 
     companion object {
       fun from(input: Int): Type = values().first { it.value == input }

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/BundleEntryComponentGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/BundleEntryComponentGenerator.kt
@@ -64,6 +64,7 @@ abstract class BundleEntryComponentGenerator(
             LocalChange.Type.UPDATE,
             LocalChange.Type.DELETE -> ifMatch = "W/\"${localChange.versionId}\""
             LocalChange.Type.INSERT -> {}
+            LocalChange.Type.NO_OP -> error("Cannot create a bundle from a NO_OP request")
           }
         }
       }

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/TransactionBundleGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/TransactionBundleGenerator.kt
@@ -30,7 +30,7 @@ open class TransactionBundleGenerator(
   private val generatedBundleSize: Int,
   private val useETagForUpload: Boolean,
   val getBundleEntryComponentGeneratorForLocalChangeType:
-    (type: Type, useETagForUpload: Boolean) -> BundleEntryComponentGenerator?
+    (type: Type, useETagForUpload: Boolean) -> BundleEntryComponentGenerator
 ) : UploadRequestGenerator {
 
   override fun generateUploadRequests(localChanges: List<LocalChange>): List<BundleUploadRequest> {
@@ -48,7 +48,7 @@ open class TransactionBundleGenerator(
           .filterNot { it.type == Type.NO_OP }
           .forEach {
             this.addEntry(
-              getBundleEntryComponentGeneratorForLocalChangeType(it.type, useETagForUpload)!!
+              getBundleEntryComponentGeneratorForLocalChangeType(it.type, useETagForUpload)
                 .getEntry(it)
             )
           }
@@ -93,12 +93,13 @@ open class TransactionBundleGenerator(
     private fun putForCreateAndPatchForUpdateBasedBundleComponentMapper(
       type: Type,
       useETagForUpload: Boolean
-    ): BundleEntryComponentGenerator? {
+    ): BundleEntryComponentGenerator {
       return when (type) {
         Type.INSERT -> HttpPutForCreateEntryComponentGenerator(useETagForUpload)
         Type.UPDATE -> HttpPatchForUpdateEntryComponentGenerator(useETagForUpload)
         Type.DELETE -> HttpDeleteEntryComponentGenerator(useETagForUpload)
-        Type.NO_OP -> null
+        Type.NO_OP ->
+          error("NO_OP type represents a no-operation and is not mapped to an HTTP operation.")
       }
     }
   }

--- a/engine/src/test/java/com/google/android/fhir/sync/upload/SquashedChangesUploadWorkManagerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/upload/SquashedChangesUploadWorkManagerTest.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.sync.upload
+
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
+import com.google.android.fhir.LocalChange
+import com.google.android.fhir.db.impl.dao.LocalChangeToken
+import com.google.android.fhir.db.impl.dao.LocalChangeUtils
+import com.google.android.fhir.db.impl.dao.toLocalChange
+import com.google.android.fhir.db.impl.entities.LocalChangeEntity
+import com.google.common.truth.Truth.assertThat
+import java.time.Instant
+import org.hl7.fhir.r4.model.HumanName
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.ResourceType
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SquashedChangesUploadWorkManagerTest {
+
+  private val jsonParser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
+
+  @Test
+  fun `prepareChangesForUpload should return no LocalChanges for same resource locally inserted and deleted`() {
+    val changes =
+      listOf(
+        LocalChangeEntity(
+            id = 1,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.INSERT,
+            payload =
+              FhirContext.forCached(FhirVersionEnum.R4)
+                .newJsonParser()
+                .encodeResourceToString(
+                  Patient().apply {
+                    id = "Patient-001"
+                    addName(
+                      HumanName().apply {
+                        addGiven("John")
+                        family = "Doe"
+                      }
+                    )
+                  }
+                ),
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(1)) },
+        LocalChangeEntity(
+            id = 2,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.DELETE,
+            payload = "",
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(2)) }
+      )
+    val patchToUpload = SquashedChangesUploadWorkManager().prepareChangesForUpload(changes)
+
+    assertThat(patchToUpload).hasSize(1)
+    assertThat(patchToUpload.first().type).isEqualTo(LocalChange.Type.NO_OP)
+  }
+
+  @Test
+  fun `prepareChangesForUpload should squash change to NO_OP if insert is followed by an update, then a delete`() {
+    val changes =
+      listOf(
+        LocalChangeEntity(
+            id = 1,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.INSERT,
+            payload =
+              FhirContext.forCached(FhirVersionEnum.R4)
+                .newJsonParser()
+                .encodeResourceToString(
+                  Patient().apply {
+                    id = "Patient-001"
+                    addName(
+                      HumanName().apply {
+                        addGiven("John")
+                        family = "Doe"
+                      }
+                    )
+                  }
+                ),
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(1)) },
+        LocalChangeEntity(
+            id = 2,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.UPDATE,
+            payload =
+              LocalChangeUtils.diff(
+                  jsonParser,
+                  Patient().apply {
+                    id = "Patient-001"
+                    addName(
+                      HumanName().apply {
+                        addGiven("Jane")
+                        family = "Doe"
+                      }
+                    )
+                  },
+                  Patient().apply {
+                    id = "Patient-001"
+                    addName(
+                      HumanName().apply {
+                        addGiven("Janet")
+                        family = "Doe"
+                      }
+                    )
+                  }
+                )
+                .toString(),
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(1)) },
+        LocalChangeEntity(
+            id = 3,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.DELETE,
+            payload = "",
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(3)) },
+      )
+    val patchToUpload = SquashedChangesUploadWorkManager().prepareChangesForUpload(changes)
+
+    assertThat(patchToUpload).hasSize(1)
+    assertThat(patchToUpload.first().type).isEqualTo(LocalChange.Type.NO_OP)
+  }
+
+  @Test
+  fun `prepareChangesForUpload should throw an error if a change is done after a resource is deleted locally`() {
+    val changes =
+      listOf(
+        LocalChangeEntity(
+            id = 1,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.INSERT,
+            payload =
+              FhirContext.forCached(FhirVersionEnum.R4)
+                .newJsonParser()
+                .encodeResourceToString(
+                  Patient().apply {
+                    id = "Patient-001"
+                    addName(
+                      HumanName().apply {
+                        addGiven("John")
+                        family = "Doe"
+                      }
+                    )
+                  }
+                ),
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(1)) },
+        LocalChangeEntity(
+            id = 2,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.DELETE,
+            payload = "",
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(2)) },
+        LocalChangeEntity(
+            id = 3,
+            resourceType = ResourceType.Patient.name,
+            resourceId = "Patient-001",
+            type = LocalChangeEntity.Type.UPDATE,
+            payload = "",
+            timestamp = Instant.now()
+          )
+          .toLocalChange()
+          .apply { LocalChangeToken(listOf(3)) }
+      )
+
+    val errorMessage =
+      assertThrows(IllegalArgumentException::class.java) {
+          SquashedChangesUploadWorkManager().prepareChangesForUpload(changes)
+        }
+        .localizedMessage
+
+    assertThat(errorMessage).isEqualTo("Cannot merge local changes with type NO_OP and UPDATE.")
+  }
+}


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #1951, #2031 

**Description**
Clear and concise code change description. 

  *  Introduced a new Type.NO_OP to represent no-operation actions.
   *  Modified the mergeLocalChanges function to recognize a local insert followed by a delete, converting the sequence into a Type.NO_OP.
   *  Added error handling for unexpected usage of Type.NO_OP within the merge context.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

PR #2111

**Type**
Choose one: (**Bug fix** | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
