### PR TITLE
Allow custom package server in Knowledge Manager

### DIFF
--- a/knowledge/src/androidTest/java/com/google/android/fhir/knowledge/db/impl/KnowledgeDatabaseTest.kt
+++ b/knowledge/src/androidTest/java/com/google/android/fhir/knowledge/db/impl/KnowledgeDatabaseTest.kt
@@ -20,8 +20,9 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.android.fhir.knowledge.db.impl.entities.ImplementationGuideEntity
-import com.google.android.fhir.knowledge.db.impl.entities.ResourceMetadataEntity
+import com.google.android.fhir.knowledge.db.KnowledgeDatabase
+import com.google.android.fhir.knowledge.db.entities.ImplementationGuideEntity
+import com.google.android.fhir.knowledge.db.entities.ResourceMetadataEntity
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
@@ -20,12 +20,12 @@ import android.content.Context
 import androidx.room.Room
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.parser.IParser
-import com.google.android.fhir.knowledge.db.impl.KnowledgeDatabase
-import com.google.android.fhir.knowledge.db.impl.entities.ResourceMetadataEntity
-import com.google.android.fhir.knowledge.db.impl.entities.toEntity
-import com.google.android.fhir.knowledge.npm.NpmFileManager
-import com.google.android.fhir.knowledge.npm.OkHttpPackageDownloader
-import com.google.android.fhir.knowledge.npm.PackageDownloader
+import com.google.android.fhir.knowledge.db.KnowledgeDatabase
+import com.google.android.fhir.knowledge.db.entities.ResourceMetadataEntity
+import com.google.android.fhir.knowledge.db.entities.toEntity
+import com.google.android.fhir.knowledge.files.NpmFileManager
+import com.google.android.fhir.knowledge.npm.NpmPackageDownloader
+import com.google.android.fhir.knowledge.npm.OkHttpNpmPackageDownloader
 import java.io.File
 import java.io.FileInputStream
 import kotlinx.coroutines.Dispatchers
@@ -36,15 +36,21 @@ import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
 import timber.log.Timber
 
