### PR TITLE
Bump com.android.tools.build:gradle from 8.1.1 to 8.1.2

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 dependencies {
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.21.0")
 
-  implementation("com.android.tools.build:gradle:8.1.1")
+  implementation("com.android.tools.build:gradle:8.1.2")
 
   implementation("app.cash.licensee:licensee-gradle-plugin:1.3.0")
   implementation("com.osacky.flank.gradle:fladle:0.17.4")


### PR DESCRIPTION
This was automatically proposed when I opened this project in Android Studio today.