### PR TITLE
Renames generateCarePlan's param from patientId to subject

### DIFF
--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
@@ -185,8 +185,8 @@ internal constructor(
    * from a worker thread or it may throw [BlockingMainThreadException] exception.
    */
   @WorkerThread
-  fun generateCarePlan(planDefinitionId: String, patientId: String): IBaseResource {
-    return generateCarePlan(planDefinitionId, patientId, encounterId = null)
+  fun generateCarePlan(planDefinitionId: String, subject: String): IBaseResource {
+    return generateCarePlan(planDefinitionId, subject, encounterId = null)
   }
 
   /**
@@ -198,14 +198,14 @@ internal constructor(
   @WorkerThread
   fun generateCarePlan(
     planDefinitionId: String,
-    patientId: String,
+    subject: String,
     encounterId: String?,
   ): IBaseResource {
     return planDefinitionProcessor.apply(
       /* id = */ IdType("PlanDefinition", planDefinitionId),
       /* canonical = */ null,
       /* planDefinition = */ null,
-      /* subject = */ patientId,
+      /* subject = */ subject,
       /* encounterId = */ encounterId,
       /* practitionerId = */ null,
       /* organizationId = */ null,

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
@@ -99,7 +99,7 @@ class FhirOperatorTest {
     assertThat(
         fhirOperator.generateCarePlan(
           planDefinitionId = "plandefinition-RuleFilters-1.0.0",
-          patientId = "Reportable",
+          subject = "Patient/Reportable",
           encounterId = "reportable-encounter",
         ),
       )
@@ -114,7 +114,7 @@ class FhirOperatorTest {
     val carePlan =
       fhirOperator.generateCarePlan(
         planDefinitionId = "MedRequest-Example",
-        patientId = "Patient/Patient-Example",
+        subject = "Patient/Patient-Example",
       )
 
     println(jsonParser.encodeResourceToString(carePlan))
@@ -138,7 +138,7 @@ class FhirOperatorTest {
     val carePlan =
       fhirOperator.generateCarePlan(
         planDefinitionId = "Plan-Definition-Example",
-        patientId = "Patient/Female-Patient-Example",
+        subject = "Patient/Female-Patient-Example",
       )
 
     println(jsonParser.setPrettyPrint(true).encodeResourceToString(carePlan))


### PR DESCRIPTION
The idea is to: 
1. clarify the need to send a full reference "type/id" instead of just the ID
2. clarify that any reference (e.g. Patient, Group) would work, not only Patient. 
3. match the evaluator's name

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
