### PR TITLE
Add initial docs/index.html (re. #2232)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+
+<h1>Android FHIR SDK Technical Documentation</h1>
+
+<h2>API Docs</h2>
+<ul>
+  <li><a href="engine/">engine</a></li>
+  <li><a href="data-capture/">data-capture</a></li>
+  <li><a href="workflow/">workflow</a></li>
+</ul>  
+
+</body>
+</html>


### PR DESCRIPTION
Related to #2232

This is just a very small start which will (should) make https://google.github.io/android-fhir/ not be a 404.

I have ideas for (much) more to come here, later.