### PR TITLE
Not exposing upload work manager to developers

### DIFF
--- a/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
+++ b/demo/src/main/java/com/google/android/fhir/demo/data/DemoFhirSyncWorker.kt
@@ -22,8 +22,6 @@ import com.google.android.fhir.demo.FhirApplication
 import com.google.android.fhir.sync.AcceptLocalConflictResolver
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.FhirSyncWorker
-import com.google.android.fhir.sync.UploadWorkManager
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 
 class DemoFhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
   FhirSyncWorker(appContext, workerParams) {
@@ -31,8 +29,6 @@ class DemoFhirSyncWorker(appContext: Context, workerParams: WorkerParameters) :
   override fun getDownloadWorkManager(): DownloadWorkManager {
     return TimestampBasedDownloadWorkManagerImpl(FhirApplication.dataStore(applicationContext))
   }
-
-  override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
 
   override fun getConflictResolver() = AcceptLocalConflictResolver
 

--- a/engine/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/FhirSyncWorkerBenchmark.kt
+++ b/engine/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/FhirSyncWorkerBenchmark.kt
@@ -35,8 +35,6 @@ import com.google.android.fhir.sync.AcceptRemoteConflictResolver
 import com.google.android.fhir.sync.DownloadRequest
 import com.google.android.fhir.sync.DownloadWorkManager
 import com.google.android.fhir.sync.FhirSyncWorker
-import com.google.android.fhir.sync.UploadWorkManager
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.common.truth.Truth.assertThat
 import java.math.BigDecimal
 import java.util.LinkedList
@@ -87,7 +85,6 @@ class FhirSyncWorkerBenchmark {
     }
     override fun getDownloadWorkManager(): DownloadWorkManager = BenchmarkTestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
   }
 
   open class BenchmarkTestDownloadManagerImpl(queries: List<String> = listOf("List/sync-list")) :

--- a/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
@@ -25,7 +25,6 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.google.android.fhir.FhirEngine
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
 import com.google.android.fhir.testing.TestFhirEngineImpl
@@ -53,7 +52,6 @@ class SyncInstrumentedTest {
     override fun getFhirEngine(): FhirEngine = TestFhirEngineImpl
     override fun getDataSource(): DataSource = TestDataSourceImpl
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
-    override fun getUploadWorkManager() = SquashedChangesUploadWorkManager()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
   }
 

--- a/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
@@ -25,6 +25,7 @@ import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.FhirEngineProvider
 import com.google.android.fhir.OffsetDateTimeTypeAdapter
 import com.google.android.fhir.sync.download.DownloaderImpl
+import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.android.fhir.sync.upload.UploaderImpl
 import com.google.gson.ExclusionStrategy
 import com.google.gson.FieldAttributes
@@ -43,7 +44,9 @@ abstract class FhirSyncWorker(appContext: Context, workerParams: WorkerParameter
   CoroutineWorker(appContext, workerParams) {
   abstract fun getFhirEngine(): FhirEngine
   abstract fun getDownloadWorkManager(): DownloadWorkManager
-  abstract fun getUploadWorkManager(): UploadWorkManager
+  private fun getUploadWorkManager(): UploadWorkManager {
+    return SquashedChangesUploadWorkManager()
+  }
   abstract fun getConflictResolver(): ConflictResolver
 
   private val gson =

--- a/engine/src/main/java/com/google/android/fhir/sync/UploadWorkManager.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/UploadWorkManager.kt
@@ -21,7 +21,7 @@ import com.google.android.fhir.LocalChange
 /**
  * Manager that pre-processes the local FHIR changes and handles how to upload them to the server.
  */
-interface UploadWorkManager {
+internal interface UploadWorkManager {
   /**
    * Transforms the [LocalChange]s to the final set of changes that needs to be uploaded to the
    * server. The transformations can be of various types like squashing the [LocalChange]s by

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/UploadRequestGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/UploadRequestGenerator.kt
@@ -20,7 +20,7 @@ import com.google.android.fhir.LocalChange
 import com.google.android.fhir.sync.UploadRequest
 
 /** Generator that generates [UploadRequest]s from the [LocalChange]s */
-interface UploadRequestGenerator {
+internal interface UploadRequestGenerator {
   /** Generates a list of [UploadRequest] from the [localChanges] */
   fun generateUploadRequests(localChanges: List<LocalChange>): List<UploadRequest>
 }

--- a/engine/src/test/java/com/google/android/fhir/sync/FhirSyncWorkerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/FhirSyncWorkerTest.kt
@@ -23,7 +23,6 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.google.android.fhir.FhirEngine
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
 import com.google.android.fhir.testing.TestFailingDatasource
@@ -47,7 +46,6 @@ class FhirSyncWorkerTest {
     override fun getDataSource(): DataSource = TestDataSourceImpl
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
   }
 
   class FailingPeriodicSyncWorker(appContext: Context, workerParams: WorkerParameters) :
@@ -57,7 +55,6 @@ class FhirSyncWorkerTest {
     override fun getDataSource(): DataSource = TestFailingDatasource
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
     override fun getConflictResolver() = AcceptRemoteConflictResolver
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
   }
 
   class FailingPeriodicSyncWorkerWithoutDataSource(
@@ -67,7 +64,6 @@ class FhirSyncWorkerTest {
 
     override fun getFhirEngine(): FhirEngine = TestFhirEngineImpl
     override fun getDownloadWorkManager() = TestDownloadManagerImpl()
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
     override fun getDataSource(): DataSource? = null
     override fun getConflictResolver() = AcceptRemoteConflictResolver
   }

--- a/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/SyncTest.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import androidx.work.BackoffPolicy
 import androidx.work.WorkerParameters
 import com.google.android.fhir.FhirEngine
-import com.google.android.fhir.sync.upload.SquashedChangesUploadWorkManager
 import com.google.android.fhir.testing.TestDataSourceImpl
 import com.google.android.fhir.testing.TestDownloadManagerImpl
 import com.google.android.fhir.testing.TestFhirEngineImpl
@@ -40,8 +39,6 @@ class SyncTest {
     override fun getFhirEngine(): FhirEngine = TestFhirEngineImpl
     override fun getDataSource(): DataSource = TestDataSourceImpl
     override fun getDownloadWorkManager(): DownloadWorkManager = TestDownloadManagerImpl()
-    override fun getUploadWorkManager(): UploadWorkManager = SquashedChangesUploadWorkManager()
-
     override fun getConflictResolver() = AcceptRemoteConflictResolver
   }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
We are undergoing a re-degin of the entire upload sync process which will be completed in various steps. To avoid modifying interfaces exposed to the developers in the interim, we are cutting off exposure to the modified interfaces. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)
feature
**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
