### PR TITLE
Update the version of resource after updates are downloaded from the server

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/MoreResources.kt
+++ b/engine/src/main/java/com/google/android/fhir/MoreResources.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2022-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ fun <R : Resource> getResourceClass(resourceType: String): Class<R> {
   return Class.forName(R4_RESOURCE_PACKAGE_PREFIX + className) as Class<R>
 }
 
-internal val Resource.versionId
+internal val Resource.versionId: String?
   get() = meta.versionId
 
 internal val Resource.lastUpdated

--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
@@ -140,7 +140,7 @@ internal class DatabaseImpl(
       resources.forEach {
         val timeOfLocalChange = Instant.now()
         val oldResourceEntity = selectEntity(it.resourceType, it.logicalId)
-        resourceDao.updateLocalChange(it, timeOfLocalChange)
+        resourceDao.applyLocalUpdate(it, timeOfLocalChange)
         localChangeDao.addUpdate(oldResourceEntity, it, timeOfLocalChange)
       }
     }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/DatabaseImpl.kt
@@ -140,7 +140,7 @@ internal class DatabaseImpl(
       resources.forEach {
         val timeOfLocalChange = Instant.now()
         val oldResourceEntity = selectEntity(it.resourceType, it.logicalId)
-        resourceDao.update(it, timeOfLocalChange)
+        resourceDao.updateLocalChange(it, timeOfLocalChange)
         localChangeDao.addUpdate(oldResourceEntity, it, timeOfLocalChange)
       }
     }

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -62,7 +62,7 @@ internal abstract class ResourceDao {
    * Updates the resource in the [ResourceEntity] and adds indexes.
    *
    * @param [resource] the resource with local (on device) updates
-   * @param [timeOfLocalChange] Time when the local change was made.
+   * @param [timeOfLocalChange] time when the local change was made
    */
   suspend fun applyLocalUpdate(resource: Resource, timeOfLocalChange: Instant?) {
     getResourceEntity(resource.logicalId, resource.resourceType)?.let {

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -61,7 +61,7 @@ internal abstract class ResourceDao {
   /**
    * Updates the resource in the [ResourceEntity] and adds indexes.
    *
-   * @param [resource] The resource with local (on device) updates.
+   * @param [resource] the resource with local (on device) updates
    * @param [timeOfLocalChange] Time when the local change was made.
    */
   suspend fun applyLocalUpdate(resource: Resource, timeOfLocalChange: Instant?) {

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -59,7 +59,8 @@ internal abstract class ResourceDao {
   lateinit var resourceIndexer: ResourceIndexer
 
   /**
-   * Updates the resource in the [ResourceEntity] and adds indexes as a result of changes made on device.
+   * Updates the resource in the [ResourceEntity] and adds indexes as a result of changes made on
+   * device.
    *
    * @param [resource] the resource with local (on device) updates
    * @param [timeOfLocalChange] time when the local change was made
@@ -77,7 +78,8 @@ internal abstract class ResourceDao {
   }
 
   /**
-   * Updates the resource in the [ResourceEntity] and adds indexes as a result of downloading the resource from server.
+   * Updates the resource in the [ResourceEntity] and adds indexes as a result of downloading the
+   * resource from server.
    *
    * @param [resource] the resource with the remote(server) updates
    */
@@ -118,7 +120,7 @@ internal abstract class ResourceDao {
     updateIndicesForResource(index, resource.resourceType, entity.resourceUuid)
   }
 
- suspend fun insertAllRemote(resources: List<Resource>): List<UUID> {
+  suspend fun insertAllRemote(resources: List<Resource>): List<UUID> {
     return resources.map { resource -> insertRemoteResource(resource) }
   }
 

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -79,7 +79,7 @@ internal abstract class ResourceDao {
   /**
    * Updates the resource in the [ResourceEntity] and adds indexes.
    *
-   * @param [resource] The resource with the remote(server) updates.
+   * @param [resource] the resource with the remote(server) updates
    */
   private suspend fun applyRemoteUpdate(resource: Resource) {
     getResourceEntity(resource.logicalId, resource.resourceType)?.let {

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -94,7 +94,6 @@ internal abstract class ResourceDao {
       ?: throw ResourceNotFoundException(resource.resourceType.name, resource.id)
   }
 
-  // WARNING : This is a private function and shouldn't be called directly.
   private suspend fun updateChanges(entity: ResourceEntity, resource: Resource) {
     // The foreign key in Index entity tables is set with cascade delete constraint and
     // insertResource has REPLACE conflict resolution. So, when we do an insert to update the

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -119,7 +119,7 @@ internal abstract class ResourceDao {
     updateIndicesForResource(index, resource.resourceType, entity.resourceUuid)
   }
 
-  open suspend fun insertAllRemote(resources: List<Resource>): List<UUID> {
+ suspend fun insertAllRemote(resources: List<Resource>): List<UUID> {
     return resources.map { resource -> insertRemoteResource(resource) }
   }
 

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -67,6 +67,7 @@ internal abstract class ResourceDao {
           serializedResource = iParser.encodeResourceToString(resource),
           lastUpdatedLocal = timeOfLocalChange,
           lastUpdatedRemote = lastUpdatedRemote?.toInstant() ?: it.lastUpdatedRemote,
+          versionId = resource.versionId ?: it.versionId,
         )
       // The foreign key in Index entity tables is set with cascade delete constraint and
       // insertResource has REPLACE conflict resolution. So, when we do an insert to update the

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -59,7 +59,7 @@ internal abstract class ResourceDao {
   lateinit var resourceIndexer: ResourceIndexer
 
   /**
-   * Updates the resource in the [ResourceEntity] and adds indexes.
+   * Updates the resource in the [ResourceEntity] and adds indexes as a result of changes made on device.
    *
    * @param [resource] the resource with local (on device) updates
    * @param [timeOfLocalChange] time when the local change was made

--- a/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/dao/ResourceDao.kt
@@ -77,7 +77,7 @@ internal abstract class ResourceDao {
   }
 
   /**
-   * Updates the resource in the [ResourceEntity] and adds indexes.
+   * Updates the resource in the [ResourceEntity] and adds indexes as a result of downloading the resource from server.
    *
    * @param [resource] the resource with the remote(server) updates
    */

--- a/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
@@ -616,7 +616,7 @@ class FhirEngineImplTest {
       // First sync
       fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf((originalPatient)))) }
 
-      val remoteChange =
+      val updatedPatient =
         originalPatient.copy().apply {
           meta =
             Meta().apply {
@@ -627,11 +627,11 @@ class FhirEngineImplTest {
         }
 
       // Sync to get updates from server
-      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf(remoteChange))) }
+      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf(updatedPatient))) }
 
       val result = services.database.selectEntity(ResourceType.Patient, "original-002")
-      assertThat(result.versionId).isEqualTo(remoteChange.versionId)
-      assertThat(result.lastUpdatedRemote).isEqualTo(remoteChange.lastUpdated)
+      assertThat(result.versionId).isEqualTo(updatedPatient.versionId)
+      assertThat(result.lastUpdatedRemote).isEqualTo(updatedPatient.lastUpdated)
     }
 
   @Test
@@ -659,7 +659,7 @@ class FhirEngineImplTest {
         originalPatient.copy().apply { addAddress(Address().apply { city = "Malibu" }) }
       fhirEngine.update(localChange)
 
-      val remoteChange =
+      val updatedPatient =
         originalPatient.copy().apply {
           meta =
             Meta().apply {
@@ -670,10 +670,10 @@ class FhirEngineImplTest {
         }
 
       // Sync to get updates from server
-      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf(remoteChange))) }
+      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf(updatedPatient))) }
 
       val result = fhirEngine.getLocalChanges(ResourceType.Patient, "original-002").first()
-      assertThat(result.versionId).isEqualTo(remoteChange.versionId)
+      assertThat(result.versionId).isEqualTo(updatedPatient.versionId)
     }
 
   @Test

--- a/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
@@ -24,6 +24,7 @@ import com.google.android.fhir.LocalChange.Type
 import com.google.android.fhir.LocalChangeToken
 import com.google.android.fhir.db.ResourceNotFoundException
 import com.google.android.fhir.get
+import com.google.android.fhir.lastUpdated
 import com.google.android.fhir.logicalId
 import com.google.android.fhir.search.LOCAL_LAST_UPDATED_PARAM
 import com.google.android.fhir.search.search
@@ -36,7 +37,9 @@ import com.google.android.fhir.sync.upload.UploadSyncResult
 import com.google.android.fhir.testing.assertResourceEquals
 import com.google.android.fhir.testing.assertResourceNotEquals
 import com.google.android.fhir.testing.readFromFile
+import com.google.android.fhir.versionId
 import com.google.common.truth.Truth.assertThat
+import java.time.Instant
 import java.util.Date
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
@@ -590,6 +593,87 @@ class FhirEngineImplTest {
         )
         .isEqualTo(localChangeDiff)
       assertResourceEquals(fhirEngine.get<Patient>("original-002"), localChange)
+    }
+
+  @Test
+  fun `syncDownload ResourceEntity should have the latest versionId and lastUpdated from server`() =
+    runBlocking {
+      val originalPatient =
+        Patient().apply {
+          id = "original-002"
+          meta =
+            Meta().apply {
+              versionId = "1"
+              lastUpdated = Date.from(Instant.parse("2022-12-02T10:15:30.00Z"))
+            }
+          addName(
+            HumanName().apply {
+              family = "Stark"
+              addGiven("Tony")
+            },
+          )
+        }
+      // First sync
+      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf((originalPatient)))) }
+
+      val remoteChange =
+        originalPatient.copy().apply {
+          meta =
+            Meta().apply {
+              versionId = "2"
+              lastUpdated = Date.from(Instant.parse("2022-12-03T10:15:30.00Z"))
+            }
+          addAddress(Address().apply { country = "USA" })
+        }
+
+      // Sync to get updates from server
+      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf(remoteChange))) }
+
+      val result = services.database.selectEntity(ResourceType.Patient, "original-002")
+      assertThat(result.versionId).isEqualTo(remoteChange.versionId)
+      assertThat(result.lastUpdatedRemote).isEqualTo(remoteChange.lastUpdated)
+    }
+
+  @Test
+  fun `syncDownload LocalChangeEntity should have the latest versionId from server`() =
+    runBlocking {
+      val originalPatient =
+        Patient().apply {
+          id = "original-002"
+          meta =
+            Meta().apply {
+              versionId = "1"
+              lastUpdated = Date.from(Instant.parse("2022-12-02T10:15:30.00Z"))
+            }
+          addName(
+            HumanName().apply {
+              family = "Stark"
+              addGiven("Tony")
+            },
+          )
+        }
+      // First sync
+      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf((originalPatient)))) }
+
+      val localChange =
+        originalPatient.copy().apply { addAddress(Address().apply { city = "Malibu" }) }
+      fhirEngine.update(localChange)
+
+      val remoteChange =
+        originalPatient.copy().apply {
+          meta =
+            Meta().apply {
+              versionId = "2"
+              lastUpdated = Date.from(Instant.parse("2022-12-03T10:15:30.00Z"))
+            }
+          addAddress(Address().apply { country = "USA" })
+        }
+
+      // Sync to get updates from server
+      fhirEngine.syncDownload(AcceptLocalConflictResolver) { flowOf((listOf(remoteChange))) }
+
+      val result = fhirEngine.getLocalChanges(ResourceType.Patient, "original-002").first()
+      assertThat(result.versionId).isEqualTo(remoteChange.versionId)
     }
 
   @Test


### PR DESCRIPTION

Fixes #2271

**Description**
When updates are downloaded from the server, the database update code wasn't putting the new versionID of the updated resource into the table. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix 
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
