### PR TITLE
disable jetifier in codelab and bump to use latest version of engine

### DIFF
--- a/codelabs/datacapture/gradle.properties
+++ b/codelabs/datacapture/gradle.properties
@@ -15,7 +15,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/codelabs/engine/README.md
+++ b/codelabs/engine/README.md
@@ -125,7 +125,7 @@ file of your project:
 dependencies {
     // ...
 
-    implementation("com.google.android.fhir:engine:0.1.0-beta04")
+    implementation("com.google.android.fhir:engine:0.1.0-beta05")
 }
 ```
 

--- a/codelabs/engine/app/build.gradle.kts
+++ b/codelabs/engine/app/build.gradle.kts
@@ -49,6 +49,6 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
-    implementation("com.google.android.fhir:engine:0.1.0-beta04")
+    implementation("com.google.android.fhir:engine:0.1.0-beta05")
     implementation("androidx.fragment:fragment-ktx:1.6.1")
 }

--- a/codelabs/engine/gradle.properties
+++ b/codelabs/engine/gradle.properties
@@ -15,7 +15,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official


### PR DESCRIPTION
**Description**
Get engine codelab to work with the latest version of the engine lib

The main change is to disable Android Jetifier when building the app. The Jackson library is not compaitble with Jetifier.



**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
