### PR TITLE
Fix broken dependabot.yaml syntax again (re. #2195)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,6 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 
-# Gotta Catch 'Em All! (i.e. don't wait and propose them only "trickled")
-open-pull-requests-limit: 99
-
 updates:
   - package-ecosystem: gradle
     directory: /


### PR DESCRIPTION
This should fix the latest new problem on #2195.