### PR TITLE
Moves commons to HAPI 6.8, removes caffeine and forces guava-android

### DIFF
--- a/buildSrc/src/main/kotlin/LicenseeConfig.kt
+++ b/buildSrc/src/main/kotlin/LicenseeConfig.kt
@@ -24,6 +24,12 @@ fun Project.configureLicensee() {
     allow("Apache-2.0")
     allow("MIT")
 
+    ignoreDependencies("com.ibm.icu", "icu4j") {
+      because(
+        "ICU uses an ICU license that was mispaced and cannot be loaded by this tool right now",
+      )
+    }
+
     // Occasionally, dependencies may add their licenses via a direct URL instead of an SPDX id.
     nonStandardLicenseUrls.forEach { allowUrl(it) }
 
@@ -33,7 +39,7 @@ fun Project.configureLicensee() {
     ignoreDependencies("org.jacoco", "org.jacoco.agent") {
       because("JaCoCo is used in tests only, so it is not distributed with our library")
     }
-    allowDependency("org.javassist", "javassist", "3.20.0-GA") {
+    allowDependency("org.javassist", "javassist", "3.29.0-GA") {
       because("Multi-licensed under Apache. https://github.com/jboss-javassist/javassist")
     }
 

--- a/buildSrc/src/main/kotlin/LicenseeConfig.kt
+++ b/buildSrc/src/main/kotlin/LicenseeConfig.kt
@@ -39,7 +39,7 @@ fun Project.configureLicensee() {
     ignoreDependencies("org.jacoco", "org.jacoco.agent") {
       because("JaCoCo is used in tests only, so it is not distributed with our library")
     }
-    allowDependency("org.javassist", "javassist", "3.29.0-GA") {
+    allowDependency("org.javassist", "javassist", "3.20.0-GA") {
       because("Multi-licensed under Apache. https://github.com/jboss-javassist/javassist")
     }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,10 +17,20 @@ android {
   kotlin { jvmToolchain(11) }
 }
 
-configurations { all { exclude(module = "xpp3") } }
+configurations {
+  all {
+    exclude(module = "xpp3")
+    exclude(module = "hapi-fhir-caching-caffeine")
+    exclude(group = "com.github.ben-manes.caffeine", module = "caffeine")
+
+    resolutionStrategy { force("com.google.guava:guava:32.1.2-android") }
+  }
+}
 
 dependencies {
-  api(Dependencies.HapiFhir.structuresR4)
+  // REVERT to DEPENDENCIES LATER
+  api("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.8.0")
+  api("ca.uhn.hapi.fhir:hapi-fhir-caching-guava:6.8.0")
 
   implementation(Dependencies.fhirUcum)
 


### PR DESCRIPTION
Starts to Fix #2172 

**Description**
This is the first step to migrate the engine and then the workflow to a new version

**Type**
Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
