### PR TITLE
Add non empty check on asset file name.

### DIFF
--- a/catalog/src/main/java/com/google/android/fhir/catalog/ComponentListFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/ComponentListFragment.kt
@@ -103,10 +103,9 @@ class ComponentListFragment : Fragment(R.layout.component_list_fragment) {
                 getQuestionnaireJsonStringFromAssets(
                   context = requireContext(),
                   backgroundContext = coroutineContext,
-                  fileName = component.questionnaireFileWithValidation,
+                  fileName = it
                 )
-              }
-                ?: null,
+              },
             workflow = component.workflow
           )
         )

--- a/catalog/src/main/java/com/google/android/fhir/catalog/ComponentListFragment.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/ComponentListFragment.kt
@@ -99,11 +99,14 @@ class ComponentListFragment : Fragment(R.layout.component_list_fragment) {
                 fileName = component.questionnaireFile,
               ),
             questionnaireWithValidationJsonStringKey =
-              getQuestionnaireJsonStringFromAssets(
-                context = requireContext(),
-                backgroundContext = coroutineContext,
-                fileName = component.questionnaireFileWithValidation,
-              ),
+              component.questionnaireFileWithValidation?.let {
+                getQuestionnaireJsonStringFromAssets(
+                  context = requireContext(),
+                  backgroundContext = coroutineContext,
+                  fileName = component.questionnaireFileWithValidation,
+                )
+              }
+                ?: null,
             workflow = component.workflow
           )
         )

--- a/catalog/src/main/java/com/google/android/fhir/catalog/ComponentListViewModel.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/ComponentListViewModel.kt
@@ -44,7 +44,7 @@ class ComponentListViewModel(application: Application, private val state: SavedS
      * Path to the questionnaire json file with some or all required fields. If the user doesn't
      * answer the required questions, an error may be displayed on the particular question.
      */
-    val questionnaireFileWithValidation: String = "",
+    val questionnaireFileWithValidation: String? = null,
     val workflow: WorkflowType = WorkflowType.COMPONENT
   ) {
     BOOLEAN_CHOICE(

--- a/catalog/src/main/java/com/google/android/fhir/catalog/QuestionnaireFileOperationUtil.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/QuestionnaireFileOperationUtil.kt
@@ -28,7 +28,11 @@ suspend fun getQuestionnaireJsonStringFromAssets(
   fileName: String
 ): String {
   return withContext(backgroundContext) {
-    context.assets.open(fileName).bufferedReader().use { it.readText() }
+    if (fileName.isNotEmpty()) {
+      context.assets.open(fileName).bufferedReader().use { it.readText() }
+    } else {
+      ""
+    }
   }
 }
 

--- a/catalog/src/main/java/com/google/android/fhir/catalog/QuestionnaireFileOperationUtil.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/QuestionnaireFileOperationUtil.kt
@@ -26,12 +26,12 @@ suspend fun getQuestionnaireJsonStringFromAssets(
   context: Context,
   backgroundContext: CoroutineContext,
   fileName: String
-): String {
+): String? {
   return withContext(backgroundContext) {
     if (fileName.isNotEmpty()) {
       context.assets.open(fileName).bufferedReader().use { it.readText() }
     } else {
-      ""
+      null
     }
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2151 

**Description**
Miscellaneous components do not have a questionnaire with a validation JSON as compared to other components. As a result, it gives the filename as an empty string from the adapter. This leads to a crash when it attempts to perform a file open operation on an empty string. To prevent this, a non-empty check has been added before performing a file operation on the asset filename

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix )

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
