### PR TITLE
Fix issue with duplicated IDs inside the Knowledge Manager

### DIFF
--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
@@ -124,7 +124,7 @@ internal constructor(
         url != null && version != null ->
           listOfNotNull(knowledgeDao.getResourceWithUrlAndVersion(url, version))
         url != null -> listOfNotNull(knowledgeDao.getResourceWithUrl(url))
-        id != null -> listOfNotNull(knowledgeDao.getResourceWithUrlLike("%$id"))
+        id != null -> knowledgeDao.getResourceWithUrlLike(resType, "%/$id")
         name != null && version != null ->
           listOfNotNull(knowledgeDao.getResourcesWithNameAndVersion(resType, name, version))
         name != null -> knowledgeDao.getResourcesWithName(resType, name)

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/dao/KnowledgeDao.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/dao/KnowledgeDao.kt
@@ -95,10 +95,13 @@ abstract class KnowledgeDao {
   ): ResourceMetadataEntity?
 
   // Remove after https://github.com/google/android-fhir/issues/1920
-  @Query("SELECT * from ResourceMetadataEntity WHERE url LIKE :urlPart")
+  @Query(
+    "SELECT * from ResourceMetadataEntity WHERE resourceType = :resourceType AND url LIKE :urlPart",
+  )
   internal abstract suspend fun getResourceWithUrlLike(
+    resourceType: ResourceType,
     urlPart: String,
-  ): ResourceMetadataEntity?
+  ): List<ResourceMetadataEntity>
 
   @Query(
     "SELECT * from ResourceMetadataEntity WHERE  resourceType = :resourceType AND name = :name",


### PR DESCRIPTION
Search by ID in the KnowledgeManager was used to return only the first reference. If the ID was duplicated in the DB, it would not filter by type and return the wrong one. This fixes it while also enforcing the ID to be a complete word in the URL

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
