### PR TITLE
Migrates engine to HAPI 6.8 while forcing Workflow to stay on 6.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,6 +18,6 @@ dependencies {
 
   implementation("com.spotify.ruler:ruler-gradle-plugin:1.2.1")
 
-  implementation("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.0.1")
+  implementation("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.8.0")
   implementation("com.squareup:kotlinpoet:1.12.0")
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -100,7 +100,7 @@ object Dependencies {
 
     const val annotations = "$coreGroup:jackson-annotations:${Versions.jackson}"
     const val bom = "$mainGroup:jackson-bom:${Versions.jackson}"
-    const val core = "$coreGroup:jackson-core:${Versions.jackson}"
+    const val core = "$coreGroup:jackson-core:${Versions.jacksonCore}"
     const val databind = "$coreGroup:jackson-databind:${Versions.jackson}"
     const val dataformatXml = "$dataformatGroup:jackson-dataformat-xml:${Versions.jackson}"
     const val jaxbAnnotations = "$moduleGroup:jackson-module-jaxb-annotations:${Versions.jackson}"
@@ -259,9 +259,13 @@ object Dependencies {
 
     const val http = "4.11.0"
 
-    // Maximum version that supports Android API Level 24:
+    // Maximum Jackson libraries (excluding core) version that supports Android API Level 24:
     // https://github.com/FasterXML/jackson-databind/issues/3658
-    const val jackson = "2.15.2"
+    const val jackson = "2.13.5"
+
+    // Maximum Jackson Core library version that supports Android API Level 24:
+    const val jacksonCore = "2.15.2"
+
     const val jsonToolsPatch = "1.13"
     const val jsonAssert = "1.5.1"
     const val material = "1.9.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -88,6 +88,7 @@ object Dependencies {
     // Version 3.0 uses java.lang.System.Logger, which is not available on Android
     // Replace for Guava when this PR gets merged: https://github.com/hapifhir/hapi-fhir/pull/3977
     const val caffeine = "com.github.ben-manes.caffeine:caffeine:${Versions.caffeine}"
+    const val guavaCaching = "ca.uhn.hapi.fhir:hapi-fhir-caching-guava:${Versions.hapiFhir}"
   }
 
   object Jackson {
@@ -243,7 +244,7 @@ object Dependencies {
       const val stdlib = "1.8.20"
     }
 
-    const val androidFhirCommon = "0.1.0-alpha04"
+    const val androidFhirCommon = "0.1.0-alpha05"
     const val androidFhirEngine = "0.1.0-beta03"
     const val androidFhirKnowledge = "0.1.0-alpha01"
     const val apacheCommonsCompress = "1.21"
@@ -251,22 +252,16 @@ object Dependencies {
     const val caffeine = "2.9.1"
     const val fhirUcum = "1.0.3"
     const val gson = "2.9.1"
-    const val guava = "28.2-android"
+    const val guava = "32.1.2-android"
 
-    // Hapi FHIR and HL7 Core Components are interlinked.
-    // Newer versions of HapiFhir don't work on Android due to the use of Caffeine 3+
-    // Wait for this to release (6.3): https://github.com/hapifhir/hapi-fhir/pull/4196
-    const val hapiFhir = "6.0.1"
-
-    // Newer versions don't work on Android due to Apache Commons Codec:
-    // Wait for this fix: https://github.com/hapifhir/org.hl7.fhir.core/issues/1046
-    const val hapiFhirCore = "5.6.36"
+    const val hapiFhir = "6.8.0"
+    const val hapiFhirCore = "6.0.22"
 
     const val http = "4.11.0"
 
     // Maximum version that supports Android API Level 24:
     // https://github.com/FasterXML/jackson-databind/issues/3658
-    const val jackson = "2.13.5"
+    const val jackson = "2.15.2"
     const val jsonToolsPatch = "1.13"
     const val jsonAssert = "1.5.1"
     const val material = "1.9.0"
@@ -312,13 +307,22 @@ object Dependencies {
     exclude(group = "org.apache.httpcomponents")
   }
 
+  fun Configuration.forceGuava() {
+    // Removes caffeine
+    exclude(module = "hapi-fhir-caching-caffeine")
+    exclude(group = "com.github.ben-manes.caffeine", module = "caffeine")
+
+    resolutionStrategy {
+      force(guava)
+      force(HapiFhir.guavaCaching)
+    }
+  }
+
   fun Configuration.forceHapiVersion() {
     // Removes newer versions of caffeine and manually imports 2.9
     // Removes newer versions of hapi and keeps on 6.0.1
     // (newer versions don't work on Android)
     resolutionStrategy {
-      force(HapiFhir.caffeine)
-
       force(HapiFhir.fhirBase)
       force(HapiFhir.fhirClient)
       force(HapiFhir.fhirCoreConvertors)

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -63,8 +63,6 @@ fun Project.configureFirebaseTestLabForMicroBenchmark() {
         "clearPackageData" to "true",
       ),
     )
-    // some of the benchmark tests get timed-out in the default 15m
-    testTimeout.set("45m")
     devices.set(
       listOf(
         mapOf(
@@ -87,6 +85,7 @@ private fun FlankGradleExtension.commonConfigurationForFirebaseTestLab(project: 
   useOrchestrator.set(true)
   flakyTestAttempts.set(1)
   maxTestShards.set(10)
+  testTimeout.set("45m")
   directoriesToPull.set(listOf("/sdcard/Download"))
   resultsBucket.set("android-fhir-build-artifacts")
   resultsDir.set(

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -42,7 +42,7 @@ fun Project.configureFirebaseTestLabForLibraries() {
           "locale" to "en_US",
         ),
         mapOf(
-          "model" to "panther",
+          "model" to "MediumPhone.arm",
           "version" to "${project.extensions.getByType(LibraryExtension::class.java).compileSdk}",
           "locale" to "en_US",
         ),
@@ -85,7 +85,8 @@ private fun FlankGradleExtension.commonConfigurationForFirebaseTestLab(project: 
     },
   )
   useOrchestrator.set(true)
-  maxTestShards.set(10)
+  flakyTestAttempts.set(1)
+  numUniformShards.set(10)
   directoriesToPull.set(listOf("/sdcard/Download"))
   resultsBucket.set("android-fhir-build-artifacts")
   resultsDir.set(

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -85,7 +85,7 @@ private fun FlankGradleExtension.commonConfigurationForFirebaseTestLab(project: 
     },
   )
   useOrchestrator.set(true)
-  maxTestShards.set(20)
+  maxTestShards.set(10)
   directoriesToPull.set(listOf("/sdcard/Download"))
   resultsBucket.set("android-fhir-build-artifacts")
   resultsDir.set(

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -33,7 +33,6 @@ fun Project.configureFirebaseTestLabForLibraries() {
         "clearPackageData" to "true",
       ),
     )
-    flakyTestAttempts.set(3)
     devices.set(
       listOf(
         mapOf(

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -86,7 +86,7 @@ private fun FlankGradleExtension.commonConfigurationForFirebaseTestLab(project: 
   )
   useOrchestrator.set(true)
   flakyTestAttempts.set(1)
-  numUniformShards.set(10)
+  maxTestShards.set(10)
   directoriesToPull.set(listOf("/sdcard/Download"))
   resultsBucket.set("android-fhir-build-artifacts")
   resultsDir.set(

--- a/buildSrc/src/main/kotlin/LicenseeConfig.kt
+++ b/buildSrc/src/main/kotlin/LicenseeConfig.kt
@@ -42,6 +42,7 @@ fun Project.configureLicensee() {
     allowDependency("org.javassist", "javassist", "3.29.0-GA") {
       because("Multi-licensed under Apache. https://github.com/jboss-javassist/javassist")
     }
+    // Remove once Evaluator 3 migration is over
     allowDependency("org.javassist", "javassist", "3.20.0-GA") {
       because("Multi-licensed under Apache. https://github.com/jboss-javassist/javassist")
     }

--- a/buildSrc/src/main/kotlin/LicenseeConfig.kt
+++ b/buildSrc/src/main/kotlin/LicenseeConfig.kt
@@ -39,6 +39,9 @@ fun Project.configureLicensee() {
     ignoreDependencies("org.jacoco", "org.jacoco.agent") {
       because("JaCoCo is used in tests only, so it is not distributed with our library")
     }
+    allowDependency("org.javassist", "javassist", "3.29.0-GA") {
+      because("Multi-licensed under Apache. https://github.com/jboss-javassist/javassist")
+    }
     allowDependency("org.javassist", "javassist", "3.20.0-GA") {
       because("Multi-licensed under Apache. https://github.com/jboss-javassist/javassist")
     }

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -1,3 +1,5 @@
+import Dependencies.forceGuava
+
 plugins {
   id(Plugins.BuildPlugins.application)
   id(Plugins.BuildPlugins.kotlinAndroid)
@@ -39,6 +41,8 @@ android {
   }
   kotlin { jvmToolchain(11) }
 }
+
+configurations { all { forceGuava() } }
 
 dependencies {
   androidTestImplementation(Dependencies.AndroidxTest.extJunit)

--- a/contrib/barcode/build.gradle.kts
+++ b/contrib/barcode/build.gradle.kts
@@ -1,3 +1,5 @@
+import Dependencies.forceGuava
+
 plugins {
   id(Plugins.BuildPlugins.androidLib)
   id(Plugins.BuildPlugins.kotlinAndroid)
@@ -44,7 +46,12 @@ android {
   kotlin { jvmToolchain(11) }
 }
 
-configurations { all { exclude(module = "xpp3") } }
+configurations {
+  all {
+    exclude(module = "xpp3")
+    forceGuava()
+  }
+}
 
 dependencies {
   androidTestImplementation(Dependencies.AndroidxTest.core)

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -1,4 +1,6 @@
 import Dependencies.forceGuava
+import Dependencies.forceHapiVersion
+import Dependencies.forceJacksonVersion
 import java.net.URL
 
 plugins {
@@ -56,7 +58,10 @@ afterEvaluate { configureFirebaseTestLabForLibraries() }
 configurations {
   all {
     exclude(module = "xpp3")
+    exclude(group = "net.sf.saxon", module = "Saxon-HE")
     forceGuava()
+    forceHapiVersion()
+    forceJacksonVersion()
   }
 }
 
@@ -87,7 +92,6 @@ dependencies {
   implementation(Dependencies.HapiFhir.validation) {
     exclude(module = "commons-logging")
     exclude(module = "httpclient")
-    exclude(group = "net.sf.saxon", module = "Saxon-HE")
   }
   implementation(Dependencies.Kotlin.kotlinCoroutinesCore)
   implementation(Dependencies.Kotlin.stdlib)

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -1,3 +1,4 @@
+import Dependencies.forceGuava
 import java.net.URL
 
 plugins {
@@ -52,7 +53,12 @@ android {
 
 afterEvaluate { configureFirebaseTestLabForLibraries() }
 
-configurations { all { exclude(module = "xpp3") } }
+configurations {
+  all {
+    exclude(module = "xpp3")
+    forceGuava()
+  }
+}
 
 dependencies {
   androidTestImplementation(Dependencies.AndroidxTest.core)
@@ -77,6 +83,7 @@ dependencies {
   implementation(Dependencies.Androidx.coreKtx)
   implementation(Dependencies.Androidx.fragmentKtx)
   implementation(Dependencies.Glide.glide)
+  implementation(Dependencies.HapiFhir.guavaCaching)
   implementation(Dependencies.HapiFhir.validation) {
     exclude(module = "commons-logging")
     exclude(module = "httpclient")

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServices.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServices.kt
@@ -25,8 +25,12 @@ import org.hl7.fhir.r4.utils.FHIRPathEngine
  * Resolves constants defined in the fhir path expressions beyond those defined in the specification
  */
 internal object FHIRPathEngineHostServices : FHIRPathEngine.IEvaluationContext {
-  override fun resolveConstant(appContext: Any?, name: String?, beforeContext: Boolean): Base? =
-    (appContext as? Map<*, *>)?.get(name) as? Base
+  override fun resolveConstant(
+    appContext: Any?,
+    name: String?,
+    beforeContext: Boolean,
+  ): List<Base>? =
+    ((appContext as? Map<*, *>)?.get(name) as? Base)?.let { listOf(it) } ?: emptyList()
 
   override fun resolveConstantType(appContext: Any?, name: String?): TypeDetails {
     throw UnsupportedOperationException()
@@ -59,7 +63,7 @@ internal object FHIRPathEngineHostServices : FHIRPathEngine.IEvaluationContext {
     throw UnsupportedOperationException()
   }
 
-  override fun resolveReference(appContext: Any?, url: String?): Base {
+  override fun resolveReference(appContext: Any?, url: String?, refContext: Base?): Base? {
     throw UnsupportedOperationException()
   }
 
@@ -67,7 +71,7 @@ internal object FHIRPathEngineHostServices : FHIRPathEngine.IEvaluationContext {
     throw UnsupportedOperationException()
   }
 
-  override fun resolveValueSet(appContext: Any?, url: String?): ValueSet {
+  override fun resolveValueSet(appContext: Any?, url: String?): ValueSet? {
     throw UnsupportedOperationException()
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/mapping/ResourceMapper.kt
@@ -775,13 +775,21 @@ private fun Base.asExpectedReferenceType(): Type {
       this@asExpectedReferenceType as Resource
       Reference().apply {
         reference =
-          "${this@asExpectedReferenceType.resourceType}/${this@asExpectedReferenceType.logicalId}"
+          if (this@asExpectedReferenceType.resourceType != null) {
+            "${this@asExpectedReferenceType.resourceType}/${this@asExpectedReferenceType.logicalId}"
+          } else {
+            this@asExpectedReferenceType.logicalId
+          }
       }
     }
     this is IdType ->
       Reference().apply {
         reference =
-          "${this@asExpectedReferenceType.resourceType}/${this@asExpectedReferenceType.idPart}"
+          if (this@asExpectedReferenceType.resourceType != null) {
+            "${this@asExpectedReferenceType.resourceType}/${this@asExpectedReferenceType.idPart}"
+          } else {
+            this@asExpectedReferenceType.idPart
+          }
       }
     else -> throw FHIRException("Expression supplied does not evaluate to IdType.")
   }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -4400,7 +4400,7 @@ class QuestionnaireViewModelTest {
                 Extension(
                   "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression",
                   Expression().apply {
-                    this.expression = "Observation?subject={{%patient.id}}"
+                    this.expression = "Observation?subject=Patient/{{%patient.id}}"
                     this.language = Expression.ExpressionLanguage.APPLICATION_XFHIRQUERY.toCode()
                   },
                 ),

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServicesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/FHIRPathEngineHostServicesTest.kt
@@ -30,28 +30,28 @@ class FHIRPathEngineHostServicesTest {
   fun testFHIRPathHostServices_resolveConstantKeyNotPresent_returnsNull() {
     val answer = FHIRPathEngineHostServices.resolveConstant(mapOf("A" to IntegerType(1)), "B", true)
 
-    assertThat(answer).isNull()
+    assertThat(answer).isEmpty()
   }
 
   @Test
   fun testFHIRPathHostServices_resolveConstantKeyAndValuePresent_returnsNotNull() {
     val answer = FHIRPathEngineHostServices.resolveConstant(mapOf("A" to IntegerType(1)), "A", true)
 
-    assertThat((answer as Type).asStringValue()).isEqualTo("1")
+    assertThat((answer?.first() as Type).asStringValue()).isEqualTo("1")
   }
 
   @Test
   fun testFHIRPathHostServices_resolveConstantKeyPresentAndValueNotPresent_returnsNull() {
     val answer = FHIRPathEngineHostServices.resolveConstant(mapOf("A" to null), "A", true)
 
-    assertThat(answer).isNull()
+    assertThat(answer).isEmpty()
   }
 
   @Test
   fun testFHIRPathHostServices_resolveConstantNullAppContext_returnsNull() {
     val answer = FHIRPathEngineHostServices.resolveConstant(null, "A", true)
 
-    assertThat(answer).isNull()
+    assertThat(answer).isEmpty()
   }
 
   @Test
@@ -97,7 +97,7 @@ class FHIRPathEngineHostServicesTest {
   @Test
   fun testFHIRPathHostServices_resolveReference_throwsUnsupportedOperationException() {
     assertThrows(UnsupportedOperationException::class.java) {
-      FHIRPathEngineHostServices.resolveReference(mapOf<Any, Any>(), "")
+      FHIRPathEngineHostServices.resolveReference(mapOf<Any, Any>(), "", null)
     }
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/mapping/ResourceMapperTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/mapping/ResourceMapperTest.kt
@@ -1564,7 +1564,7 @@ class ResourceMapperTest {
       val questionnaireResponse = ResourceMapper.populate(questionnaire, patient)
 
       assertThat((questionnaireResponse.item[0].answer[0].value as Reference).reference)
-        .isEqualTo(patient.id)
+        .isEqualTo(patient.idPart)
     }
 
   @Test

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -1,3 +1,5 @@
+import Dependencies.forceGuava
+
 plugins {
   id(Plugins.BuildPlugins.application)
   id(Plugins.BuildPlugins.kotlinAndroid)
@@ -37,6 +39,8 @@ android {
   packaging { resources.excludes.addAll(listOf("META-INF/ASL-2.0.txt", "META-INF/LGPL-3.0.txt")) }
   kotlin { jvmToolchain(11) }
 }
+
+configurations { all { forceGuava() } }
 
 dependencies {
   androidTestImplementation(Dependencies.AndroidxTest.extJunit)

--- a/engine/benchmark/build.gradle.kts
+++ b/engine/benchmark/build.gradle.kts
@@ -1,3 +1,4 @@
+import Dependencies.forceGuava
 import Dependencies.forceHapiVersion
 import Dependencies.forceJacksonVersion
 import Dependencies.removeIncompatibleDependencies
@@ -50,6 +51,7 @@ afterEvaluate { configureFirebaseTestLabForMicroBenchmark() }
 configurations {
   all {
     removeIncompatibleDependencies()
+    forceGuava()
     forceHapiVersion()
     forceJacksonVersion()
   }

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -1,3 +1,6 @@
+import Dependencies.forceGuava
+import Dependencies.forceHapiVersion
+import Dependencies.forceJacksonVersion
 import codegen.GenerateSearchParamsTask
 import java.net.URL
 
@@ -84,6 +87,10 @@ configurations {
     exclude(module = "jakarta.activation-api")
     exclude(module = "javax.activation")
     exclude(module = "jakarta.xml.bind-api")
+
+    forceGuava()
+    forceHapiVersion()
+    forceJacksonVersion()
   }
 }
 
@@ -97,6 +104,17 @@ dependencies {
   androidTestImplementation(Dependencies.truth)
 
   api(Dependencies.HapiFhir.structuresR4) { exclude(module = "junit") }
+
+  // We have removed the dependency on Caffeine from HAPI due to conflicts with android
+  // Guave Caching must be individually loaded instead.
+  implementation(Dependencies.HapiFhir.guavaCaching)
+
+  // Validation to load system types into FhirPath's Context
+  // The loading happens via a ResourceStream in XML and thus
+  // XML parsers are also necessary.
+  implementation(Dependencies.HapiFhir.validationR4)
+  implementation(Dependencies.woodstox)
+  implementation(Dependencies.xerces)
 
   coreLibraryDesugaring(Dependencies.desugarJdkLibs)
 

--- a/engine/src/main/java/com/google/android/fhir/index/DualHapiWorkerContext.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/DualHapiWorkerContext.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.index
+
+import ca.uhn.fhir.context.FhirContext
+import org.fhir.ucum.UcumEssenceService
+import org.hl7.fhir.r4.context.SimpleWorkerContext
+import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext
+import org.hl7.fhir.r4.model.Resource
+
+/**
+ * Merges the caching system in the HAPIWorker with the Ucum Support in the SimpleWorker
+ *
+ * TODO: Ideally we update the upstream's HapiWorkerContext to support ucumServices.
+ */
+class DualHapiWorkerContext : SimpleWorkerContext() {
+  val hapi =
+    HapiWorkerContext(
+      FhirContext.forR4Cached(),
+      FhirContext.forR4Cached().validationSupport,
+    )
+
+  init {
+    // TODO: get this service from Common: UnitConverter.ucumService
+    this.ucumService = UcumEssenceService(this::class.java.getResourceAsStream("/ucum-essence.xml"))
+  }
+
+  override fun <T : Resource?> fetchResourceWithException(class_: Class<T>?, uri: String?): T {
+    return hapi.fetchResourceWithException(class_, uri)
+      ?: super.fetchResourceWithException(class_, uri)
+  }
+}

--- a/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
+++ b/engine/src/main/java/com/google/android/fhir/index/ResourceIndexer.kt
@@ -34,7 +34,6 @@ import com.google.android.fhir.search.LAST_UPDATED
 import com.google.android.fhir.search.LOCAL_LAST_UPDATED
 import com.google.android.fhir.ucumUrl
 import java.math.BigDecimal
-import org.hl7.fhir.r4.context.SimpleWorkerContext
 import org.hl7.fhir.r4.model.Address
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.CanonicalType
@@ -68,9 +67,7 @@ import org.hl7.fhir.r4.utils.FHIRPathEngine
 internal class ResourceIndexer(
   private val searchParamDefinitionsProvider: SearchParamDefinitionsProvider,
 ) {
-  // Switched HapiWorkerContext to SimpleWorkerContext as a fix for
-  // https://github.com/google/android-fhir/issues/768
-  private val fhirPathEngine = FHIRPathEngine(SimpleWorkerContext())
+  private val fhirPathEngine = FHIRPathEngine(DualHapiWorkerContext())
 
   fun <R : Resource> index(resource: R) = extractIndexValues(resource)
 

--- a/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
@@ -241,7 +241,7 @@ class FhirEngineImplTest {
           fhirEngine.search("CustomResource?active=true&gender=male&_sort=name&_count=2")
         }
       }
-    assertThat(exception.message).isEqualTo("Unknown resource typeCustomResource")
+    assertThat(exception.message).isEqualTo("Unknown resource type CustomResource")
   }
 
   @Test

--- a/knowledge/build.gradle.kts
+++ b/knowledge/build.gradle.kts
@@ -1,3 +1,4 @@
+import Dependencies.guava
 import java.net.URL
 
 plugins {
@@ -70,6 +71,33 @@ configurations {
   all {
     exclude(module = "xpp3")
     exclude(module = "xpp3_min")
+    exclude(
+      module = "hapi-fhir-structures-r4b",
+    )
+    resolutionStrategy {
+      force(Dependencies.guava)
+      force("ca.uhn.hapi.fhir:hapi-fhir-base:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-client:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.convertors:6.0.22")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2016may:6.0.22")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r5:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.utilities:6.0.22")
+
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2:6.0.22")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu3:6.0.22")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4:6.0.22")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4b:6.0.22")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r5:6.0.22")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r5:6.0.1")
+    }
   }
 }
 
@@ -81,7 +109,7 @@ dependencies {
   androidTestImplementation(Dependencies.junit)
   androidTestImplementation(Dependencies.truth)
 
-  api(Dependencies.HapiFhir.structuresR4) { exclude(module = "junit") }
+  api("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.0.1") { exclude(module = "junit") }
 
   coreLibraryDesugaring(Dependencies.desugarJdkLibs)
 
@@ -92,7 +120,7 @@ dependencies {
   implementation(Dependencies.Room.runtime)
   implementation(Dependencies.timber)
   implementation(Dependencies.http)
-  implementation(Dependencies.HapiFhir.fhirCoreConvertors)
+  implementation("ca.uhn.hapi.fhir:org.hl7.fhir.convertors:6.0.22")
   implementation(Dependencies.apacheCommonsCompress)
 
   kapt(Dependencies.Room.compiler)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,19 @@ if (kokoroRun == true) {
   }
 }
 
+// NECESSARY force of the Jackson to run generateSearchParams in the new version of HAPI (6.8)
+buildscript {
+  dependencies {
+    classpath("com.fasterxml.jackson.core:jackson-core:2.15.2")
+    classpath("com.fasterxml.jackson.core:jackson-annotations:2.15.2")
+    classpath("com.fasterxml.jackson.core:jackson-databind:2.15.2")
+    classpath("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2")
+    classpath("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.15.2")
+    classpath("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
+    classpath("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+  }
+}
+
 include(":catalog")
 
 include(":common")

--- a/workflow-testing/build.gradle.kts
+++ b/workflow-testing/build.gradle.kts
@@ -1,5 +1,3 @@
-import Dependencies.forceHapiVersion
-import Dependencies.forceJacksonVersion
 import Dependencies.removeIncompatibleDependencies
 
 plugins {
@@ -17,8 +15,33 @@ android {
 configurations {
   all {
     removeIncompatibleDependencies()
-    forceHapiVersion()
-    forceJacksonVersion()
+    exclude(
+      module = "hapi-fhir-structures-r4b",
+    )
+    resolutionStrategy {
+      force(Dependencies.guava)
+      force("ca.uhn.hapi.fhir:hapi-fhir-base:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-client:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.convertors:5.6.36")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2016may:5.6.36")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r5:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.36")
+
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu3:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4b:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r5:5.6.36")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r5:6.0.1")
+    }
   }
 }
 

--- a/workflow/benchmark/build.gradle.kts
+++ b/workflow/benchmark/build.gradle.kts
@@ -1,5 +1,3 @@
-import Dependencies.forceHapiVersion
-import Dependencies.forceJacksonVersion
 import Dependencies.removeIncompatibleDependencies
 
 plugins {
@@ -50,8 +48,33 @@ afterEvaluate { configureFirebaseTestLabForMicroBenchmark() }
 configurations {
   all {
     removeIncompatibleDependencies()
-    forceHapiVersion()
-    forceJacksonVersion()
+    exclude(
+      module = "hapi-fhir-structures-r4b",
+    )
+    resolutionStrategy {
+      force(Dependencies.guava)
+      force("ca.uhn.hapi.fhir:hapi-fhir-base:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-client:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.convertors:5.6.36")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2016may:5.6.36")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r5:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.36")
+
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu3:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4b:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r5:5.6.36")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r5:6.0.1")
+    }
   }
 }
 

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -1,3 +1,4 @@
+import Dependencies.forceJacksonVersion
 import Dependencies.guava
 import Dependencies.removeIncompatibleDependencies
 import java.net.URL
@@ -104,9 +105,7 @@ configurations {
       force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:6.0.1")
       force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r5:6.0.1")
     }
-
-    // forceHapiVersion()
-    // forceJacksonVersion()
+    forceJacksonVersion()
   }
 }
 

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -1,5 +1,4 @@
-import Dependencies.forceHapiVersion
-import Dependencies.forceJacksonVersion
+import Dependencies.guava
 import Dependencies.removeIncompatibleDependencies
 import java.net.URL
 
@@ -78,8 +77,36 @@ afterEvaluate { configureFirebaseTestLabForLibraries() }
 configurations {
   all {
     removeIncompatibleDependencies()
-    forceHapiVersion()
-    forceJacksonVersion()
+    exclude(
+      module = "hapi-fhir-structures-r4b",
+    )
+    resolutionStrategy {
+      force(Dependencies.guava)
+      force("ca.uhn.hapi.fhir:hapi-fhir-base:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-client:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.convertors:5.6.36")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2016may:5.6.36")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-structures-r5:6.0.1")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.36")
+
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu2:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.dstu3:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r4b:5.6.36")
+      force("ca.uhn.hapi.fhir:org.hl7.fhir.r5:5.6.36")
+
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:6.0.1")
+      force("ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r5:6.0.1")
+    }
+
+    // forceHapiVersion()
+    // forceJacksonVersion()
   }
 }
 
@@ -98,7 +125,7 @@ dependencies {
   androidTestImplementation(Dependencies.xmlUnit)
   androidTestImplementation(project(":workflow-testing"))
 
-  api(Dependencies.HapiFhir.structuresR4) { exclude(module = "junit") }
+  api("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.0.1") { exclude(module = "junit") }
 
   implementation(Dependencies.Androidx.coreKtx)
 


### PR DESCRIPTION
**Description**
Migrates engine to HAPI 6.8 while forcing Workflow to stay on 6.0

**Type**
Feature 

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
