### PR TITLE
Switch Firebase Test Lab Artifacts to another GCP GCS Bucket

### DIFF
--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -87,7 +87,9 @@ private fun FlankGradleExtension.commonConfigurationForFirebaseTestLab(project: 
   maxTestShards.set(10)
   testTimeout.set("45m")
   directoriesToPull.set(listOf("/sdcard/Download"))
-  resultsBucket.set("android-fhir-build-artifacts")
+  resultsBucket.set(
+    "android-fhir-firebase-test-logs",
+  ) // This is also in //kokoro/gcp_ubuntu/kokoro_build.sh as GCS_BUCKET!
   resultsDir.set(
     if (project.providers.environmentVariable("KOKORO_BUILD_ARTIFACTS_SUBDIR").isPresent) {
       "${System.getenv("KOKORO_BUILD_ARTIFACTS_SUBDIR")}/firebase/${project.name}"

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -38,7 +38,8 @@ set -e
 export JAVA_HOME="/usr/lib/jvm/java-1.17.0-openjdk-amd64"
 export ANDROID_HOME=${HOME}/android_sdk
 export PATH=$PATH:$JAVA_HOME/bin:${ANDROID_HOME}/cmdline-tools/latest/bin
-export GCS_BUCKET="android-fhir-build-artifacts"
+export GCS_BUCKET="android-fhir-firebase-test-logs"
+# This ^^^ is also in //buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt as resultsBucket.set()
 
 # Uploads files generated from builds and tests to GCS when this script exits.
 # If videos were recorded from Firebase, prints their URL to the console so users


### PR DESCRIPTION
Related to #2304

Motivated by https://github.com/google/android-fhir/issues/2304#issuecomment-1783526569.

Not technically strictly required, but it (having the GCS bucket in the same single GCP project) seems simpler, to me.

Happy to abandon this if I'm missing something.