-/** Responsible for importing, accessing and deleting Implementation Guides. */
+/**
+ * Manages knowledge artifacts on the Android device. Knowledge artifacts can be installed
+ * individually as JSON files or from FHIR NPM packages.
+ *
+ * Coordinates the management of knowledge artifacts by using the three following components:
+ * - database: indexing knowledge artifacts stored in the local file system,
+ * - file manager: managing files containing the knowledge artifacts, and
+ * - NPM downloader: downloading from an NPM package server the knowledge artifacts.
+ */
 class KnowledgeManager
 internal constructor(
-  private val knowledgeDatabase: KnowledgeDatabase,
-  dataFolder: File,
+  knowledgeDatabase: KnowledgeDatabase,
+  private val npmFileManager: NpmFileManager,
+  private val npmPackageDownloader: NpmPackageDownloader,
   private val jsonParser: IParser = FhirContext.forR4().newJsonParser(),
-  private val npmFileManager: NpmFileManager =
-    NpmFileManager(File(dataFolder, ".fhir_package_cache")),
-  private val packageDownloader: PackageDownloader = OkHttpPackageDownloader(npmFileManager),
 ) {
   private val knowledgeDao = knowledgeDatabase.knowledgeDao()
 
@@ -57,14 +63,16 @@ internal constructor(
     fhirNpmPackages
       .filter { knowledgeDao.getImplementationGuide(it.name, it.version) == null }
       .forEach {
-        val npmPackage =
-          if (npmFileManager.containsPackage(it.name, it.version)) {
-            npmFileManager.getPackage(it.name, it.version)
-          } else {
-            packageDownloader.downloadPackage(it, PACKAGE_SERVER)
-          }
-        install(it, npmPackage.rootDirectory)
-        install(*npmPackage.dependencies.toTypedArray())
+        if (!npmFileManager.containsPackage(it.name, it.version)) {
+          npmPackageDownloader.downloadPackage(
+            it,
+            npmFileManager.getPackageDir(it.name, it.version),
+          )
+        }
+        val localFhirNpmPackageMetadata =
+          npmFileManager.getLocalFhirNpmPackageMetadata(it.name, it.version)
+        install(it, localFhirNpmPackageMetadata.rootDirectory)
+        install(*localFhirNpmPackageMetadata.dependencies.toTypedArray())
       }
   }
 
@@ -160,26 +168,35 @@ internal constructor(
     return jsonParser.parseResource(FileInputStream(resourceEntity.resourceFile))
   }
 
-  fun close() {
-    knowledgeDatabase.close()
-  }
-
   companion object {
     private const val DB_NAME = "knowledge.db"
-    private const val PACKAGE_SERVER = "https://packages.fhir.org/packages/"
+    private const val DOWNLOADED_DATA_SUB_DIR = ".fhir_package_cache"
+    private const val DEFAULT_PACKAGE_SERVER = "https://packages.fhir.org/packages/"
 
-    /** Creates an [KnowledgeManager] backed by the Room DB. */
-    fun create(context: Context) =
+    /**
+     * Creates a [KnowledgeManager] instance.
+     *
+     * @param context the application context
+     * @param inMemory whether the knowledge manager instance is in-memory or backed by a Room
+     *   database
+     * @param downloadedDataDir the directory to store downloaded NPM packages
+     * @param packageServer the package server to download FHIR NPM packages from. Defaulted to
+     *   https://packages.fhir.org/packages/.
+     */
+    fun create(
+      context: Context,
+      inMemory: Boolean = false,
+      downloadedDataDir: String,
+      packageServer: String?,
+    ) =
       KnowledgeManager(
-        Room.databaseBuilder(context, KnowledgeDatabase::class.java, DB_NAME).build(),
-        context.dataDir,
-      )
-
-    /** Creates an [KnowledgeManager] backed by the in-memory DB. */
-    fun createInMemory(context: Context) =
-      KnowledgeManager(
-        Room.inMemoryDatabaseBuilder(context, KnowledgeDatabase::class.java).build(),
-        context.dataDir,
+        if (inMemory) {
+          Room.inMemoryDatabaseBuilder(context, KnowledgeDatabase::class.java).build()
+        } else {
+          Room.databaseBuilder(context, KnowledgeDatabase::class.java, DB_NAME).build()
+        },
+        NpmFileManager(File(downloadedDataDir, DOWNLOADED_DATA_SUB_DIR)),
+        OkHttpNpmPackageDownloader(packageServer ?: DEFAULT_PACKAGE_SERVER),
       )
   }
 }

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
@@ -179,15 +179,15 @@ internal constructor(
      * @param context the application context
      * @param inMemory whether the knowledge manager instance is in-memory or backed by a Room
      *   database
-     * @param downloadedDataDir the directory to store downloaded NPM packages
+     * @param downloadedNpmDir the directory to store downloaded NPM packages
      * @param packageServer the package server to download FHIR NPM packages from. Defaulted to
      *   https://packages.fhir.org/packages/.
      */
     fun create(
       context: Context,
       inMemory: Boolean = false,
-      downloadedDataDir: String,
-      packageServer: String?,
+      downloadedNpmDir: File? = context.dataDir,
+      packageServer: String? = DEFAULT_PACKAGE_SERVER,
     ) =
       KnowledgeManager(
         if (inMemory) {
@@ -195,8 +195,8 @@ internal constructor(
         } else {
           Room.databaseBuilder(context, KnowledgeDatabase::class.java, DB_NAME).build()
         },
-        NpmFileManager(File(downloadedDataDir, DOWNLOADED_DATA_SUB_DIR)),
-        OkHttpNpmPackageDownloader(packageServer ?: DEFAULT_PACKAGE_SERVER),
+        NpmFileManager(File(downloadedNpmDir, DOWNLOADED_DATA_SUB_DIR)),
+        OkHttpNpmPackageDownloader(packageServer!!),
       )
   }
 }

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
@@ -63,16 +63,24 @@ internal constructor(
     fhirNpmPackages
       .filter { knowledgeDao.getImplementationGuide(it.name, it.version) == null }
       .forEach {
-        if (!npmFileManager.containsPackage(it.name, it.version)) {
-          npmPackageDownloader.downloadPackage(
-            it,
-            npmFileManager.getPackageDir(it.name, it.version),
-          )
+        try {
+          if (!npmFileManager.containsPackage(it.name, it.version)) {
+            npmPackageDownloader.downloadPackage(
+              it,
+              npmFileManager.getPackageDir(it.name, it.version),
+            )
+          }
+        } catch (e: Exception) {
+          Timber.w("Unable to download package ${it.name} ${it.version}")
         }
-        val localFhirNpmPackageMetadata =
-          npmFileManager.getLocalFhirNpmPackageMetadata(it.name, it.version)
-        install(it, localFhirNpmPackageMetadata.rootDirectory)
-        install(*localFhirNpmPackageMetadata.dependencies.toTypedArray())
+        try {
+          val localFhirNpmPackageMetadata =
+            npmFileManager.getLocalFhirNpmPackageMetadata(it.name, it.version)
+          install(it, localFhirNpmPackageMetadata.rootDirectory)
+          install(*localFhirNpmPackageMetadata.dependencies.toTypedArray())
+        } catch (e: Exception) {
+          Timber.w("Unable to install package ${it.name} ${it.version}")
+        }
       }
   }
 

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/LocalFhirNpmPackageMetadata.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/LocalFhirNpmPackageMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.db.impl
+package com.google.android.fhir.knowledge
 
-import androidx.room.TypeConverter
 import java.io.File
 
-internal object DbTypeConverters {
-
-  @JvmStatic @TypeConverter fun filePathToFile(filePath: String) = File(filePath)
-
-  @JvmStatic @TypeConverter fun fileToFilePath(file: File): String = file.path
-}
+/** Downloaded FHIR NPM Package metadata. */
+data class LocalFhirNpmPackageMetadata(
+  val packageId: String,
+  val version: String,
+  val canonical: String?,
+  val dependencies: List<FhirNpmPackage>,
+  val rootDirectory: File,
+)

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/DbTypeConverters.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/DbTypeConverters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2022-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.npm
+package com.google.android.fhir.knowledge.db
 
-import com.google.android.fhir.knowledge.FhirNpmPackage
+import androidx.room.TypeConverter
 import java.io.File
 
-/** Downloaded FHIR NPM Package metadata. */
-data class LocalFhirNpmPackageMetadata(
-  val packageId: String,
-  val version: String,
-  val canonical: String?,
-  val dependencies: List<FhirNpmPackage>,
-  val rootDirectory: File,
-)
+internal object DbTypeConverters {
+
+  @JvmStatic @TypeConverter fun filePathToFile(filePath: String) = File(filePath)
+
+  @JvmStatic @TypeConverter fun fileToFilePath(file: File): String = file.path
+}

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/KnowledgeDatabase.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/KnowledgeDatabase.kt
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.db.impl
+package com.google.android.fhir.knowledge.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
-import com.google.android.fhir.knowledge.db.impl.dao.KnowledgeDao
-import com.google.android.fhir.knowledge.db.impl.entities.ImplementationGuideEntity
-import com.google.android.fhir.knowledge.db.impl.entities.ImplementationGuideResourceMetadataEntity
-import com.google.android.fhir.knowledge.db.impl.entities.ResourceMetadataEntity
+import com.google.android.fhir.knowledge.db.dao.KnowledgeDao
+import com.google.android.fhir.knowledge.db.entities.ImplementationGuideEntity
+import com.google.android.fhir.knowledge.db.entities.ImplementationGuideResourceMetadataEntity
+import com.google.android.fhir.knowledge.db.entities.ResourceMetadataEntity
 
 /**
  * Stores knowledge artifacts metadata for implementation guides and their containing FHIR

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/dao/KnowledgeDao.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/dao/KnowledgeDao.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.db.impl.dao
+package com.google.android.fhir.knowledge.db.dao
 
 import androidx.room.Dao
 import androidx.room.Delete
@@ -22,10 +22,10 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
-import com.google.android.fhir.knowledge.db.impl.entities.ImplementationGuideEntity
-import com.google.android.fhir.knowledge.db.impl.entities.ImplementationGuideResourceMetadataEntity
-import com.google.android.fhir.knowledge.db.impl.entities.ImplementationGuideWithResources
-import com.google.android.fhir.knowledge.db.impl.entities.ResourceMetadataEntity
+import com.google.android.fhir.knowledge.db.entities.ImplementationGuideEntity
+import com.google.android.fhir.knowledge.db.entities.ImplementationGuideResourceMetadataEntity
+import com.google.android.fhir.knowledge.db.entities.ImplementationGuideWithResources
+import com.google.android.fhir.knowledge.db.entities.ResourceMetadataEntity
 import org.hl7.fhir.r4.model.ResourceType
 
 @Dao

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/entities/ImplementationGuideEntity.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/entities/ImplementationGuideEntity.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.db.impl.entities
+package com.google.android.fhir.knowledge.db.entities
 
 import androidx.room.Entity
 import androidx.room.Index

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/entities/ImplementationGuideResourceMetadataEntity.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/entities/ImplementationGuideResourceMetadataEntity.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.db.impl.entities
+package com.google.android.fhir.knowledge.db.entities
 
 import androidx.room.Embedded
 import androidx.room.Entity

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/entities/ResourceMetadataEntity.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/entities/ResourceMetadataEntity.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.db.impl.entities
+package com.google.android.fhir.knowledge.db.entities
 
 import androidx.room.Entity
 import androidx.room.Index

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/files/NpmFileManager.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/files/NpmFileManager.kt
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.npm
+package com.google.android.fhir.knowledge.files
 
 import com.google.android.fhir.knowledge.FhirNpmPackage
+import com.google.android.fhir.knowledge.LocalFhirNpmPackageMetadata
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,17 +25,8 @@ import org.json.JSONObject
 
 /** Manages stored NPM packages. */
 internal class NpmFileManager(private val cacheRoot: File) {
-
-  /**
-   * Returns the NpmPackage for the given [packageId] and [version] from cache or `null` if the
-   * package is not cached.
-   */
-  suspend fun getPackage(packageId: String, version: String): LocalFhirNpmPackageMetadata {
-    return withContext(Dispatchers.IO) {
-      val packageFolder = File(getPackageFolder(packageId, version), "package")
-      readNpmPackage(packageFolder)
-    }
-  }
+  /** Returns the package directory for the given [packageId] and [version]. */
+  fun getPackageDir(packageId: String, version: String) = File(cacheRoot, "$packageId#$version")
 
   /**
    * Returns the NpmPackage for the given [packageId] and [version] from cache or `null` if the
@@ -42,14 +34,25 @@ internal class NpmFileManager(private val cacheRoot: File) {
    */
   suspend fun containsPackage(packageId: String, version: String): Boolean {
     return withContext(Dispatchers.IO) {
-      val packageFolder = File(getPackageFolder(packageId, version), "package")
+      val packageFolder = File(getPackageDir(packageId, version), "package")
       val packageJson = File(packageFolder, "package.json")
       packageJson.exists()
     }
   }
 
-  /** Returns the package folder for the given [packageId] and [version]. */
-  fun getPackageFolder(packageId: String, version: String) = File(cacheRoot, "$packageId#$version")
+  /**
+   * Returns the NpmPackage for the given [packageId] and [version] from cache or `null` if the
+   * package is not cached.
+   */
+  suspend fun getLocalFhirNpmPackageMetadata(
+    packageId: String,
+    version: String,
+  ): LocalFhirNpmPackageMetadata {
+    return withContext(Dispatchers.IO) {
+      val packageFolder = File(getPackageDir(packageId, version), "package")
+      readNpmPackage(packageFolder)
+    }
+  }
 
   /** Creates an [LocalFhirNpmPackageMetadata] parsing the package manifest file. */
   private fun readNpmPackage(packageFolder: File): LocalFhirNpmPackageMetadata {

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/files/NpmFileManager.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/files/NpmFileManager.kt
@@ -35,8 +35,7 @@ internal class NpmFileManager(private val cacheRoot: File) {
   suspend fun containsPackage(packageId: String, version: String): Boolean {
     return withContext(Dispatchers.IO) {
       val packageFolder = File(getPackageDir(packageId, version), "package")
-      val packageJson = File(packageFolder, "package.json")
-      packageJson.exists()
+      File(packageFolder, "package.json").exists()
     }
   }
 

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/npm/NpmPackageDownloader.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/npm/NpmPackageDownloader.kt
@@ -17,13 +17,13 @@
 package com.google.android.fhir.knowledge.npm
 
 import com.google.android.fhir.knowledge.FhirNpmPackage
+import java.io.File
 
 /** Downloads Npm package from the provided package server. */
-fun interface PackageDownloader {
-
+fun interface NpmPackageDownloader {
   /** Downloads the [fhirNpmPackage] from the [packageServerUrl]. */
   suspend fun downloadPackage(
     fhirNpmPackage: FhirNpmPackage,
-    packageServerUrl: String,
-  ): LocalFhirNpmPackageMetadata
+    packageFolder: File,
+  )
 }

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/npm/OkHttpNpmPackageDownloader.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/npm/OkHttpNpmPackageDownloader.kt
@@ -31,17 +31,17 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 
 /** Downloads Npm package from the provided package server using OkHttp library. */
-internal class OkHttpPackageDownloader(
-  private val npmFileManager: NpmFileManager,
-) : PackageDownloader {
+internal class OkHttpNpmPackageDownloader(
+  private val packageServerUrl: String,
+) : NpmPackageDownloader {
 
   val client = OkHttpClient()
 
   @Throws(IOException::class)
   override suspend fun downloadPackage(
     fhirNpmPackage: FhirNpmPackage,
-    packageServerUrl: String,
-  ): LocalFhirNpmPackageMetadata {
+    packageFolder: File,
+  ) {
     return withContext(Dispatchers.IO) {
       val packageName = fhirNpmPackage.name
       val version = fhirNpmPackage.version
@@ -54,8 +54,6 @@ internal class OkHttpPackageDownloader(
       if (!response.isSuccessful) {
         throw IOException("Unexpected code $response")
       }
-      val packageFolder =
-        npmFileManager.getPackageFolder(fhirNpmPackage.name, fhirNpmPackage.version)
 
       response.body?.use { responseBody ->
         packageFolder.mkdirs()
@@ -66,7 +64,6 @@ internal class OkHttpPackageDownloader(
 
         tgzFile.delete()
       }
-      npmFileManager.getPackage(fhirNpmPackage.name, fhirNpmPackage.version)
     }
   }
 

--- a/knowledge/src/test/java/com/google/android/fhir/knowledge/KnowledgeManagerTest.kt
+++ b/knowledge/src/test/java/com/google/android/fhir/knowledge/KnowledgeManagerTest.kt
@@ -21,9 +21,8 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
-import com.google.android.fhir.knowledge.db.impl.KnowledgeDatabase
-import com.google.android.fhir.knowledge.npm.LocalFhirNpmPackageMetadata
-import com.google.android.fhir.knowledge.npm.NpmFileManager
+import com.google.android.fhir.knowledge.db.KnowledgeDatabase
+import com.google.android.fhir.knowledge.files.NpmFileManager
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlinx.coroutines.test.runTest
@@ -45,9 +44,8 @@ internal class KnowledgeManagerTest {
   private val knowledgeManager =
     KnowledgeManager(
       knowledgeDb,
-      context.dataDir,
       npmFileManager = npmFileManager,
-      packageDownloader = { fhirPackage, _ ->
+      npmPackageDownloader = { fhirPackage, _ ->
         LocalFhirNpmPackageMetadata(
           fhirPackage.name,
           fhirPackage.version,

--- a/knowledge/src/test/java/com/google/android/fhir/knowledge/files/NpmFileManagerTest.kt
+++ b/knowledge/src/test/java/com/google/android/fhir/knowledge/files/NpmFileManagerTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.fhir.knowledge.npm
+package com.google.android.fhir.knowledge.files
 
 import com.google.android.fhir.knowledge.FhirNpmPackage
 import com.google.common.truth.Truth.assertThat
@@ -31,7 +31,7 @@ class NpmFileManagerTest {
 
   @Test
   fun getPackageFolder() {
-    val packageFolder = npmFileManager.getPackageFolder(PACKAGE_ID, VERSION)
+    val packageFolder = npmFileManager.getPackageDir(PACKAGE_ID, VERSION)
 
     assertThat(packageFolder.absolutePath)
       .isEqualTo("${testDataFolder.absolutePath}/$PACKAGE_ID#$VERSION")
@@ -39,7 +39,7 @@ class NpmFileManagerTest {
 
   @Test
   fun getPackage() = runTest {
-    val npmPackage = npmFileManager.getPackage(PACKAGE_ID, VERSION)
+    val npmPackage = npmFileManager.getLocalFhirNpmPackageMetadata(PACKAGE_ID, VERSION)
 
     assertThat(npmPackage.packageId).isEqualTo(PACKAGE_ID)
     assertThat(npmPackage.version).isEqualTo(VERSION)

--- a/knowledge/src/test/java/com/google/android/fhir/knowledge/npm/OkHttpNpmPackageDownloaderTest.kt
+++ b/knowledge/src/test/java/com/google/android/fhir/knowledge/npm/OkHttpNpmPackageDownloaderTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.fhir.knowledge.FhirNpmPackage
 import com.google.android.fhir.knowledge.files.NpmFileManager
+import com.google.common.truth.Truth.assertThat
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -49,15 +50,16 @@ class OkHttpNpmPackageDownloaderTest {
     val responseBody = MockResponse().setResponseCode(200).setBody(testFileBuffer)
     mockWebServer.enqueue(responseBody)
 
-    val npmPackage =
-      downloader.downloadPackage(
-        fhirNpmPackage,
-        npmFileManager.getPackageDir(fhirNpmPackage.name, fhirNpmPackage.version),
-      )
+    downloader.downloadPackage(
+      fhirNpmPackage,
+      npmFileManager.getPackageDir(fhirNpmPackage.name, fhirNpmPackage.version),
+    )
 
-    //    assertThat(npmPackage.packageId).isEqualTo(PACKAGE_ID)
-    //    assertThat(npmPackage.version).isEqualTo(VERSION)
-    //    assertThat(npmPackage.dependencies).isEqualTo(DEPENDENCIES)
+    val npmPackage =
+      npmFileManager.getLocalFhirNpmPackageMetadata(fhirNpmPackage.name, fhirNpmPackage.version)
+    assertThat(npmPackage.packageId).isEqualTo(PACKAGE_ID)
+    assertThat(npmPackage.version).isEqualTo(VERSION)
+    assertThat(npmPackage.dependencies).isEqualTo(DEPENDENCIES)
   }
 
   @Test(expected = IOException::class)

--- a/workflow/benchmark/src/androidTest/java/com/google/android/fhir/workflow/benchmark/F_CqlEvaluatorBenchmark.kt
+++ b/workflow/benchmark/src/androidTest/java/com/google/android/fhir/workflow/benchmark/F_CqlEvaluatorBenchmark.kt
@@ -61,7 +61,7 @@ class F_CqlEvaluatorBenchmark {
         val patientImmunizationHistory =
           jsonParser.parseResource(open("/immunity-check/ImmunizationHistory.json")) as Bundle
         val fhirEngine = FhirEngineProvider.getInstance(ApplicationProvider.getApplicationContext())
-        val knowledgeManager = KnowledgeManager.createInMemory(context)
+        val knowledgeManager = KnowledgeManager.create(context = context, inMemory = true)
         val lib = jsonParser.parseResource(open("/immunity-check/ImmunityCheck.json")) as Library
 
         runBlocking {

--- a/workflow/src/androidTest/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateTest.kt
+++ b/workflow/src/androidTest/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateTest.kt
@@ -48,7 +48,7 @@ class FhirOperatorLibraryEvaluateTest {
 
   private val context: Context = ApplicationProvider.getApplicationContext()
   private val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
-  private val knowledgeManager = KnowledgeManager.create(context, inMemory = true)
+  private val knowledgeManager = KnowledgeManager.create(context = context, inMemory = true)
   private val jsonParser = fhirContext.newJsonParser()
 
   private fun open(asset: String): InputStream? {

--- a/workflow/src/androidTest/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateTest.kt
+++ b/workflow/src/androidTest/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateTest.kt
@@ -48,7 +48,7 @@ class FhirOperatorLibraryEvaluateTest {
 
   private val context: Context = ApplicationProvider.getApplicationContext()
   private val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
-  private val knowledgeManager = KnowledgeManager.createInMemory(context)
+  private val knowledgeManager = KnowledgeManager.create(context, inMemory = true)
   private val jsonParser = fhirContext.newJsonParser()
 
   private fun open(asset: String): InputStream? {

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineDalTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineDalTest.kt
@@ -48,7 +48,7 @@ class FhirEngineDalTest {
   fun setupTest() {
     val context: Context = ApplicationProvider.getApplicationContext()
     fhirEngine = FhirEngineProvider.getInstance(context)
-    fhirEngineDal = FhirEngineDal(fhirEngine, KnowledgeManager.createInMemory(context))
+    fhirEngineDal = FhirEngineDal(fhirEngine, KnowledgeManager.create(context, inMemory = true))
     runBlocking { fhirEngine.create(testPatient) }
   }
 

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineDalTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineDalTest.kt
@@ -48,7 +48,8 @@ class FhirEngineDalTest {
   fun setupTest() {
     val context: Context = ApplicationProvider.getApplicationContext()
     fhirEngine = FhirEngineProvider.getInstance(context)
-    fhirEngineDal = FhirEngineDal(fhirEngine, KnowledgeManager.create(context, inMemory = true))
+    fhirEngineDal =
+      FhirEngineDal(fhirEngine, KnowledgeManager.create(context = context, inMemory = true))
     runBlocking { fhirEngine.create(testPatient) }
   }
 

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineRetrieveProviderTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineRetrieveProviderTest.kt
@@ -62,7 +62,7 @@ class FhirEngineRetrieveProviderTest : Loadable() {
           FhirEngineTerminologyProvider(
             FhirContext.forR4Cached(),
             fhirEngine,
-            KnowledgeManager.createInMemory(context),
+            KnowledgeManager.create(context, inMemory = true),
           )
         isExpandValueSets = true
       }

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineTerminologyProviderTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineTerminologyProviderTest.kt
@@ -59,7 +59,7 @@ class FhirEngineTerminologyProviderTest : Loadable() {
       FhirEngineTerminologyProvider(
         FhirContext.forR4Cached(),
         fhirEngine,
-        KnowledgeManager.createInMemory(context),
+        KnowledgeManager.create(context, inMemory = true),
       )
   }
 

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineTerminologyProviderTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirEngineTerminologyProviderTest.kt
@@ -59,7 +59,7 @@ class FhirEngineTerminologyProviderTest : Loadable() {
       FhirEngineTerminologyProvider(
         FhirContext.forR4Cached(),
         fhirEngine,
-        KnowledgeManager.create(context, inMemory = true),
+        KnowledgeManager.create(context = context, inMemory = true),
       )
   }
 

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateJavaTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateJavaTest.kt
@@ -51,7 +51,7 @@ class FhirOperatorLibraryEvaluateJavaTest {
   private lateinit var fhirOperator: FhirOperator
 
   private val context: Context = ApplicationProvider.getApplicationContext()
-  private val knowledgeManager = KnowledgeManager.create(context, inMemory = true)
+  private val knowledgeManager = KnowledgeManager.create(context = context, inMemory = true)
   private val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
   private val jsonParser = fhirContext.newJsonParser()
 

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateJavaTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorLibraryEvaluateJavaTest.kt
@@ -51,7 +51,7 @@ class FhirOperatorLibraryEvaluateJavaTest {
   private lateinit var fhirOperator: FhirOperator
 
   private val context: Context = ApplicationProvider.getApplicationContext()
-  private val knowledgeManager = KnowledgeManager.createInMemory(context)
+  private val knowledgeManager = KnowledgeManager.create(context, inMemory = true)
   private val fhirContext = FhirContext.forCached(FhirVersionEnum.R4)
   private val jsonParser = fhirContext.newJsonParser()
 

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
@@ -28,7 +28,6 @@ import com.google.android.fhir.workflow.testing.FhirEngineProviderTestRule
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import java.io.InputStream
-import java.lang.IllegalArgumentException
 import java.util.TimeZone
 import kotlin.reflect.KSuspendFunction1
 import org.hl7.fhir.r4.model.Bundle
@@ -36,7 +35,6 @@ import org.hl7.fhir.r4.model.Library
 import org.hl7.fhir.r4.model.MetadataResource
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -50,7 +48,7 @@ class FhirOperatorTest {
   @get:Rule val fhirEngineProviderRule = FhirEngineProviderTestRule()
 
   private val context: Context = ApplicationProvider.getApplicationContext()
-  private val knowledgeManager = KnowledgeManager.createInMemory(context)
+  private val knowledgeManager = KnowledgeManager.create(context, inMemory = true)
   private val fhirContext = FhirContext.forR4()
   private val jsonParser = fhirContext.newJsonParser()
   private val xmlParser = fhirContext.newXmlParser()
@@ -74,11 +72,6 @@ class FhirOperatorTest {
       ),
       rootDirectory,
     )
-  }
-
-  @After
-  fun tearDown() {
-    knowledgeManager.close()
   }
 
   @Test

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
@@ -48,7 +48,7 @@ class FhirOperatorTest {
   @get:Rule val fhirEngineProviderRule = FhirEngineProviderTestRule()
 
   private val context: Context = ApplicationProvider.getApplicationContext()
-  private val knowledgeManager = KnowledgeManager.create(context, inMemory = true)
+  private val knowledgeManager = KnowledgeManager.create(context = context, inMemory = true)
   private val fhirContext = FhirContext.forR4()
   private val jsonParser = fhirContext.newJsonParser()
   private val xmlParser = fhirContext.newXmlParser()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
- Allow custom package option in the `create` API of Knowledge Manager
- Simplify the `create` APIs for Knowledge Manager by merging two versions into one
- Refactor KnowledgeManager to be a class that coordinates between 1) db indices 2) local files and 3) downloader
- Organise package structure to reflect the three components: `db`, `files`, `npm`
- Remove dependency from downloader to file manager to make responsibilities clear

**Alternative(s) considered**
NA

**Type**
Feature

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
