### PR TITLE
Overrides Ids when installing an IG

### DIFF
--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/KnowledgeManager.kt
@@ -28,9 +28,11 @@ import com.google.android.fhir.knowledge.npm.NpmPackageDownloader
 import com.google.android.fhir.knowledge.npm.OkHttpNpmPackageDownloader
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.hl7.fhir.instance.model.api.IBaseResource
+import org.hl7.fhir.r4.model.IdType
 import org.hl7.fhir.r4.model.MetadataResource
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.ResourceType
@@ -95,7 +97,13 @@ internal constructor(
       try {
         val resource = jsonParser.parseResource(FileInputStream(file))
         if (resource is Resource) {
-          importResource(igId, resource, file)
+          val newId = importResource(igId, resource, file)
+          resource.setId(IdType(resource.resourceType.name, newId))
+
+          // Overrides the Id in the file
+          FileOutputStream(file).use {
+            it.write(jsonParser.encodeResourceToString(resource).toByteArray())
+          }
         } else {
           Timber.d("Unable to import file: %file")
         }
@@ -124,7 +132,7 @@ internal constructor(
         url != null && version != null ->
           listOfNotNull(knowledgeDao.getResourceWithUrlAndVersion(url, version))
         url != null -> listOfNotNull(knowledgeDao.getResourceWithUrl(url))
-        id != null -> listOfNotNull(knowledgeDao.getResourceWithUrlLike("%$id"))
+        id != null -> listOfNotNull(knowledgeDao.getResourcesWithId(resType, id.toLong()))
         name != null && version != null ->
           listOfNotNull(knowledgeDao.getResourcesWithNameAndVersion(resType, name, version))
         name != null -> knowledgeDao.getResourcesWithName(resType, name)
@@ -154,11 +162,19 @@ internal constructor(
         }
       }
     when (resource) {
-      is Resource -> importResource(igId, resource, file)
+      is Resource -> {
+        val newId = importResource(igId, resource, file)
+        resource.setId(IdType(resource.resourceType.name, newId))
+
+        // Overrides the Id in the file
+        FileOutputStream(file).use {
+          it.write(jsonParser.encodeResourceToString(resource).toByteArray())
+        }
+      }
     }
   }
 
-  private suspend fun importResource(igId: Long?, resource: Resource, file: File) {
+  private suspend fun importResource(igId: Long?, resource: Resource, file: File): Long {
     val metadataResource = resource as? MetadataResource
     val res =
       ResourceMetadataEntity(
@@ -169,7 +185,8 @@ internal constructor(
         metadataResource?.version,
         file,
       )
-    knowledgeDao.insertResource(igId, res)
+
+    return knowledgeDao.insertResource(igId, res)
   }
 
   private fun loadResource(resourceEntity: ResourceMetadataEntity): IBaseResource {

--- a/knowledge/src/main/java/com/google/android/fhir/knowledge/db/dao/KnowledgeDao.kt
+++ b/knowledge/src/main/java/com/google/android/fhir/knowledge/db/dao/KnowledgeDao.kt
@@ -35,7 +35,7 @@ abstract class KnowledgeDao {
   internal open suspend fun insertResource(
     implementationGuideId: Long?,
     resource: ResourceMetadataEntity,
-  ) {
+  ): Long {
     val resourceMetadata =
       if (resource.url != null && resource.version != null) {
         getResourceWithUrlAndVersion(resource.url, resource.version)
@@ -48,6 +48,7 @@ abstract class KnowledgeDao {
     // exception if they are different.
     val resourceMetadataId = resourceMetadata?.resourceMetadataId ?: insert(resource)
     insert(ImplementationGuideResourceMetadataEntity(0, implementationGuideId, resourceMetadataId))
+    return resourceMetadataId
   }
 
   @Transaction
@@ -107,6 +108,14 @@ abstract class KnowledgeDao {
     resourceType: ResourceType,
     name: String?,
   ): List<ResourceMetadataEntity>
+
+  @Query(
+    "SELECT * from ResourceMetadataEntity WHERE resourceType = :resourceType AND resourceMetadataId = :id",
+  )
+  internal abstract suspend fun getResourcesWithId(
+    resourceType: ResourceType,
+    id: Long?,
+  ): ResourceMetadataEntity?
 
   @Query(
     "SELECT * from ResourceMetadataEntity WHERE resourceType = :resourceType AND name = :name AND version = :version",

--- a/knowledge/src/test/java/com/google/android/fhir/knowledge/KnowledgeManagerTest.kt
+++ b/knowledge/src/test/java/com/google/android/fhir/knowledge/KnowledgeManagerTest.kt
@@ -113,14 +113,14 @@ internal class KnowledgeManagerTest {
   fun `inserting a library of a different version creates new entry`() = runTest {
     val libraryAOld =
       Library().apply {
-        id = "defaultA"
+        id = "Library/defaultA-A.1.0.0"
         name = "defaultA"
         url = "www.exampleA.com"
         version = "A.1.0.0"
       }
     val libraryANew =
       Library().apply {
-        id = "defaultA"
+        id = "Library/defaultA-A.1.0.1"
         name = "defaultA"
         url = "www.exampleA.com"
         version = "A.1.0.1"
@@ -131,6 +131,18 @@ internal class KnowledgeManagerTest {
 
     val resources = knowledgeDb.knowledgeDao().getResources()
     assertThat(resources).hasSize(2)
+
+    val resourceA100 =
+      knowledgeManager
+        .loadResources(resourceType = "Library", name = "defaultA", version = "A.1.0.0")
+        .single()
+    assertThat(resourceA100.idElement.toString()).isEqualTo("Library/1")
+
+    val resourceA101 =
+      knowledgeManager
+        .loadResources(resourceType = "Library", name = "defaultA", version = "A.1.0.1")
+        .single()
+    assertThat(resourceA101.idElement.toString()).isEqualTo("Library/2")
   }
 
   fun `installing from npmPackageManager`() = runTest {
@@ -153,7 +165,8 @@ internal class KnowledgeManagerTest {
   }
 
   private fun writeToFile(library: Library): File {
-    return File(context.filesDir, library.name).apply {
+    return File(context.filesDir, library.id).apply {
+      this.parentFile?.mkdirs()
       writeText(jsonParser.encodeResourceToString(library))
     }
   }

--- a/workflow-testing/src/main/resources/plan-definition/cql-applicability-condition/care_plan.json
+++ b/workflow-testing/src/main/resources/plan-definition/cql-applicability-condition/care_plan.json
@@ -1,9 +1,9 @@
 {
   "resourceType": "CarePlan",
-  "id": "Plan-Definition-Example",
+  "id": "17",
   "contained": [ {
     "resourceType": "RequestGroup",
-    "id": "Plan-Definition-Example",
+    "id": "17",
     "instantiatesCanonical": [ "http://example.com/PlanDefinition/Plan-Definition-Example" ],
     "status": "draft",
     "intent": "proposal",
@@ -20,12 +20,12 @@
         }
       } ],
       "resource": {
-        "reference": "Task/Activity-Example"
+        "reference": "Task/16"
       }
     } ]
   }, {
     "resourceType": "Task",
-    "id": "Activity-Example",
+    "id": "16",
     "extension": [ {
       "url": "http://hl7.org/fhir/aphl/StructureDefinition/condition",
       "valueExpression": {
@@ -35,7 +35,7 @@
     } ],
     "instantiatesCanonical": "http://example.com/ActivityDefinition/Activity-Example",
     "basedOn": [ {
-      "reference": "#RequestGroup/Plan-Definition-Example",
+      "reference": "#RequestGroup/17",
       "type": "RequestGroup"
     } ],
     "status": "draft",
@@ -53,7 +53,7 @@
   },
   "activity": [ {
     "reference": {
-      "reference": "#RequestGroup/Plan-Definition-Example"
+      "reference": "#RequestGroup/17"
     }
   } ]
 }

--- a/workflow-testing/src/main/resources/plan-definition/med-request/med_request_careplan.json
+++ b/workflow-testing/src/main/resources/plan-definition/med-request/med_request_careplan.json
@@ -1,10 +1,10 @@
 {
   "resourceType": "CarePlan",
-  "id": "MedRequest-Example",
+  "id": "17",
   "contained": [
     {
       "resourceType": "RequestGroup",
-      "id": "MedRequest-Example",
+      "id": "17",
       "instantiatesCanonical": [
         "http://localhost/PlanDefinition/MedRequest-Example"
       ],
@@ -18,14 +18,14 @@
           "id": "medication-action-1",
           "title": "Administer Medication 1",
           "resource": {
-            "reference": "MedicationRequest/MedicationRequest-1"
+            "reference": "MedicationRequest/16"
           }
         }
       ]
     },
     {
       "resourceType": "MedicationRequest",
-      "id": "MedicationRequest-1",
+      "id": "16",
       "status": "draft",
       "intent": "order",
       "medicationCodeableConcept": {
@@ -50,7 +50,7 @@
   "activity": [
     {
       "reference": {
-        "reference": "#RequestGroup/MedRequest-Example"
+        "reference": "#RequestGroup/17"
       }
     }
   ]

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
@@ -189,6 +189,11 @@ internal constructor(
     return generateCarePlan(planDefinitionId, patientId, encounterId = null)
   }
 
+  @WorkerThread
+  fun generateCarePlan(planDefinition: CanonicalType, patientId: String): IBaseResource {
+    return generateCarePlan(planDefinition, patientId, encounterId = null)
+  }
+
   /**
    * Generates a [CarePlan] based on the provided inputs.
    *
@@ -204,6 +209,33 @@ internal constructor(
     return planDefinitionProcessor.apply(
       /* id = */ IdType("PlanDefinition", planDefinitionId),
       /* canonical = */ null,
+      /* planDefinition = */ null,
+      /* subject = */ patientId,
+      /* encounterId = */ encounterId,
+      /* practitionerId = */ null,
+      /* organizationId = */ null,
+      /* userType = */ null,
+      /* userLanguage = */ null,
+      /* userTaskContext = */ null,
+      /* setting = */ null,
+      /* settingContext = */ null,
+      /* parameters = */ null,
+      /* useServerData = */ null,
+      /* bundle = */ null,
+      /* prefetchData = */ null,
+      libraryProcessor,
+    ) as IBaseResource
+  }
+
+  @WorkerThread
+  fun generateCarePlan(
+    planDefinition: CanonicalType,
+    patientId: String,
+    encounterId: String?,
+  ): IBaseResource {
+    return planDefinitionProcessor.apply(
+      /* id = */ null,
+      /* canonical = */ planDefinition,
       /* planDefinition = */ null,
       /* subject = */ patientId,
       /* encounterId = */ encounterId,

--- a/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
+++ b/workflow/src/test/java/com/google/android/fhir/workflow/FhirOperatorTest.kt
@@ -32,6 +32,7 @@ import java.lang.IllegalArgumentException
 import java.util.TimeZone
 import kotlin.reflect.KSuspendFunction1
 import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.CanonicalType
 import org.hl7.fhir.r4.model.Library
 import org.hl7.fhir.r4.model.MetadataResource
 import org.hl7.fhir.r4.model.Resource
@@ -98,7 +99,10 @@ class FhirOperatorTest {
 
     assertThat(
         fhirOperator.generateCarePlan(
-          planDefinitionId = "plandefinition-RuleFilters-1.0.0",
+          planDefinition =
+            CanonicalType(
+              "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-RuleFilters-1.0.0",
+            ),
           patientId = "Reportable",
           encounterId = "reportable-encounter",
         ),
@@ -113,11 +117,9 @@ class FhirOperatorTest {
 
     val carePlan =
       fhirOperator.generateCarePlan(
-        planDefinitionId = "MedRequest-Example",
+        planDefinition = CanonicalType("http://localhost/PlanDefinition/MedRequest-Example"),
         patientId = "Patient/Patient-Example",
       )
-
-    println(jsonParser.encodeResourceToString(carePlan))
 
     assertEquals(
       readResourceAsString("/plan-definition/med-request/med_request_careplan.json"),
@@ -137,7 +139,7 @@ class FhirOperatorTest {
 
     val carePlan =
       fhirOperator.generateCarePlan(
-        planDefinitionId = "Plan-Definition-Example",
+        planDefinition = CanonicalType("http://example.com/PlanDefinition/Plan-Definition-Example"),
         patientId = "Patient/Female-Patient-Example",
       )
 
@@ -287,11 +289,16 @@ class FhirOperatorTest {
   private fun writeToFile(resource: Resource): File {
     val fileName =
       if (resource is MetadataResource && resource.name != null) {
-        resource.name
+        if (resource.version != null) {
+          resource.name + "-" + resource.version
+        } else {
+          resource.name
+        }
       } else {
-        resource.idElement.idPart
+        resource.idElement.toString()
       }
     return File(context.filesDir, fileName).apply {
+      this.parentFile.mkdirs()
       writeText(jsonParser.encodeResourceToString(resource))
     }
   }


### PR DESCRIPTION
**Description**
A draft solution to make sure the searchById in the Knowledge Manager works without searching by part of the URL. 

This PR: 
1. Overrides `id` when installing Knowledge Artifacts
2. Updates files to match `id`
3. Updates test case framework to not rely in `id`, because they will change 
4. Updates FhirOperator interface to offer a way to not use the internal `id` when selecting a PlanDefinition
5. Updates test cases to match the new output `id`s 

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
