### PR TITLE
Very significantly increase CI VM CPU Cores, RAM & disk (re. #2197)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
   # Build will compile APK, test APK and run tests, lint, etc.
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-64core
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
This increases the size of the VM [used for CI](https://github.com/google/android-fhir/actions/workflows/build.yml) jobs runs from [GitHub's default](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) from / to:

* 2-core => 64-cores CPU
* 7 GB => 256 GB RAM
* 14 GB => 2040 GB of SSD space

This should fix the `Error: The operation was canceled` problem described in issue #2197.

This is a worthwhile trade off of expensive engineering time VS infrastructure cost. Thank You Sundar for paying for this to enable this project to productively produce an Open Health Stack!

**Alternative(s) considered**
_Have you considered any alternatives? And if so, why have you chosen the approach in this PR?_ The alternative is to spend expensive human engineering time. This is rarely a good tradeoff.

**Type**
Choose one: **Bug fix** ~| Feature | Documentation | Testing | Code health | Builds | Releases | Other~