### PR TITLE
Add resource UUID to LocalChangeEntity, fixing changing UUID issue for the same resource 

### DIFF
--- a/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/7.json
+++ b/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/7.json
@@ -1,0 +1,957 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "f06ae2e84f7588be59916d32f8d5a6e4",
+    "entities": [
+      {
+        "tableName": "ResourceEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `resourceId` TEXT NOT NULL, `serializedResource` TEXT NOT NULL, `versionId` TEXT, `lastUpdatedRemote` INTEGER, `lastUpdatedLocal` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceId",
+            "columnName": "resourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serializedResource",
+            "columnName": "serializedResource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedRemote",
+            "columnName": "lastUpdatedRemote",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedLocal",
+            "columnName": "lastUpdatedLocal",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ResourceEntity_resourceUuid",
+            "unique": true,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ResourceEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          },
+          {
+            "name": "index_ResourceEntity_resourceType_resourceId",
+            "unique": true,
+            "columnNames": [
+              "resourceType",
+              "resourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ResourceEntity_resourceType_resourceId` ON `${TABLE_NAME}` (`resourceType`, `resourceId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "StringIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_StringIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StringIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_StringIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StringIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ReferenceIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReferenceIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReferenceIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_ReferenceIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReferenceIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TokenIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_system` TEXT, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.system",
+            "columnName": "index_system",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TokenIndexEntity_resourceType_index_name_index_system_index_value_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_system",
+              "index_value",
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceType_index_name_index_system_index_value_resourceUuid` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_system`, `index_value`, `resourceUuid`)"
+          },
+          {
+            "name": "index_TokenIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TokenIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "QuantityIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_system` TEXT NOT NULL, `index_code` TEXT NOT NULL, `index_value` REAL NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.system",
+            "columnName": "index_system",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.code",
+            "columnName": "index_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_QuantityIndexEntity_resourceType_index_name_index_value_index_code",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value",
+              "index_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_QuantityIndexEntity_resourceType_index_name_index_value_index_code` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`, `index_code`)"
+          },
+          {
+            "name": "index_QuantityIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_QuantityIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "UriIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` TEXT NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_UriIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_UriIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_UriIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_UriIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "DateIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_from` INTEGER NOT NULL, `index_to` INTEGER NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.from",
+            "columnName": "index_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.to",
+            "columnName": "index_to",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_DateIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "resourceUuid",
+              "index_from",
+              "index_to"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
+          },
+          {
+            "name": "index_DateIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "DateTimeIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_from` INTEGER NOT NULL, `index_to` INTEGER NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.from",
+            "columnName": "index_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.to",
+            "columnName": "index_to",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_DateTimeIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "resourceUuid",
+              "index_from",
+              "index_to"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceType_index_name_resourceUuid_index_from_index_to` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `resourceUuid`, `index_from`, `index_to`)"
+          },
+          {
+            "name": "index_DateTimeIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DateTimeIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NumberIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_name` TEXT NOT NULL, `index_path` TEXT NOT NULL, `index_value` REAL NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.name",
+            "columnName": "index_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.path",
+            "columnName": "index_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.value",
+            "columnName": "index_value",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_NumberIndexEntity_resourceType_index_name_index_value",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_name",
+              "index_value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NumberIndexEntity_resourceType_index_name_index_value` ON `${TABLE_NAME}` (`resourceType`, `index_name`, `index_value`)"
+          },
+          {
+            "name": "index_NumberIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NumberIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LocalChangeEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceType` TEXT NOT NULL, `resourceId` TEXT NOT NULL, `resourceUuid` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, `type` INTEGER NOT NULL, `payload` TEXT NOT NULL, `versionId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceId",
+            "columnName": "resourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LocalChangeEntity_resourceType_resourceId",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "resourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceId` ON `${TABLE_NAME}` (`resourceType`, `resourceId`)"
+          },
+          {
+            "name": "index_LocalChangeEntity_resourceType_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceUuid` ON `${TABLE_NAME}` (`resourceType`, `resourceUuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PositionIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceUuid` BLOB NOT NULL, `resourceType` TEXT NOT NULL, `index_latitude` REAL NOT NULL, `index_longitude` REAL NOT NULL, FOREIGN KEY(`resourceUuid`) REFERENCES `ResourceEntity`(`resourceUuid`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceUuid",
+            "columnName": "resourceUuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceType",
+            "columnName": "resourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.latitude",
+            "columnName": "index_latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index.longitude",
+            "columnName": "index_longitude",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PositionIndexEntity_resourceType_index_latitude_index_longitude",
+            "unique": false,
+            "columnNames": [
+              "resourceType",
+              "index_latitude",
+              "index_longitude"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PositionIndexEntity_resourceType_index_latitude_index_longitude` ON `${TABLE_NAME}` (`resourceType`, `index_latitude`, `index_longitude`)"
+          },
+          {
+            "name": "index_PositionIndexEntity_resourceUuid",
+            "unique": false,
+            "columnNames": [
+              "resourceUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PositionIndexEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ResourceEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "resourceUuid"
+            ],
+            "referencedColumns": [
+              "resourceUuid"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f06ae2e84f7588be59916d32f8d5a6e4')"
+    ]
+  }
+}

--- a/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/7.json
+++ b/engine/schemas/com.google.android.fhir.db.impl.ResourceDatabase/7.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 7,
-    "identityHash": "f06ae2e84f7588be59916d32f8d5a6e4",
+    "identityHash": "112cd4c5acec0220c1a0298571087d0d",
     "entities": [
       {
         "tableName": "ResourceEntity",
@@ -858,14 +858,13 @@
             "createSql": "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceId` ON `${TABLE_NAME}` (`resourceType`, `resourceId`)"
           },
           {
-            "name": "index_LocalChangeEntity_resourceType_resourceUuid",
+            "name": "index_LocalChangeEntity_resourceUuid",
             "unique": false,
             "columnNames": [
-              "resourceType",
               "resourceUuid"
             ],
             "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceUuid` ON `${TABLE_NAME}` (`resourceType`, `resourceUuid`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceUuid` ON `${TABLE_NAME}` (`resourceUuid`)"
           }
         ],
         "foreignKeys": []
@@ -951,7 +950,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f06ae2e84f7588be59916d32f8d5a6e4')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '112cd4c5acec0220c1a0298571087d0d')"
     ]
   }
 }

