### PR TITLE
SdkSuppress FhirSyncWorkerBenchmark oneTimeSync_50patients (re. #2235)

### DIFF
--- a/engine/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/FhirSyncWorkerBenchmark.kt
+++ b/engine/benchmark/src/androidTest/java/com/google/android/fhir/benchmark/FhirSyncWorkerBenchmark.kt
@@ -21,6 +21,7 @@ import androidx.benchmark.junit4.BenchmarkRule
 import androidx.benchmark.junit4.measureRepeated
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
@@ -127,7 +128,9 @@ class FhirSyncWorkerBenchmark {
 
   @Test fun oneTimeSync_10patients() = oneTimeSync(10, 5, 5)
 
-  @Test fun oneTimeSync_50patients() = oneTimeSync(50, 5, 5)
+  @Test
+  @SdkSuppress // TODO https://github.com/google/android-fhir/issues/2235 FIXME
+  fun oneTimeSync_50patients() = oneTimeSync(50, 5, 5)
 
   private fun oneTimeSync(numberPatients: Int, numberObservations: Int, numberEncounters: Int) =
     runBlocking {


### PR DESCRIPTION
Related to #2235.