### PR TITLE
UnpackReapted Groups Fix for single group item

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -100,22 +100,27 @@ private fun unpackRepeatedGroups(
   questionnaireItem: Questionnaire.QuestionnaireItemComponent,
   questionnaireResponseItem: QuestionnaireResponse.QuestionnaireResponseItemComponent,
 ): List<QuestionnaireResponse.QuestionnaireResponseItemComponent> {
-  questionnaireResponseItem.item =
-    unpackRepeatedGroups(questionnaireItem.item, questionnaireResponseItem.item)
-  questionnaireResponseItem.answer.forEach {
-    it.item = unpackRepeatedGroups(questionnaireItem.item, it.item)
-  }
-  return if (
-    questionnaireItem.type == Questionnaire.QuestionnaireItemType.GROUP && questionnaireItem.repeats
-  ) {
-    questionnaireResponseItem.answer.map {
-      QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-        linkId = questionnaireItem.linkId
-        text = questionnaireItem.localizedTextSpanned?.toString()
-        item = it.item
+  if (questionnaireResponseItem.hasAnswer()) {
+    questionnaireResponseItem.item =
+      unpackRepeatedGroups(questionnaireItem.item, questionnaireResponseItem.item)
+    questionnaireResponseItem.answer.forEach {
+      it.item = unpackRepeatedGroups(questionnaireItem.item, it.item)
+    }
+    return if (
+      questionnaireItem.type == Questionnaire.QuestionnaireItemType.GROUP &&
+        questionnaireItem.repeats
+    ) {
+      questionnaireResponseItem.answer.map {
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          linkId = questionnaireItem.linkId
+          text = questionnaireItem.localizedTextSpanned?.toString()
+          item = it.item
+        }
       }
+    } else {
+      listOf(questionnaireResponseItem)
     }
   } else {
-    listOf(questionnaireResponseItem)
+    return listOf(questionnaireResponseItem)
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
@@ -22,11 +22,13 @@ import com.google.common.truth.Truth.assertThat
 import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemInitialComponent
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
 import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.Resource
+import org.hl7.fhir.r4.model.StringType
 import org.junit.Test
 
 class MoreQuestionnaireResponsesTest {
@@ -403,6 +405,61 @@ class MoreQuestionnaireResponsesTest {
         )
       }
 
+    questionnaireResponse.unpackRepeatedGroups(questionnaire)
+    assertResourceEquals(questionnaireResponse, unpackedQuestionnaireResponse)
+  }
+
+  @Test
+  fun `should unpack correctly for only one group`() {
+    val questionnaire =
+      Questionnaire().apply {
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "group-item"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            repeats = true
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-item"
+                type = Questionnaire.QuestionnaireItemType.STRING
+                initial = listOf(QuestionnaireItemInitialComponent().setValue(StringType("ABC")))
+              },
+            )
+          },
+        )
+      }
+    val questionnaireResponse =
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponseItemComponent().apply {
+            linkId = "group-item"
+            addItem(
+              QuestionnaireResponseItemComponent().apply {
+                linkId = "nested-item"
+                addAnswer(
+                  QuestionnaireResponseItemAnswerComponent().setValue(StringType("Sample Answer")),
+                )
+              },
+            )
+          },
+        )
+      }
+    val unpackedQuestionnaireResponse =
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponseItemComponent().apply {
+            linkId = "group-item"
+            addItem(
+              QuestionnaireResponseItemComponent().apply {
+                linkId = "nested-item"
+                addAnswer(
+                  QuestionnaireResponseItemAnswerComponent().setValue(StringType("Sample Answer")),
+                )
+              },
+            )
+          },
+        )
+      }
     questionnaireResponse.unpackRepeatedGroups(questionnaire)
     assertResourceEquals(questionnaireResponse, unpackedQuestionnaireResponse)
   }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2162

**Description**
Consider a scenario where there is a questionnaire with one questionnaire item whose type is group and repeats is set to true for the same.

```
{
  "resourceType": "Questionnaire",
  "item": [
    {
      "type": "group",
      "linkId": "parent-item",
      "text": "Parent Group Item",
      "repeats": true,
      "item": [
        {
          "linkId": "1",
          "type": "string",
          "text": "Personal information",
          "initial": [
            {
              "valueString": "ABC"
            }
          ]
        }
      ]
    }
  ]
}
```

In this case if only group item is answered then questionnaire response returned is with empty item list like following:

```
{
  "resourceType": "QuestionnaireResponse",
  "item": [
    {
      "linkId": "parent-item",
      "text": "Parent Group Item",
      "item": [
        {
          "linkId": "1",
          "text": "Personal information",
          "answer": [
            {
              "valueString": "ABC"
            }
          ]
        }
      ]
    }
  ]
}
```

But if there are more than one group items being answered in the questionnaire then the questionnaire response is proper.
To fix this issue if there are more than one repeated group items in the questionnaire response then do the recursive unpacking logic or else if there is only one group item in the questionnaire response then do not do the unpacking of repeated groups instead return the group item.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug Fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
