### PR TITLE
Replace styfle/cancel-workflow-action with new GitHub `concurrency:` standard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,11 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: "fhir" # change this to invalidate cache
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
-  cancel-in-progress: true
+  # github.head_ref uniquely identifies Pull Requests (but is not available when building branches like main or master)
+  # github.ref is the fallback used when building for workflows triggered by push
+  # Note that || are fallback values (not "concatenations")
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true # Use e.g. ${{ github.ref != 'refs/heads/main' }} (or master, until #2180) to only cancel for PRs not on branch
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ env:
   GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: "fhir" # change this to invalidate cache
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Build will compile APK, test APK and run tests, lint, etc.
@@ -49,10 +53,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          access_token: ${{ github.token }}
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repo

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -28,6 +28,10 @@ on:
   schedule:
     - cron: '32 13 * * 2'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
See https://github.com/styfle/cancel-workflow-action/blob/main/README.md (and go/github-actions#cancel-workflows)

I've intentionally raised this separately from #2313 (which is included here) and #2314 (which builds on this) to make it easier to review, and revert in case it's needed because this unexpectedly breaks anything (which it should not).

This should be rebased after #2313 is merged.