### PR TITLE
Bump Jackson versions in (only) buildscript from 2.15.2 to 2.15.3

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,13 +31,13 @@ if (kokoroRun == true) {
 // NECESSARY force of the Jackson to run generateSearchParams in the new version of HAPI (6.8)
 buildscript {
   dependencies {
-    classpath("com.fasterxml.jackson.core:jackson-core:2.15.2")
-    classpath("com.fasterxml.jackson.core:jackson-annotations:2.15.2")
-    classpath("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-    classpath("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2")
-    classpath("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.15.2")
-    classpath("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
-    classpath("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+    classpath("com.fasterxml.jackson.core:jackson-core:2.15.3")
+    classpath("com.fasterxml.jackson.core:jackson-annotations:2.15.3")
+    classpath("com.fasterxml.jackson.core:jackson-databind:2.15.3")
+    classpath("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3")
+    classpath("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.15.3")
+    classpath("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3")
+    classpath("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3")
   }
 }
 


### PR DESCRIPTION
This is better than #2283 and #2285.