### PR TITLE
Introduce Version Catalog, initially intentionally only for Glide

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -41,10 +41,6 @@ object Dependencies {
       "org.opencds.cqf.fhir:cqf-fhir-utility:${Versions.Cql.clinicalReasoning}"
   }
 
-  object Glide {
-    const val glide = "com.github.bumptech.glide:glide:${Versions.Glide.glide}"
-  }
-
   object HapiFhir {
     const val fhirBase = "ca.uhn.hapi.fhir:hapi-fhir-base:${Versions.hapiFhir}"
     const val fhirClient = "ca.uhn.hapi.fhir:hapi-fhir-client:${Versions.hapiFhir}"
@@ -216,10 +212,6 @@ object Dependencies {
 
     object Cql {
       const val clinicalReasoning = "3.0.0-PRE9-SNAPSHOT"
-    }
-
-    object Glide {
-      const val glide = "4.14.2"
     }
 
     object Kotlin {

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
   implementation(Dependencies.Androidx.constraintLayout)
   implementation(Dependencies.Androidx.coreKtx)
   implementation(Dependencies.Androidx.fragmentKtx)
-  implementation(Dependencies.Glide.glide)
+  implementation(libs.glide)
   implementation(Dependencies.HapiFhir.guavaCaching)
   implementation(Dependencies.HapiFhir.validation) {
     exclude(module = "commons-logging")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+# see https://docs.gradle.org/current/userguide/platforms.html
+
+[versions]
+glide = "4.14.2"
+
+[libraries]
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+
+[bundles]
+
+[plugins]


### PR DESCRIPTION
see #2302 

My expectation is that if this passes CI and gets merged, Dependabot will automagically propose a bump for Glide - let's try and see.

If this works, we should then migrate to this model. Perhaps that's something that could be "crowd sourced" and fanned out, instead of me doing all migrations myself?

PS: There would be an intermediate phase with "mixed" dependency declaration; to me such a "gradual adoption" is a "feature not a bug", with testing each change, and more sensible than a single big bang all in one migration.