--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
@@ -468,6 +468,21 @@ class DatabaseImplTest {
   }
 
   @Test
+  fun insert_existingRemoteResource_shouldNotChangeResourceEntityUuidOrId() = runBlocking {
+    val patient: Patient = readFromFile(Patient::class.java, "/date_test_patient.json")
+    database.insertRemote(patient)
+    val patientEntityAfterFirstRemoteSync =
+      database.selectEntity(ResourceType.Patient, patient.logicalId)
+    database.insertRemote(patient)
+    val patientEntityAfterSecondRemoteSync =
+      database.selectEntity(ResourceType.Patient, patient.logicalId)
+    assertThat(patientEntityAfterSecondRemoteSync.resourceUuid)
+      .isEqualTo(patientEntityAfterFirstRemoteSync.resourceUuid)
+    assertThat(patientEntityAfterSecondRemoteSync.id)
+      .isEqualTo(patientEntityAfterFirstRemoteSync.id)
+  }
+
+  @Test
   fun insert_remoteResource_shouldSaveVersionIdAndLastUpdated() = runBlocking {
     val patient =
       Patient().apply {

--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/ResourceDatabaseMigrationTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/ResourceDatabaseMigrationTest.kt
@@ -70,13 +70,13 @@ class ResourceDatabaseMigrationTest {
     val migratedDatabase = helper.runMigrationsAndValidate(DB_NAME, 2, true, MIGRATION_1_2)
 
     val readPatientJson: String?
-    migratedDatabase.apply {
-      query("SELECT serializedResource FROM ResourceEntity").let {
+    migratedDatabase.let { database ->
+      database.query("SELECT serializedResource FROM ResourceEntity").let {
         it.moveToFirst()
         readPatientJson = it.getString(0)
       }
     }
-
+    migratedDatabase.close()
     assertThat(readPatientJson).isEqualTo(insertedPatientJson)
   }
 
@@ -104,13 +104,13 @@ class ResourceDatabaseMigrationTest {
     val migratedDatabase = helper.runMigrationsAndValidate(DB_NAME, 3, true, MIGRATION_2_3)
 
     val retrievedTask: String?
-    migratedDatabase.apply {
-      query("SELECT serializedResource FROM ResourceEntity").let {
+    migratedDatabase.let { database ->
+      database.query("SELECT serializedResource FROM ResourceEntity").let {
         it.moveToFirst()
         retrievedTask = it.getString(0)
       }
     }
-
+    migratedDatabase.close()
     assertThat(retrievedTask).isEqualTo(bedNetTask)
   }
 
@@ -138,13 +138,13 @@ class ResourceDatabaseMigrationTest {
     val migratedDatabase = helper.runMigrationsAndValidate(DB_NAME, 4, true, MIGRATION_3_4)
 
     val retrievedTask: String?
-    migratedDatabase.apply {
-      query("SELECT serializedResource FROM ResourceEntity").let {
+    migratedDatabase.let { database ->
+      database.query("SELECT serializedResource FROM ResourceEntity").let {
         it.moveToFirst()
         retrievedTask = it.getString(0)
       }
     }
-
+    migratedDatabase.close()
     assertThat(retrievedTask).isEqualTo(bedNetTask)
   }
 
@@ -171,13 +171,13 @@ class ResourceDatabaseMigrationTest {
     val migratedDatabase = helper.runMigrationsAndValidate(DB_NAME, 5, true, MIGRATION_4_5)
 
     val retrievedTask: String?
-    migratedDatabase.apply {
-      query("SELECT serializedResource FROM ResourceEntity").let {
+    migratedDatabase.let { database ->
+      database.query("SELECT serializedResource FROM ResourceEntity").let {
         it.moveToFirst()
         retrievedTask = it.getString(0)
       }
     }
-
+    migratedDatabase.close()
     assertThat(retrievedTask).isEqualTo(bedNetTask)
   }
 
@@ -218,26 +218,26 @@ class ResourceDatabaseMigrationTest {
     val resourceEntityLastUpdatedLocal: Long
     val localChangeEntityCorruptedTimeStamp: Long
 
-    migratedDatabase.apply {
-      query("SELECT serializedResource FROM ResourceEntity").let {
+    migratedDatabase.let { database ->
+      database.query("SELECT serializedResource FROM ResourceEntity").let {
         it.moveToFirst()
         retrievedTask = it.getString(0)
       }
 
       resourceEntityLastUpdatedLocal =
-        query("Select lastUpdatedLocal from ResourceEntity").let {
+        database.query("Select lastUpdatedLocal from ResourceEntity").let {
           it.moveToFirst()
           it.getLong(0)
         }
 
-      query("SELECT timestamp FROM LocalChangeEntity").let {
+      database.query("SELECT timestamp FROM LocalChangeEntity").let {
         it.moveToFirst()
         localChangeEntityTimeStamp = it.getLong(0)
         it.moveToNext()
         localChangeEntityCorruptedTimeStamp = it.getLong(0)
       }
     }
-
+    migratedDatabase.close()
     assertThat(retrievedTask).isEqualTo(bedNetTask)
     assertThat(localChangeEntityTimeStamp).isEqualTo(resourceEntityLastUpdatedLocal)
     assertThat(Instant.ofEpochMilli(localChangeEntityCorruptedTimeStamp)).isEqualTo(Instant.EPOCH)
@@ -275,20 +275,20 @@ class ResourceDatabaseMigrationTest {
     val localChangeResourceUuid: String?
     val localChangeResourceId: String?
 
-    migratedDatabase.apply {
-      query("SELECT resourceId, resourceUuid FROM ResourceEntity").let {
+    migratedDatabase.let { database ->
+      database.query("SELECT resourceId, resourceUuid FROM ResourceEntity").let {
         it.moveToFirst()
         retrievedTaskResourceId = it.getString(0)
         retrievedTaskResourceUuid = String(it.getBlob(1), Charsets.UTF_8)
       }
 
-      query("SELECT resourceId,resourceUuid FROM LocalChangeEntity").let {
+      database.query("SELECT resourceId,resourceUuid FROM LocalChangeEntity").let {
         it.moveToFirst()
         localChangeResourceId = it.getString(0)
         localChangeResourceUuid = String(it.getBlob(1), Charsets.UTF_8)
       }
     }
-
+    migratedDatabase.close()
     assertThat(retrievedTaskResourceUuid).isEqualTo(localChangeResourceUuid)
     assertThat(localChangeResourceId).isEqualTo(retrievedTaskResourceId)
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
@@ -122,10 +122,9 @@ internal class DatabaseImpl(
       logicalIds.addAll(
         resource.map {
           val timeOfLocalChange = Instant.now()
-          val resourceId = resourceDao.insertLocalResource(it, timeOfLocalChange)
-          val resourceEntity = selectEntity(it.resourceType, it.logicalId)
-          localChangeDao.addInsert(it, resourceEntity.resourceUuid, timeOfLocalChange)
-          resourceId
+          val resourceUuid = resourceDao.insertLocalResource(it, timeOfLocalChange)
+          localChangeDao.addInsert(it, resourceUuid, timeOfLocalChange)
+          it.logicalId
         },
       )
     }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
@@ -95,7 +95,14 @@ internal class DatabaseImpl(
             }
           }
 
-          addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+          addMigrations(
+            MIGRATION_1_2,
+            MIGRATION_2_3,
+            MIGRATION_3_4,
+            MIGRATION_4_5,
+            MIGRATION_5_6,
+            MIGRATION_6_7,
+          )
         }
         .build()
   }
@@ -115,8 +122,10 @@ internal class DatabaseImpl(
       logicalIds.addAll(
         resource.map {
           val timeOfLocalChange = Instant.now()
-          localChangeDao.addInsert(it, timeOfLocalChange)
-          resourceDao.insertLocalResource(it, timeOfLocalChange)
+          val resourceId = resourceDao.insertLocalResource(it, timeOfLocalChange)
+          val resourceEntity = selectEntity(it.resourceType, it.logicalId)
+          localChangeDao.addInsert(it, resourceEntity.resourceUuid, timeOfLocalChange)
+          resourceId
         },
       )
     }
@@ -169,19 +178,16 @@ internal class DatabaseImpl(
 
   override suspend fun delete(type: ResourceType, id: String) {
     db.withTransaction {
-      val remoteVersionId: String? =
-        try {
-          selectEntity(type, id).versionId
-        } catch (e: ResourceNotFoundException) {
-          null
+      resourceDao.getResourceEntity(id, type)?.let {
+        val rowsDeleted = resourceDao.deleteResource(resourceId = id, resourceType = type)
+        if (rowsDeleted > 0) {
+          localChangeDao.addDelete(
+            resourceId = id,
+            resourceType = type,
+            resourceUuid = it.resourceUuid,
+            remoteVersionId = it.versionId,
+          )
         }
-      val rowsDeleted = resourceDao.deleteResource(resourceId = id, resourceType = type)
-      if (rowsDeleted > 0) {
-        localChangeDao.addDelete(
-          resourceId = id,
-          resourceType = type,
-          remoteVersionId = remoteVersionId,
-        )
       }
     }
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
@@ -145,7 +145,7 @@ val MIGRATION_6_7 =
         "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceId` ON `LocalChangeEntity` (`resourceType`, `resourceId`)",
       )
       database.execSQL(
-        "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceUuid` ON `LocalChangeEntity` (`resourceType`, `resourceUuid`)",
+        "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceUuid` ON `LocalChangeEntity` (`resourceUuid`)",
       )
     }
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/ResourceDatabase.kt
@@ -50,7 +50,7 @@ import com.google.android.fhir.db.impl.entities.UriIndexEntity
       LocalChangeEntity::class,
       PositionIndexEntity::class,
     ],
-  version = 6,
+  version = 7,
   exportSchema = true,
 )
 @TypeConverters(DbTypeConverters::class)
@@ -124,6 +124,28 @@ val MIGRATION_5_6 =
       database.execSQL("ALTER TABLE `_new_LocalChangeEntity` RENAME TO `LocalChangeEntity`")
       database.execSQL(
         "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceId` ON `LocalChangeEntity` (`resourceType`, `resourceId`)",
+      )
+    }
+  }
+
+/** Add column resourceUuid in [LocalChangeEntity] */
+val MIGRATION_6_7 =
+  object : Migration(6, 7) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+      database.execSQL(
+        "CREATE TABLE IF NOT EXISTS `_new_LocalChangeEntity` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resourceType` TEXT NOT NULL, `resourceId` TEXT NOT NULL, `resourceUuid` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, `type` INTEGER NOT NULL, `payload` TEXT NOT NULL, `versionId` TEXT)",
+      )
+      database.execSQL(
+        "INSERT INTO `_new_LocalChangeEntity` (`id`,`resourceType`,`resourceId`,`resourceUuid`,`timestamp`,`type`,`payload`,`versionId`) " +
+          "SELECT localChange.id, localChange.resourceType, localChange.resourceId, resource.resourceUuid, localChange.timestamp, localChange.type, localChange.payload, localChange.versionId FROM `LocalChangeEntity` localChange LEFT JOIN ResourceEntity resource ON localChange.resourceId= resource.resourceId",
+      )
+      database.execSQL("DROP TABLE `LocalChangeEntity`")
+      database.execSQL("ALTER TABLE `_new_LocalChangeEntity` RENAME TO `LocalChangeEntity`")
+      database.execSQL(
+        "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceId` ON `LocalChangeEntity` (`resourceType`, `resourceId`)",
+      )
+      database.execSQL(
+        "CREATE INDEX IF NOT EXISTS `index_LocalChangeEntity_resourceType_resourceUuid` ON `LocalChangeEntity` (`resourceType`, `resourceUuid`)",
       )
     }
   }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -183,8 +183,9 @@ internal abstract class ResourceDao {
   suspend fun insertLocalResource(resource: Resource, timeOfChange: Instant) =
     insertResource(resource, timeOfChange)
 
-  // Since the insert removes any old indexes and lastUpdatedLocal (data not contained in resource
-  // itself), we extract the lastUpdatedLocal if any and then set it back again.
+  // Check if the resource already exists using its logical ID, if it does, we just update the
+  // existing [ResourceEntity]
+  // Else, we insert with a new [ResourceEntity]
   private suspend fun insertRemoteResource(resource: Resource): UUID {
     val existingResourceEntity = getResourceEntity(resource.logicalId, resource.resourceType)
     if (existingResourceEntity != null) {

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/LocalChangeEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/LocalChangeEntity.kt
@@ -20,6 +20,7 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import java.time.Instant
+import java.util.UUID
 
 /**
  * When a local change to a resource happens, the lastUpdated timestamp in [ResourceEntity] is
@@ -55,11 +56,18 @@ import java.time.Instant
  *
  * ] For resource that is fully synced with server this table should not have any rows.
  */
-@Entity(indices = [Index(value = ["resourceType", "resourceId"])])
+@Entity(
+  indices =
+    [
+      Index(value = ["resourceType", "resourceId"]),
+      Index(value = ["resourceType", "resourceUuid"]),
+    ],
+)
 internal data class LocalChangeEntity(
   @PrimaryKey(autoGenerate = true) val id: Long,
   val resourceType: String,
   val resourceId: String,
+  val resourceUuid: UUID,
   val timestamp: Instant,
   val type: Type,
   val payload: String,

--- a/engine/src/main/java/com/google/android/fhir/db/impl/entities/LocalChangeEntity.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/entities/LocalChangeEntity.kt
@@ -60,7 +60,7 @@ import java.util.UUID
   indices =
     [
       Index(value = ["resourceType", "resourceId"]),
-      Index(value = ["resourceType", "resourceUuid"]),
+      Index(value = ["resourceUuid"]),
     ],
 )
 internal data class LocalChangeEntity(

--- a/engine/src/test/java/com/google/android/fhir/LocalChangeTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/LocalChangeTest.kt
@@ -22,6 +22,7 @@ import ca.uhn.fhir.parser.IParser
 import com.google.android.fhir.db.impl.entities.LocalChangeEntity
 import com.google.common.truth.Truth.assertThat
 import java.time.Instant
+import java.util.UUID
 import junit.framework.TestCase
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.HumanName
@@ -42,6 +43,7 @@ class LocalChangeTest : TestCase() {
       LocalChangeEntity(
         id = 1,
         resourceType = ResourceType.Patient.name,
+        resourceUuid = UUID.randomUUID(),
         resourceId = "Patient-001",
         type = LocalChangeEntity.Type.INSERT,
         payload =

--- a/engine/src/test/java/com/google/android/fhir/sync/upload/UploaderImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/upload/UploaderImplTest.kt
@@ -25,6 +25,7 @@ import com.google.android.fhir.toLocalChange
 import com.google.common.truth.Truth.assertThat
 import java.net.ConnectException
 import java.time.Instant
+import java.util.UUID
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.Bundle
@@ -133,6 +134,7 @@ class UploaderImplTest {
         LocalChangeEntity(
             id = 1,
             resourceType = ResourceType.Patient.name,
+            resourceUuid = UUID.randomUUID(),
             resourceId = "Patient-001",
             type = LocalChangeEntity.Type.INSERT,
             payload =

--- a/engine/src/test/java/com/google/android/fhir/sync/upload/patch/PerResourcePatchGeneratorTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/upload/patch/PerResourcePatchGeneratorTest.kt
@@ -32,6 +32,7 @@ import com.google.android.fhir.versionId
 import com.google.common.truth.Truth.assertThat
 import java.time.Instant
 import java.util.Date
+import java.util.UUID
 import org.hl7.fhir.r4.model.HumanName
 import org.hl7.fhir.r4.model.Meta
 import org.hl7.fhir.r4.model.Patient
@@ -135,6 +136,7 @@ class PerResourcePatchGeneratorTest {
             id = 1,
             resourceType = ResourceType.Patient.name,
             resourceId = "Patient-001",
+            resourceUuid = UUID.randomUUID(),
             type = LocalChangeEntity.Type.INSERT,
             payload =
               FhirContext.forCached(FhirVersionEnum.R4)
@@ -158,6 +160,7 @@ class PerResourcePatchGeneratorTest {
             id = 2,
             resourceType = ResourceType.Patient.name,
             resourceId = "Patient-001",
+            resourceUuid = UUID.randomUUID(),
             type = LocalChangeEntity.Type.DELETE,
             payload = "",
             timestamp = Instant.now(),
@@ -178,6 +181,7 @@ class PerResourcePatchGeneratorTest {
             id = 1,
             resourceType = ResourceType.Patient.name,
             resourceId = "Patient-001",
+            resourceUuid = UUID.randomUUID(),
             type = LocalChangeEntity.Type.INSERT,
             payload =
               FhirContext.forCached(FhirVersionEnum.R4)
@@ -201,6 +205,7 @@ class PerResourcePatchGeneratorTest {
             id = 2,
             resourceType = ResourceType.Patient.name,
             resourceId = "Patient-001",
+            resourceUuid = UUID.randomUUID(),
             type = LocalChangeEntity.Type.UPDATE,
             payload =
               diff(
@@ -233,6 +238,7 @@ class PerResourcePatchGeneratorTest {
             id = 3,
             resourceType = ResourceType.Patient.name,
             resourceId = "Patient-001",
+            resourceUuid = UUID.randomUUID(),
             type = LocalChangeEntity.Type.DELETE,
             payload = "",
             timestamp = Instant.now(),
@@ -314,6 +320,7 @@ class PerResourcePatchGeneratorTest {
             resourceId = "Patient-001",
             type = LocalChangeEntity.Type.DELETE,
             payload = "",
+            resourceUuid = UUID.randomUUID(),
             timestamp = Instant.now(),
           )
           .toLocalChange()
@@ -324,6 +331,7 @@ class PerResourcePatchGeneratorTest {
             resourceId = "Patient-001",
             type = LocalChangeEntity.Type.UPDATE,
             payload = "",
+            resourceUuid = UUID.randomUUID(),
             timestamp = Instant.now(),
           )
           .toLocalChange()
@@ -349,6 +357,7 @@ class PerResourcePatchGeneratorTest {
             resourceId = "Patient-001",
             type = LocalChangeEntity.Type.UPDATE,
             payload = "",
+            resourceUuid = UUID.randomUUID(),
             timestamp = Instant.now(),
           )
           .toLocalChange()
@@ -357,6 +366,7 @@ class PerResourcePatchGeneratorTest {
             id = 1,
             resourceType = ResourceType.Patient.name,
             resourceId = "Patient-001",
+            resourceUuid = UUID.randomUUID(),
             type = LocalChangeEntity.Type.INSERT,
             payload =
               FhirContext.forCached(FhirVersionEnum.R4)


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2209 

**Description**
- We need to LocalChangeEntity agnostic of the resource ID as there can be cases where the resource ID of a resource might change (POST for creation). In such cases we can use resource UUID to keep the mapping between the resource and LocalChanges intact.
- Fixing the `ResourceDatabaseMigrationTest` to use the migrated database for the particular implemented migration to run assertions
- There are cases where in download of a resource which already exists in the database leads to new resource UUID being assigned to the same resource. Hence we need to keep the same resource UUID as the previous version in such cases

**Alternative(s) considered**
One alternative in the first scenario was to just keep the resourceUuid and remove resourceId. However, when LocalChanges are uploaded to the server, we would need to look up the ResourceEntity using the resourceUuid in the LocalChangeEntity to obtain the server recognisable identifier of the resource. This would be a problem in case of deleted resources, where in for any LocalChange of a resource that has been deleted, we would not be able to find the corresponding ResourceEntity. Hence, keeping resourceId is also crucial

**Type**
Choose one:  Feature
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
