### PR TITLE
Move long process to background thread

### DIFF
--- a/catalog/src/main/assets/behavior_calculated_expression.json
+++ b/catalog/src/main/assets/behavior_calculated_expression.json
@@ -1,31 +1,58 @@
 {
   "resourceType": "Questionnaire",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q1",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='7cc2e8a9-197a-42ea-9431-ba01eefc6511').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q1-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q1-boolean.exists(), %q1-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "basic-questions-exists",
+        "language": "text/fhirpath",
+        "expression": "%q1-boolean.exists() and %q2-boolean.exists() and %q3-boolean.exists() and %q4-boolean.exists() and %q5a-boolean.exists() and %q6a-boolean.exists() and %q6b-boolean.exists() and (%q6c-boolean.exists() or %q7-boolean.exists())"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "low-risk",
+        "language": "text/fhirpath",
+        "expression": "((%q1-boolean or %q1-boolean.not()) or (%q2-boolean or %q2-boolean.not())) and (%moderate-risk-helper.not() and %high-risk-helper.not() and %severe-risk-helper.not())"
+      }
+    }
+  ],
   "item": [
     {
       "linkId": "a-birthdate",
       "text": "Birth Date",
-      "type": "date",
+      "type": "boolean",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
           "valueExpression": {
             "language": "text/fhirpath",
-            "expression": "%resource.repeat(item).where(linkId='a-age-years' and answer.empty().not()).select(today() - answer.value)"
+            "expression": "%q1"
           }
         }
       ]
     },
     {
-      "linkId": "a-age-years",
-      "text": "Age years",
-      "type": "quantity",
-      "initial": [{
-        "valueQuantity": {
-          "unit": "years",
-          "system": "http://unitsofmeasure.org",
-          "code": "years"
-        }
-      }]
+      "linkId": "7cc2e8a9-197a-42ea-9431-ba01eefc6511",
+      "text": "In the past month, have you wished you were dead or wished you could go to sleep and not wake up?",
+      "type": "boolean"
     }
   ]
 }

--- a/catalog/src/main/assets/component_text_fields.json
+++ b/catalog/src/main/assets/component_text_fields.json
@@ -4,6 +4,12 @@
     {
       "linkId": "1",
       "type": "string",
+      "readOnly": true,
+      "initial": [
+        {
+          "valueString": "whatyoo"
+        }
+      ],
       "item": [
         {
           "linkId": "1.1",

--- a/catalog/src/main/assets/layout_default.json
+++ b/catalog/src/main/assets/layout_default.json
@@ -1,121 +1,893 @@
 {
   "resourceType": "Questionnaire",
+  "id": "381030",
+  "meta": {
+    "versionId": "10",
+    "lastUpdated": "2023-08-31T01:28:16.698+00:00",
+    "source": "#11fc110835880641"
+  },
+  "language": "en",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q1-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='7cc2e8a9-197a-42ea-9431-ba01eefc6511').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q1-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q1-boolean.exists(), %q1-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q2-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='e2a74544-b333-4767-b3e3-7772413419ce').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q2-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q2-boolean.exists(), %q2-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q3-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='35062b98-748b-441c-ad74-185823e1bb52').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q3-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q3-boolean.exists(), %q3-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q4-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='41aee132-ab8e-4d64-a322-eed88f900edb').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q4-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q4-boolean.exists(), %q4-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q5a-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='567e992d-fb9e-4608-9be1-9277beae3c23').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q5a-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q5a-boolean.exists(), %q5a-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q6a-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='91e9233a-9ab1-410a-b5e3-b30867355cea').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q6a-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q6a-boolean.exists(), %q6a-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q6b-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='3c394824-02d4-4b34-b706-f89735adcd3a').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q6b-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q6b-boolean.exists(), %q6b-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q6c-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='2897fef9-abcf-4bb3-b33f-2accae4c06c5').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q6c-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q6c-boolean.exists(), %q6c-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q7-boolean",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='dcc8f1f9-c615-44d9-ab8e-ad3dec5e8d59').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q7-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q7-boolean.exists(), %q7-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "basic-questions-exists",
+        "language": "text/fhirpath",
+        "expression": "%q1-boolean.exists() and %q2-boolean.exists() and %q3-boolean.exists() and %q4-boolean.exists() and %q5a-boolean.exists() and %q6a-boolean.exists() and %q6b-boolean.exists() and (%q6c-boolean.exists() or %q7-boolean.exists())"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "low-risk",
+        "language": "text/fhirpath",
+        "expression": "((%q1-boolean or %q1-boolean.not()) or (%q2-boolean or %q2-boolean.not())) and (%moderate-risk-helper.not() and %high-risk-helper.not() and %severe-risk-helper.not())"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "moderate-risk",
+        "language": "text/fhirpath",
+        "expression": "(%q3-boolean-safe or %q7-boolean-safe) and (%high-risk-helper.not() and %severe-risk-helper.not())"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "moderate-risk-helper",
+        "language": "text/fhirpath",
+        "expression": "(%q3-boolean-safe or %q7-boolean-safe)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "high-risk",
+        "language": "text/fhirpath",
+        "expression": "(%q4-boolean-safe or %q6b-boolean-safe or %q6c-boolean-safe) and %severe-risk-helper.not()"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "high-risk-helper",
+        "language": "text/fhirpath",
+        "expression": "(%q4-boolean-safe or %q6b-boolean-safe or %q6c-boolean-safe)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "thinking-suicide",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='a80c1bc9-9554-4f83-9b01-2fc385589caf').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "thinking-suicide-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%thinking-suicide.exists(), %thinking-suicide, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "show-suicidal-thoughts-come-and-go",
+        "language": "text/fhirpath",
+        "expression": "%low-risk and %thinking-suicide-safe"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "moderate-or-high-risk",
+        "language": "text/fhirpath",
+        "expression": "%moderate-risk or %high-risk or %thinking-suicide = false"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "plan-approval",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='a842d271-cd48-47c7-963e-dcd0376ef185').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "moderate-or-high-risk-w-plan-approval",
+        "language": "text/fhirpath",
+        "expression": "%moderate-or-high-risk and %plan-approval = true"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "moderate-or-high-risk-w-plan-disapproval",
+        "language": "text/fhirpath",
+        "expression": "%moderate-or-high-risk and %plan-approval = false"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "severe-risk",
+        "language": "text/fhirpath",
+        "expression": "%q5a-boolean-safe"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "severe-risk-helper",
+        "language": "text/fhirpath",
+        "expression": "%q5a-boolean-safe"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "show-end-pages",
+        "language": "text/fhirpath",
+        "expression": "%low-risk or %moderate-or-high-risk or %severe-risk"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "text-start-of-suicide",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='92ab6e65-f9bd-4718-8af6-f731425d3031').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "text-peak-of-suicide",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='9d203bac-75fd-4f31-bed6-073502a977f3').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "text-resolution-of-suicide",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='90cedcbf-bf11-4dc3-9733-42e6900a09fc').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "warning-other",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='58721b3d-88ae-4888-b5ec-ef7dfe30fb3d').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "coping-self-care",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='3cae39d6-8d44-4fe4-835b-3f3ecd9b64fe').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "coping-other",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='db779cb5-5335-4eb6-8ccc-47ec94c626c8').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-1-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='a0017b28-0aa9-4926-a7be-813f0a5e6bd0').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-1-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='bc981d8a-7f22-450b-abab-3acca810ccad').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-2-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='d1c2fae1-f0f5-4333-97f6-2220d2ff3d95').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-2-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='603d1492-316f-497f-967b-5c4b1ab983ea').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-3-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='f5ab53d4-824c-460f-8939-b86ff3cd97a3').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-3-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='53def3a1-a7e5-4326-95f2-2561c26ecb47').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-4-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='a20b29af-3317-415e-9c6e-d9f3bbc4df33').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-4-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='965b7874-dd24-4215-acd4-8d241a262638').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-5-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='a33cdecd-b7e6-45d8-94b6-52fa80c64a6d').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "person-5-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='892337bd-d7fd-46a7-bf72-08e87c9f412c').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "place-1",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='5e2ab0f5-f5d9-4502-befe-aba770f0e206').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "place-2",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='895fad45-c3b5-47c5-9edf-5f9b9e793fbf').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "place-3",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='faefef23-d2e6-4777-b628-8f83921e8fd8').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "place-4",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='62a04638-8928-4aab-b490-1a33739b7a5c').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "place-5",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='249f5ce8-ecc0-4e43-9675-6b01ca1502a3').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-1-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='d1efad02-3686-4ce3-a96d-68d8c638ff77').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-2-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='544a444d-b101-4d56-9351-00bca8ec749e').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-3-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='e9e056c2-0469-4523-a28f-1000fed1a4f1').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-4-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='0399b747-eb74-48cf-aa07-6e9b57ee0883').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-5-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='d7f53320-e620-49e1-9a5d-b819b8d8d4c0').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-1-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='68fa6f2e-84ec-4dbc-900e-10ede297c488').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-2-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='84018cd8-9134-429c-8dfe-fd6a16e4bd17').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-3-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='bd62b649-7209-4d32-9bbb-dc2b2823aadb').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-4-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='fa1828dd-cf04-4fdc-979a-3b5c265d5c77').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-5-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='5b3b60f3-fe9c-49e4-9493-922f65ccc80c').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-1-barrier",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='ff115c26-95b9-4e0d-87ed-80817d438fc7').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-2-barrier",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='7e38a614-b0a2-48ea-b7c7-ca2bdc1f00db').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-3-barrier",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='fefdc90f-fe1d-4bfb-af93-94df8c482897').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-4-barrier",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='1341d9f8-c5eb-4191-93df-d582e622dcda').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "family-5-barrier",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='56682660-6256-4398-a93b-3e5246cc315a').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-1-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='beb4ad5f-2fd8-4b80-aa93-aa9ff1896dd0').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-1-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='c6c266cc-1c85-41c0-97ce-9ab491be45db').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-1-address",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='f7496859-63bb-4b2f-8f75-96e44e893bf7').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-2-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='13321778-b5d4-4b01-8eda-610cf0007c86').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-2-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='c1e99f8b-b1ab-46d1-b205-ecbbb4240fdf').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-2-address",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='f952feaf-7abc-4f6f-a3bc-d10a43ea62fa').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-3-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='ae949697-92ae-476a-96cc-f8b0adc4221f').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-3-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='1fc8f8e7-2022-48d2-b41d-4e8ad22af344').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-3-address",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='44f02467-8ee0-49f0-8da7-5e7ed827125a').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-4-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='796f5440-54f8-4d69-b961-a5b7e6a63240').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-4-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='92da95cc-50dd-4bf0-acca-4465c07d44cc').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-4-address",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='f895ed4f-5004-4da4-9d59-c21293674b21').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-5-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='dae7f411-758d-4800-9842-fc0038a6b4a4').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-5-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='0c308fef-8ce5-4217-a8d4-8e6ff00c8e14').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "hospital-5-address",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='9faa2b78-1842-4326-bf7f-9975bf04dc2c').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-1-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='a57b5b34-12e5-4ec8-8215-7f316267323a').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-1-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='d617b1e1-ea22-4863-a878-627f6b81963e').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-1-workplace",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='c0655b11-8f21-47ed-8ede-95498c2e8200').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-2-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='527c0166-cc35-4cc3-a9d9-7eeb0a54635e').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-2-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='e8726638-cfdb-40ae-b72c-f1d594f64de5').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-2-workplace",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='e7ba8485-5154-41b8-ac18-35410a83cd99').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-3-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='1d0ad825-09de-4018-a680-cd0e6bf0983d').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-3-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='9e11ce97-90e8-42f2-ba18-8c4f0720c131').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-3-workplace",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='cb75bba9-0bd8-4dce-ba2f-d1b21a97c2a0').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-4-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='13e2f934-82ed-4b23-af6e-95523dc3746a').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-4-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='cf16ca6e-8b1b-467d-b807-fc5d50339f71').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-4-workplace",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='ce18eee3-aa64-4423-8db1-50fe7f00850d').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-5-name",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='cebffdf4-8fd1-4829-884c-41cc42bc0111').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-5-number",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='46c2861b-70a9-4fdf-94ea-e1a01cae3149').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "comm-5-workplace",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='8a5b1c7d-e3ef-4443-85f1-fa5213d89f8d').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-pill",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='0b247120-23cf-45fc-9e4d-d959f0dda79f').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-toxin",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='3ab931b8-6bfd-4e5f-b86b-3c7377907331').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-cut",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='6f68c416-a5de-4f68-8ad0-33c6e85a9a68').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-hang",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='22c11dbc-73e0-4470-9ef6-d9bd01f48c99').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-weapon",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='88e9b865-b81a-494b-aef2-39e803b94e73').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-jump",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='229e58ac-a18a-48dd-be10-f8b024a74eb3').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-drown",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='53932020-eed8-46f4-8236-d548a6335a59').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "env-other",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='c5720a67-803f-4917-8261-3738de838418').answer.value"
+      }
+    }
+  ],
+  "version": "0.0.1",
+  "title": "SPI",
+  "status": "draft",
+  "subjectType": [
+    "Patient"
+  ],
+  "publisher": "ona",
+  "contact": [
+    {
+      "name": "http://www.smartregister.org/"
+    }
+  ],
+  "description": "SPI - Safety Planning Intervention form",
   "item": [
     {
-      "linkId": "1",
-      "type": "display",
-      "text": "Personal information",
-      "prefix":"1."
-    },
-    {
-      "linkId": "2",
-      "type": "string",
-      "required": true,
-      "item": [
-        {
-          "linkId": "2.1",
-          "text": "First Name",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "3",
-      "type": "string",
-      "item": [
-        {
-          "linkId": "3.1",
-          "text": "Family Name",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "4",
-      "type": "integer",
-      "item": [
-        {
-          "linkId": "4.1",
-          "text": "ID number",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "5",
-      "type": "integer",
-      "item": [
-        {
-          "linkId": "5.1",
-          "text": "Mobile number",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "6",
-      "type": "choice",
-      "repeats": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -123,53 +895,25 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "check-box",
-                "display": "Checkbox"
+                "code": "page",
+                "display": "Page"
               }
             ],
-            "text": "Checkbox"
+            "text": "Page"
           }
         }
       ],
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "code",
-            "display": "Receive SMS reminders"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "7",
-      "type": "date",
-      "text": "Date of birth",
-      "prefix":"2.",
+      "linkId": "0ee86db4-a12a-4aa9-9419-1c0dd2c1f44d",
+      "type": "group",
       "item": [
         {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-display-category",
-                    "code": "instructions"
-                  }
-                ]
-              }
-            }
-          ],
-          "linkId": "7.1",
-          "text": "If the real DOB is unknown, provide an estimated year.",
-          "type": "display"
+          "linkId": "3f8fac08-5705-475e-8eff-ea8349ac83e2",
+          "text": "<b>SPI - Safety Planning Intervention</b>",
+          "type": "group"
         }
       ]
     },
     {
-      "linkId": "8",
-      "type": "choice",
-      "repeats": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -177,214 +921,30 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "check-box",
-                "display": "Checkbox"
+                "code": "page",
+                "display": "Page"
               }
             ],
-            "text": "Checkbox"
+            "text": "Page"
           }
         }
       ],
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "code1",
-            "display": "Unknown birthday"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "9",
-      "type": "display",
-      "text": "Address",
-      "prefix":"3."
-    },
-    {
-      "linkId": "10",
-      "type": "string",
+      "linkId": "388018bb-88f0-4127-9800-5922026001e0",
+      "type": "group",
       "item": [
         {
-          "linkId": "10.1",
-          "text": "House number and street",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "11",
-      "type": "string",
-      "item": [
+          "linkId": "fc7e7494-92d1-4c5b-9e30-509b05802274",
+          "text": "<b>Discuss confidentiality</b>",
+          "type": "group"
+        },
         {
-          "linkId": "11.1",
-          "text": "Apartment, unit",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "12",
-      "type": "string",
-      "item": [
-        {
-          "linkId": "12.1",
-          "text": "City, town or village",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "13",
-      "type": "string",
-      "item": [
-        {
-          "linkId": "13.1",
-          "text": "County",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "14",
-      "type": "string",
-      "item": [
-        {
-          "linkId": "14.1",
-          "text": "Postal Code",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "15",
-      "type": "display",
-      "text": "Alternative contact person",
-      "prefix":"4.",
-      "item": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-display-category",
-                    "code": "instructions"
-                  }
-                ]
-              }
-            }
-          ],
-          "linkId": "15.1",
-          "text": "The alternative contact would be used in the case of an emergency situation and could be next of kin (e.g. partner, mother, sibling.)",
+          "linkId": "a7c26a50-3266-4789-8acf-f2234652ce04",
+          "text": "Everything you say here will be kept private between the two of us, unless you want me to tell someone else or you are in danger.",
           "type": "display"
         }
       ]
     },
     {
-      "linkId": "16",
-      "type": "string",
-      "item": [
-        {
-          "linkId": "16.1",
-          "text": "Name",
-          "type": "display",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
-                  }
-                ],
-                "text": "Flyover"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "17",
-      "type": "choice",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -392,19 +952,1462 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "drop-down",
-                "display": "Drop down"
+                "code": "page",
+                "display": "Page"
               }
             ],
-            "text": "Drop down"
+            "text": "Page"
           }
+        }
+      ],
+      "linkId": "1609bf66-d918-411f-88b1-77ebe1050ac3",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "f9df97d0-4965-4232-baaa-a8c35dad0134",
+          "text": "<b>Conduct the Columbia Suicide Severity Rating Scale (C-SSRS)</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "4513a203-6629-484f-ad6a-728c3afc2f56",
+          "text": "I am going to ask you a few questions that might be difficult to talk about but are important for me to assess your safety and the level of support you need.",
+          "type": "display"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "171d81e1-bc70-44ad-ae37-d0415a29776c",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "ddcb2388-4be4-4991-b82c-bbc07b2a1273",
+          "text": "<b>Question 1</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "7cc2e8a9-197a-42ea-9431-ba01eefc6511",
+          "text": "In the past month, have you wished you were dead or wished you could go to sleep and not wake up?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "ecabd308-c45a-41f7-8754-b1f63a101019",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "83ccaaad-d8d8-49e5-b9b5-9dddb1d6cf64",
+              "text": "Comments",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "c9ce9ab4-466b-4bee-95df-880e1ed657c1",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "77cb5992-635f-4db0-85d9-271aa53a5124",
+          "text": "<b>Question 2</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "text": "In the past month, have you actually had any thoughts of killing yourself?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "7fc39fba-84db-490d-af4e-8f772d91ffda",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "c1964699-4227-4b0e-84a6-3fde975bc989",
+              "text": "Comments",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "8f7bad18-7341-46c0-956e-bb64a4ae2d16",
+      "type": "group",
+      "enableWhen": [
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "=",
+          "answerBoolean": true
         }
       ],
       "item": [
         {
-          "linkId": "17.1",
-          "text": "Relationship",
-          "type": "display",
+          "linkId": "447d7aaa-fec8-4c38-a7d5-2780eb189061",
+          "text": "<b>Question 3</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "35062b98-748b-441c-ad74-185823e1bb52",
+          "text": "In the past month, have you been thinking about how you might do this?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "43898926-e9d5-400e-a095-62a8c7f8dd03",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "5920effa-66eb-4204-86d3-05776e682c7d",
+              "text": "Comments",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "7a135781-034d-4733-9408-1d2f7f7bf796",
+      "type": "group",
+      "enableWhen": [
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "3d1447cf-81b5-450f-be57-885c54c9aa81",
+          "text": "<b>Question 4</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "41aee132-ab8e-4d64-a322-eed88f900edb",
+          "text": "In the past month, have you had these thoughts and had some intention of acting on them?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "644c00f2-8b07-4911-92d0-f05f5e5cc837",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "1feef20c-3e4f-4ee5-b65a-e21a3ba4fb46",
+              "text": "Comments",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "d61a503c-706d-4444-9222-5429e5a9cd40",
+      "type": "group",
+      "enableWhen": [
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "451ea809-bfae-450f-b9de-e9da20ec7d1c",
+          "text": "<b>Question 5a</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "567e992d-fb9e-4608-9be1-9277beae3c23",
+          "text": "In the past month, have you started to work out or worked out the details of how to kill yourself?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "71dbaac9-867f-4d7f-b6d7-e1f59402bbf9",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "304c53e5-1fd0-4093-a21b-3c93b60e8205",
+              "text": "Comments",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "7033870e-7e13-4aed-9ffb-e4fb6c9b1112",
+      "type": "group",
+      "enableBehavior": "all",
+      "enableWhen": [
+        {
+          "question": "567e992d-fb9e-4608-9be1-9277beae3c23",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "990e7257-3bbf-404e-ba34-31c929773a68",
+          "text": "<b>Question 5b</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "a1a1e976-654f-4803-b5a9-80e256098b66",
+          "text": "Do you intend to carry out this plan?",
+          "type": "boolean"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "d5364147-30e5-4a92-977b-5ac2e5f7a23a",
+      "type": "group",
+      "enableWhen": [
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "exists",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "21c8e099-9503-4ab4-bbf8-a2a2384f936f",
+          "text": "<b>Question 6a</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "91e9233a-9ab1-410a-b5e3-b30867355cea",
+          "text": "Have you ever done anything, started to do anything, or prepared to do anything to end your life?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "c7d21a57-0fc6-4e3a-b411-beceb1fb2423",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "9de7c8ab-8d23-404a-a07a-f70c0485cb9b",
+              "text": "Comments",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "cd7f3989-fb61-4ae9-bfa8-79d8a7f110a3",
+      "type": "group",
+      "enableBehavior": "all",
+      "enableWhen": [
+        {
+          "question": "91e9233a-9ab1-410a-b5e3-b30867355cea",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "exists",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "dfdca7ae-089f-4afb-9786-f7abcd09a14f",
+          "text": "Can you please describe the event to me in detail",
+          "type": "display"
+        },
+        {
+          "linkId": "051250a7-1e09-4160-b7f7-3cac5e0a6e90",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "0d556f6d-0b52-4e89-a2c1-2aedf7da7dc6",
+              "text": "Description",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "bdbfff04-8b96-4590-964d-c2df8ad90def",
+      "type": "group",
+      "enableBehavior": "all",
+      "enableWhen": [
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "exists",
+          "answerBoolean": true
+        },
+        {
+          "question": "91e9233a-9ab1-410a-b5e3-b30867355cea",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "890ce4ac-0c72-41c6-a586-ebb94e5e15cc",
+          "text": "<b>Question 6b</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "3c394824-02d4-4b34-b706-f89735adcd3a",
+          "text": "Was this within the past year?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "d7f9c0a7-17c5-437a-8803-107d5c8276de",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "b44a916b-944d-4cf3-ba04-a6bed82be35e",
+              "text": "Comments",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "b61c24e4-7a5a-4482-b29a-6432668a0212",
+      "type": "group",
+      "enableBehavior": "all",
+      "enableWhen": [
+        {
+          "question": "3c394824-02d4-4b34-b706-f89735adcd3a",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "exists",
+          "answerBoolean": true
+        },
+        {
+          "question": "91e9233a-9ab1-410a-b5e3-b30867355cea",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "8b6b77f5-8129-4637-9b2a-5f831ca4eb8d",
+          "text": "<b>Question 6c</b>",
+          "type": "group"
+        },
+        {
+          "linkId": "2897fef9-abcf-4bb3-b33f-2accae4c06c5",
+          "text": "Was this within the past three months?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "a6601f97-0a34-49d0-b181-611d6705ca42",
+          "type": "string",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "24b24bcf-52d6-453a-8915-ba1bd382e229",
+              "text": "Exact Timeline",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        }
+      ],
+      "linkId": "098f45c2-54a3-436a-98a1-d26199cf61e5",
+      "type": "group",
+      "enableBehavior": "all",
+      "enableWhen": [
+        {
+          "question": "3c394824-02d4-4b34-b706-f89735adcd3a",
+          "operator": "=",
+          "answerBoolean": false
+        },
+        {
+          "question": "e2a74544-b333-4767-b3e3-7772413419ce",
+          "operator": "exists",
+          "answerBoolean": true
+        },
+        {
+          "question": "91e9233a-9ab1-410a-b5e3-b30867355cea",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
+      "item": [
+        {
+          "linkId": "dcc8f1f9-c615-44d9-ab8e-ad3dec5e8d59",
+          "text": "It sounds like there was one time in your life that you prepared to end your life, but that wasn't in the past year. Is this something you think is important for us to work on together?",
+          "type": "boolean"
+        },
+        {
+          "linkId": "9ef6a44f-af5f-4392-987e-08c6705e830d",
+          "type": "string",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "400c124c-a619-4f52-9a74-f3622cef7ee1",
+              "text": "Exact Timeline",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%severe-risk"
+          }
+        }
+      ],
+      "linkId": "bc968aff-a7b5-4148-83af-c5ac7116bdca",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "c2d3259e-1ea3-4a02-8017-00890c01c473",
+          "text": "Suicide Risk Level - Severe Risk",
+          "type": "group"
+        },
+        {
+          "linkId": "c6ae3b92-5055-47ed-8b67-36d332dcc8ab",
+          "text": "Immediate response needed: Refer to your local suicide prevention protocol",
+          "type": "display"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%high-risk"
+          }
+        }
+      ],
+      "linkId": "1dd2092d-4144-434e-921b-b737fa781309",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "b1a63767-2a32-4ed7-bb3b-7970c727c2e1",
+          "text": "Suicide Risk Level - High Risk",
+          "type": "group"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-risk"
+          }
+        }
+      ],
+      "linkId": "d0c1ec5c-ddf3-4d5c-aa06-08868ae9b810",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "39dc4387-5ecb-481f-ba09-324279d9a40c",
+          "text": "Suicide Risk Level - Moderate Risk",
+          "type": "group"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%low-risk"
+          }
+        }
+      ],
+      "linkId": "19941a0b-e008-4fce-b941-48a5f0990dd2",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "291cfb09-71a3-474d-b376-a61ae891e1e8",
+          "text": "Suicide Risk Level - Low Risk",
+          "type": "group"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%severe-risk"
+          }
+        }
+      ],
+      "linkId": "1257f98b-d30f-4c3f-a240-f83277bc1fca",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "98ef25d9-3105-4d4a-b834-f205476d4649",
+          "text": "Emergency Response Needed",
+          "type": "group"
+        },
+        {
+          "linkId": "5662abce-b532-40c2-a676-d5499eef1f35",
+          "text": "Start Rescue Protocol",
+          "type": "display"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%low-risk"
+          }
+        }
+      ],
+      "linkId": "a5737a88-d8fd-44f2-92eb-16434dc75baa",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "6dca2563-dd6a-4efc-b5e6-7125fc9fd5a6",
+          "text": "Provide Psychoeducation and describe when to seek help",
+          "type": "group"
+        },
+        {
+          "linkId": "a80c1bc9-9554-4f83-9b01-2fc385589caf",
+          "text": "You are not the only person to have thoughts of suicide. You shared that currently you don't have a plan or intent to kill yourself. Is that right?",
+          "type": "boolean"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%show-suicidal-thoughts-come-and-go"
+          }
+        }
+      ],
+      "linkId": "d6ef509c-ee25-4203-a565-69ff96b04a5f",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "d5e67696-b055-40ac-8e5a-2d0779b855b6",
+          "text": "Suicidal thoughts come and go",
+          "type": "group"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk"
+          }
+        }
+      ],
+      "linkId": "6c4e4e50-aedc-49b8-9bb5-fdd29dca8e64",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "bd474a16-45bc-4a9a-8213-a55df7e4e934",
+          "text": "Collect The Crisis Narrative",
+          "type": "group"
+        },
+        {
+          "linkId": "0a315991-799e-40b4-b599-3ab42253c1d3",
+          "text": "Please tell me more about the last time you made a suicide attempt, or you felt suicidal",
+          "type": "display"
+        },
+        {
+          "linkId": "509b140e-b195-4696-bc5f-f2fc2d2f77dd",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "59a30608-00de-457b-aadf-e79757927ff2",
+              "text": "Narrative",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk"
+          }
+        }
+      ],
+      "linkId": "8d9603dd-b755-45f3-811d-a5e3d112387e",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "9a2f3f1b-8d7a-431a-a774-06b51ee1d1ea",
+          "text": "Provide Psychoeducation",
+          "type": "group"
+        },
+        {
+          "linkId": "3f634cfb-8969-431e-a41b-c0c98eea348b",
+          "text": "1. Beginning of suicidal crisis: How did you feel at that time? What was the reason for feeling this way?",
+          "type": "display"
+        },
+        {
+          "linkId": "92ab6e65-f9bd-4718-8af6-f731425d3031",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "03fab06c-8c22-4c0c-bfe3-bf9e0f8e2206",
+              "text": "Comment",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk"
+          }
+        }
+      ],
+      "linkId": "c39ebebe-0a84-4f78-ba2e-a5b941b4f756",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "5810e815-1c23-46a8-8da1-9353fce242b2",
+          "text": "Provide Psychoeducation",
+          "type": "group"
+        },
+        {
+          "linkId": "642c70e8-3cb1-4202-a8bb-03b308ce9021",
+          "text": "2. Peak of suicidal crisis: How did you feel at that time? What was the reason for feeling this way?",
+          "type": "display"
+        },
+        {
+          "linkId": "9d203bac-75fd-4f31-bed6-073502a977f3",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "3f7aa619-e46b-4734-a934-655ea794f55b",
+              "text": "Comment",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk"
+          }
+        }
+      ],
+      "linkId": "26d8fe20-8bb5-4606-9d29-e41971f10140",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "66ab6638-2cea-48cd-b2a0-3bd087ad4b80",
+          "text": "Provide Psychoeducation",
+          "type": "group"
+        },
+        {
+          "linkId": "309215dd-4dd0-49a3-9ad5-277860508f38",
+          "text": "3. Resolution of suicidal crisis: How did you come out of it?",
+          "type": "display"
+        },
+        {
+          "linkId": "90cedcbf-bf11-4dc3-9733-42e6900a09fc",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "00620f43-1789-41aa-a4e4-6bd3712197fc",
+              "text": "Comment",
+              "type": "display"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk"
+          }
+        }
+      ],
+      "linkId": "a4b8407e-8f09-4e31-880c-cfe7431db521",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "23974248-a5fe-4a1c-b148-74af8053f65c",
+          "text": "Summarize psychoeducation about the suicidal crisis",
+          "type": "group"
+        },
+        {
+          "linkId": "44ea200a-1aa5-4919-818c-22acefaeec7a",
+          "text": "Provide Psychoeducation",
+          "type": "display"
+        },
+        {
+          "linkId": "7af324ea-b495-4f4e-936f-66e4004060f5",
+          "text": "1. Beginning of suicidal crisis:<br>-",
+          "_text": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "'1. Beginning of suicidal crisis: <br>' + %text-start-of-suicide"
+                }
+              }
+            ]
+          },
+          "type": "display"
+        },
+        {
+          "linkId": "071e53b8-b51f-4847-afd1-ecd4777abe5f",
+          "text": "2. Peak of suicidal crisis:<br>-",
+          "_text": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "'2. Peak of suicidal crisis: <br>' + %text-peak-of-suicide"
+                }
+              }
+            ]
+          },
+          "type": "display"
+        },
+        {
+          "linkId": "528f4a9b-46e9-44a7-b2a7-837748b2cd16",
+          "text": "3. Resolution of suicidal crisis: How did you come out of it?<br>-",
+          "_text": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "'3. Resolution of suicidal crisis: How did you come out of it?<br>' + %text-resolution-of-suicide"
+                }
+              }
+            ]
+          },
+          "type": "display"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk"
+          }
+        }
+      ],
+      "linkId": "026b0918-e92b-4e14-85ab-07f8b08c9ad6",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "11a32656-29d7-4086-bc6d-783c002b37f4",
+          "text": "Ask for permission to create a Safety Plan",
+          "type": "group"
+        },
+        {
+          "linkId": "a842d271-cd48-47c7-963e-dcd0376ef185",
+          "text": "I would like to create a plan with you that will help keep you safe. What do you think about creating a plan together?",
+          "type": "boolean"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-disapproval"
+          }
+        }
+      ],
+      "linkId": "5202445c-ac17-4a9a-994f-c615ba13e462",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "fd7d92d0-c014-4f39-90de-ca41dd59970b",
+          "text": "Emergency Response Needed",
+          "type": "group"
+        },
+        {
+          "linkId": "b436e194-86fc-4486-8010-b096edbeaae7",
+          "text": "Start Rescue Protocol",
+          "type": "display"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "6cfcf83e-d04f-4f54-a1f4-586611250d2f",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "42a3875d-a851-4b66-bdf6-cd7690c8041b",
+          "text": "Introduce the Safety Plan",
+          "type": "group"
+        },
+        {
+          "linkId": "ca65c6d2-29a8-4ad0-ac1f-0ef05d9b8039",
+          "text": "I will start by telling you more about the Safety Plan and how to use it. The Safety Plan has several steps. Other people who have had thoughts of harming themselves have found that having this kind of Plan can be very helpful. A lot of times suicidal thoughts feel so overwhelming that we don’t know what to do, so this plan will give you something to do to cope with the crisis. What are your thoughts so far?",
+          "type": "display"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "178bf7e4-da85-4524-b837-403c3f1434dd",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "12e9a9d2-d2f9-48dc-8e46-dcde35ae2866",
+          "text": "Step 1<br>Warning signs",
+          "type": "group"
+        },
+        {
+          "linkId": "9d0689d2-d4f0-47de-9c02-3cfd1a53485d",
+          "text": "Signs that I am in crisis and my safety plan should be used",
+          "type": "display"
+        },
+        {
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -412,57 +2415,83 @@
                 "coding": [
                   {
                     "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
+                    "code": "open-choice",
+                    "display": "Open choice"
                   }
                 ],
-                "text": "Flyover"
+                "text": "Open choice"
               }
             }
+          ],
+          "linkId": "33ae3bce-ebd5-4dbc-b40c-a4cbc30736e6",
+          "type": "choice",
+          "repeats": true,
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "hopeless",
+                "display": "Feeling hopeless"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "empty",
+                "display": "Feeling empty"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "lonely",
+                "display": "Feeling lonely and alone"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "failed",
+                "display": "Feeling that you failed"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "guilty",
+                "display": "Feeling guilty or ashamed"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "useless",
+                "display": "Feeling useless/has no purpose"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "angry",
+                "display": "Angry and feel like nothing is going to change/get better"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "e2b65a3f-3b48-436f-9a49-1cf458df59bc",
+              "text": "Thought or emotions",
+              "type": "display"
+            }
           ]
-        }
-      ],
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "child",
-            "display": "Child"
-          }
         },
         {
-          "valueCoding": {
-            "code": "father",
-            "display": "Father"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "mother",
-            "display": "Mother"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "sibling",
-            "display": "Sibling"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "other",
-            "display": "Other"
-          }
-        }
-      ]
-    },
-    {
-      "linkId": "18",
-      "type": "string",
-      "item": [
-        {
-          "linkId": "18.1",
-          "text": "Phone number",
-          "type": "display",
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -470,22 +2499,158 @@
                 "coding": [
                   {
                     "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "flyover",
-                    "display": "Fly-over"
+                    "code": "open-choice",
+                    "display": "Open choice"
                   }
                 ],
-                "text": "Flyover"
+                "text": "Open choice"
               }
+            }
+          ],
+          "linkId": "4a1c4c0d-158f-494c-a33f-1f7f8e41f21f",
+          "type": "choice",
+          "repeats": true,
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "alcohol",
+                "display": "Alcohol"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "drugs",
+                "display": "Drugs"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "isolation",
+                "display": "Isolation"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "d2a44529-9344-4ec1-ac7a-10dddbf27467",
+              "text": "Behaviors",
+              "type": "display"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "open-choice",
+                    "display": "Open choice"
+                  }
+                ],
+                "text": "Open choice"
+              }
+            }
+          ],
+          "linkId": "658e8c22-d6ba-480a-81e0-dc4b6164de13",
+          "type": "choice",
+          "repeats": true,
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "pain",
+                "display": "Pain"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "insomnia",
+                "display": "Insomnia"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "increased-sleep",
+                "display": "Increased sleep"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "lack-of-appetite",
+                "display": "Lack of appetite"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "tiredness",
+                "display": "Tiredness"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "874cd5de-7719-40d6-841b-8e79ae92d84f",
+              "text": "Physical signs",
+              "type": "display"
+            }
+          ]
+        },
+        {
+          "linkId": "58721b3d-88ae-4888-b5ec-ef7dfe30fb3d",
+          "type": "text",
+          "repeats": true,
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "0d8f7da3-c7ad-49e3-b17c-ad42cb9d48e7",
+              "text": "Other signs",
+              "type": "display"
             }
           ]
         }
       ]
     },
     {
-      "linkId": "19",
-      "type": "choice",
-      "text": "What is the highest level of education achieved?",
-      "prefix":"5.",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -493,67 +2658,301 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "radio-button",
-                "display": "Radio Button"
+                "code": "page",
+                "display": "Page"
               }
             ],
-            "text": "Radio button"
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
           }
         }
       ],
+      "linkId": "60ec72aa-5427-4af4-bf02-75dba0774317",
+      "type": "group",
       "item": [
+        {
+          "linkId": "048de1b1-68b2-49be-9a54-fcc6e53f6b6b",
+          "text": "Step 2<br>Internal coping strategies",
+          "type": "group"
+        },
+        {
+          "linkId": "b8c1911c-97e3-4cbe-ab4f-ccd86560f62a",
+          "text": "Things I can do on my own to distract myself and keep myself safe:",
+          "type": "display"
+        },
         {
           "extension": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
               "valueCodeableConcept": {
                 "coding": [
                   {
-                    "system": "http://hl7.org/fhir/questionnaire-display-category",
-                    "code": "instructions"
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "open-choice",
+                    "display": "Open choice"
                   }
-                ]
+                ],
+                "text": "Open choice"
               }
             }
           ],
-          "linkId": "19.1",
-          "text": "Select one",
-          "type": "display"
-        }
-      ],
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "education",
-            "display": "Does not know level of education"
-          }
+          "linkId": "2e03fdf1-5274-494d-88e9-dd4b41ec90e6",
+          "type": "choice",
+          "repeats": true,
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "tv",
+                "display": "Watching TV"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "music",
+                "display": "Listening to music"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "social-media",
+                "display": "Social Media"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "64759d21-9497-47a4-871d-4b1766aa88bd",
+              "text": "Entertainment",
+              "type": "display"
+            }
+          ]
         },
         {
-          "valueCoding": {
-            "code": "primary-school",
-            "display": "Primary school"
-          }
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "open-choice",
+                    "display": "Open choice"
+                  }
+                ],
+                "text": "Open choice"
+              }
+            }
+          ],
+          "linkId": "d0aa3679-e465-4225-85d6-5822efb10eba",
+          "type": "choice",
+          "repeats": true,
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "walk",
+                "display": "Walking"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "walk-at-park",
+                "display": "Walking in the park"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "exercise",
+                "display": "Exercise"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "gym",
+                "display": "Going to the Gym"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "play-sports",
+                "display": "Playing sports"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "gardening",
+                "display": "Gardening"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "meditation",
+                "display": "Meditation"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "c2144600-2d55-48e3-bebd-f395a3434ccb",
+              "text": "Physical activities",
+              "type": "display"
+            }
+          ]
         },
         {
-          "valueCoding": {
-            "code": "secondary-school",
-            "display": "Secondary school"
-          }
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "open-choice",
+                    "display": "Open choice"
+                  }
+                ],
+                "text": "Open choice"
+              }
+            }
+          ],
+          "linkId": "e6262800-1e24-4348-9bf2-9bb070d2f20a",
+          "type": "choice",
+          "repeats": true,
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "video-games",
+                "display": "Video Games"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "cooking",
+                "display": "Cooking"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "painting",
+                "display": "Painting"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "crafting",
+                "display": "Crafting"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "cleaning",
+                "display": "Cleaning"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "d1a4eb56-5d6a-4859-af71-33ef2d879e37",
+              "text": "Indoor activities and hobbies",
+              "type": "display"
+            }
+          ]
         },
         {
-          "valueCoding": {
-            "code": "higher-education",
-            "display": "Higher education"
-          }
+          "linkId": "3cae39d6-8d44-4fe4-835b-3f3ecd9b64fe",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "f6342b55-cf88-47ce-bbe5-6bfb5456e461",
+              "text": "Self care",
+              "type": "display"
+            }
+          ]
+        },
+        {
+          "linkId": "db779cb5-5335-4eb6-8ccc-47ec94c626c8",
+          "type": "text",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "linkId": "022962ae-144f-4587-84c4-da20b7c06120",
+              "text": "Other activities",
+              "type": "display"
+            }
+          ]
         }
       ]
     },
     {
-      "linkId": "20",
-      "type": "choice",
-      "repeats": true,
-      "text": "Who does the client live with?",
-      "prefix":"6.",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -561,78 +2960,611 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "check-box",
-                "display": "Checkbox"
+                "code": "page",
+                "display": "Page"
               }
             ],
-            "text": "Checkbox"
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
           }
         }
       ],
+      "linkId": "adf451b3-6e98-40c4-bb55-123240ab7042",
+      "type": "group",
       "item": [
         {
-          "extension": [
+          "linkId": "54db7d62-dfea-48be-b34e-bab158a8896f",
+          "text": "Step 3<br>People and Social Settings that provide distraction",
+          "type": "group"
+        },
+        {
+          "linkId": "2d394b35-a697-44a8-bd4e-f6e0e0998c0e",
+          "type": "group",
+          "item": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-display-category",
-                    "code": "instructions"
-                  }
-                ]
-              }
+              "linkId": "713866e6-3cf5-4c1b-8cc8-d74bdd26d55c",
+              "text": "Who can I contact to take my mind off problems and feel better",
+              "type": "display"
+            },
+            {
+              "linkId": "52703360-b425-4831-bfb1-f166ca79ccb5",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "a0017b28-0aa9-4926-a7be-813f0a5e6bd0",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "66515c54-f92c-4794-ad91-765034a73d8e",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "bc981d8a-7f22-450b-abab-3acca810ccad",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "e5d48bef-1bae-451a-950b-5fb8754e56d2",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "19967298-cf1e-47cc-adbd-609212f0c4c9",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "a0017b28-0aa9-4926-a7be-813f0a5e6bd0",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "d1c2fae1-f0f5-4333-97f6-2220d2ff3d95",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "1ac2d148-57d7-4d41-ba51-b5a1ea840efc",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "603d1492-316f-497f-967b-5c4b1ab983ea",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "7422c091-c7d2-42cf-adab-27e8d2513672",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "d4f93192-da9b-4479-b43d-c0e09caa30db",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "d1c2fae1-f0f5-4333-97f6-2220d2ff3d95",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "f5ab53d4-824c-460f-8939-b86ff3cd97a3",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "cf744569-0565-4ff2-b5b6-3c545b2eb989",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "53def3a1-a7e5-4326-95f2-2561c26ecb47",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "f6871530-1025-4535-a7d4-23a93b8c15cc",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "7ec156c6-e78c-4863-8913-dab7bd2d6376",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "f5ab53d4-824c-460f-8939-b86ff3cd97a3",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "a20b29af-3317-415e-9c6e-d9f3bbc4df33",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "25fbe76b-7f92-4597-a532-41a06cb2209b",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "965b7874-dd24-4215-acd4-8d241a262638",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "62b1522a-1acc-4777-a2e4-96dc01395d11",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "2e24f67b-3778-4908-8fc2-3e60557679f7",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "a20b29af-3317-415e-9c6e-d9f3bbc4df33",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "a33cdecd-b7e6-45d8-94b6-52fa80c64a6d",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "7a5964ec-7034-43de-85f5-7e7750f6d7b7",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "892337bd-d7fd-46a7-bf72-08e87c9f412c",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "1100a852-6a90-4485-bb52-b57009c131ac",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
             }
-          ],
-          "linkId": "20.1",
-          "text": "Check all that apply",
-          "type": "display"
-        }
-      ],
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "Parents",
-            "display": "Parents"
-          }
+          ]
         },
         {
-          "valueCoding": {
-            "code": "siblings",
-            "display": "Siblings"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "extended-family",
-            "display": "Extended family"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "partner",
-            "display": "Partner"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "friends",
-            "display": "Friend(s)"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "no-one",
-            "display": "No one"
-          }
+          "linkId": "6f96d35b-3bf0-4718-9b29-5169abe08c05",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "8c86279b-95fb-4d5b-b4b8-94f1f38beced",
+              "text": "Who can I contact to take my mind off problems and feel better",
+              "type": "display"
+            },
+            {
+              "linkId": "a295f023-e2a4-4b40-a35a-9e08d194cc96",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "5e2ab0f5-f5d9-4502-befe-aba770f0e206",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "d1eaaea7-2cac-4965-93d7-752dd84e6e85",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "895fad45-c3b5-47c5-9edf-5f9b9e793fbf",
+                  "enableWhen": [
+                    {
+                      "question": "5e2ab0f5-f5d9-4502-befe-aba770f0e206",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "1cef7f0b-f7f9-4232-b24b-78483c45efba",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "faefef23-d2e6-4777-b628-8f83921e8fd8",
+                  "enableWhen": [
+                    {
+                      "question": "895fad45-c3b5-47c5-9edf-5f9b9e793fbf",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "15bb19f5-666f-4a14-b216-653820b96360",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "62a04638-8928-4aab-b490-1a33739b7a5c",
+                  "enableWhen": [
+                    {
+                      "question": "faefef23-d2e6-4777-b628-8f83921e8fd8",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "5df460ce-967e-4b62-b903-e387473c3e03",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "249f5ce8-ecc0-4e43-9675-6b01ca1502a3",
+                  "enableWhen": [
+                    {
+                      "question": "62a04638-8928-4aab-b490-1a33739b7a5c",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "c20de1b3-f1cb-407e-bd06-8e570396a5ad",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "linkId": "21",
-      "type": "choice",
-      "text": "Has the client received this year’s seasonal flu vaccine?",
-      "prefix":"7.",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -640,86 +3572,562 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "radio-button",
-                "display": "Radio Button"
+                "code": "page",
+                "display": "Page"
               }
             ],
-            "text": "Radio button"
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
           }
         }
       ],
+      "linkId": "9f7b5704-d9a2-4e7e-b813-c79206e5625d",
+      "type": "group",
       "item": [
         {
-          "extension": [
+          "linkId": "f75dfa8d-3d08-4945-b9fe-7750e4e9833c",
+          "text": "Step 4<br>Family members or friends who may offer help",
+          "type": "group",
+          "item": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-display-category",
-                    "code": "instructions"
-                  }
-                ]
-              }
+              "linkId": "b135dbdf-ca75-4ec9-a92f-6e6db2ea216c",
+              "text": "Who can I tell that I am in crisis and need support:",
+              "type": "display"
+            },
+            {
+              "linkId": "c613e296-d9bc-475a-bc49-37bd183c740f",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "d1efad02-3686-4ce3-a96d-68d8c638ff77",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "de5e3720-d264-4812-adf2-ad6c2b370836",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "68fa6f2e-84ec-4dbc-900e-10ede297c488",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "1f6c6f1c-30c0-43ce-9823-94517d2f37a6",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "ff115c26-95b9-4e0d-87ed-80817d438fc7",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "6ca8b0b1-8890-4085-92e2-505a677cf8b9",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "52875daa-6a14-40ff-8381-cea904adbe5d",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "d1efad02-3686-4ce3-a96d-68d8c638ff77",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "544a444d-b101-4d56-9351-00bca8ec749e",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "83224403-d94c-4bab-a277-f23b23c0331a",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "84018cd8-9134-429c-8dfe-fd6a16e4bd17",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "f1fc7526-eb5b-420b-8311-1f76a2ccf786",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "7e38a614-b0a2-48ea-b7c7-ca2bdc1f00db",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "a89afb3f-a4bb-4841-b6f8-92a6a562df64",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "968da90b-8197-442e-b98f-9c325a7bc1c2",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "544a444d-b101-4d56-9351-00bca8ec749e",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "e9e056c2-0469-4523-a28f-1000fed1a4f1",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "3ba726d5-594c-4d1a-bf39-e0ce1c143e89",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "bd62b649-7209-4d32-9bbb-dc2b2823aadb",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "ba728319-5c50-4390-af7d-d870ffe768cc",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "fefdc90f-fe1d-4bfb-af93-94df8c482897",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "5df0d015-e498-46b9-85a0-20d4974cd66c",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "52dd5467-2745-4510-a7ea-6e5949e2ede6",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "e9e056c2-0469-4523-a28f-1000fed1a4f1",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "0399b747-eb74-48cf-aa07-6e9b57ee0883",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "65ec031f-8c9e-4068-af5e-2292d753fa99",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "fa1828dd-cf04-4fdc-979a-3b5c265d5c77",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "8a6c41b2-3401-4227-8f87-200634ae2004",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "1341d9f8-c5eb-4191-93df-d582e622dcda",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "f857e0a8-dbdd-42a6-87a2-543127d8e24b",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "270b6b5f-2ee5-4795-b119-ad561ab01faf",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "0399b747-eb74-48cf-aa07-6e9b57ee0883",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "d7f53320-e620-49e1-9a5d-b819b8d8d4c0",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "ab9612a8-46a4-4804-9920-379c2d623eb7",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "5b3b60f3-fe9c-49e4-9493-922f65ccc80c",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "374349f8-5375-4147-a81d-f023c21998e7",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "56682660-6256-4398-a93b-3e5246cc315a",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "fd60a3a9-8009-4376-80d5-9c96863b650a",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
             }
-          ],
-          "linkId": "21.1",
-          "text": "Select one",
-          "type": "display"
-        }
-      ],
-      "answerOption": [
-        {
-          "valueCoding": {
-            "code": "yes",
-            "display": "Yes"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "no",
-            "display": "No"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "unknown",
-            "display": "Unknown"
-          }
+          ]
         }
       ]
     },
     {
-      "linkId": "22",
-      "type": "date",
-      "text": "When was their last menstrual period? (LMP)",
-      "prefix": "8.",
-      "item": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-display-category",
-                    "code": "instructions"
-                  }
-                ]
-              }
-            }
-          ],
-          "linkId": "22.1",
-          "text":"First day of the most recent period",
-          "type": "display"
-        }
-      ]
-    },
-    {
-      "linkId": "23",
-      "type": "integer",
-      "text": "How many times have they been pregnant?",
-      "prefix": "9.",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -727,40 +4135,5065 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "slider",
-                "display": "Slider"
+                "code": "page",
+                "display": "Page"
               }
             ],
-            "text": "Slider"
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
           }
         }
       ],
+      "linkId": "b51817ba-3935-44d9-9e65-294718b64c29",
+      "type": "group",
       "item": [
+        {
+          "linkId": "6865e195-a785-4d42-ad07-f1986ad1489f",
+          "text": "Step 5<br>Professionals that can help",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "bf310972-a8bb-42bb-bb05-6a5623fa36ad",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "f9cca586-dbfd-4929-b14f-29a1d030721e",
+                  "text": "Hospitals, Clinics and Doctors I can contact for help",
+                  "type": "display"
+                },
+                {
+                  "linkId": "165895f5-728e-4285-a3f3-1c0ecae41f56",
+                  "type": "group",
+                  "item": [
+                    {
+                      "linkId": "beb4ad5f-2fd8-4b80-aa93-aa9ff1896dd0",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "db13e693-f9f8-4f3d-b05c-f3b6d924e23f",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "c6c266cc-1c85-41c0-97ce-9ab491be45db",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "583aba72-5a6d-4053-b2d6-1082c9ab4147",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "f7496859-63bb-4b2f-8f75-96e44e893bf7",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "878a4b46-ddc5-46b7-bcb8-7453f20e818f",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "5127bb2f-dedd-48e3-8b84-663359489bc2",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "beb4ad5f-2fd8-4b80-aa93-aa9ff1896dd0",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "13321778-b5d4-4b01-8eda-610cf0007c86",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "6f7437d1-ecc4-4fde-9319-dec7c18ab427",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "c1e99f8b-b1ab-46d1-b205-ecbbb4240fdf",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "9696146b-e657-4a22-a8f9-fb5c925fc097",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "f952feaf-7abc-4f6f-a3bc-d10a43ea62fa",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "d247c41b-36fa-4ad8-8be8-a13fd2eb1f8b",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "ef7fe879-7668-4d93-9134-bd291e2f4a0f",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "13321778-b5d4-4b01-8eda-610cf0007c86",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "ae949697-92ae-476a-96cc-f8b0adc4221f",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "2c803bbd-691b-4e41-ae99-e1664f28cedc",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "1fc8f8e7-2022-48d2-b41d-4e8ad22af344",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "7a2ad24e-c78a-4666-b3e5-e1cbf610edb5",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "44f02467-8ee0-49f0-8da7-5e7ed827125a",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "2ebfbbfe-ac92-449d-8c26-78c2e93143ca",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "51db7ea6-810d-4541-82b6-b5ff493ba563",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "ae949697-92ae-476a-96cc-f8b0adc4221f",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "796f5440-54f8-4d69-b961-a5b7e6a63240",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "b59afae6-1c0f-48cb-9c7d-2d6621d5f446",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "92da95cc-50dd-4bf0-acca-4465c07d44cc",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "894555b6-8b8a-4734-aa2e-1c379947e25e",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "f895ed4f-5004-4da4-9d59-c21293674b21",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "89fa8d57-67a8-4f06-b49f-9b32ce44bf6b",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "d0119558-b77d-4f51-9fc0-5a93daecbf61",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "796f5440-54f8-4d69-b961-a5b7e6a63240",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "dae7f411-758d-4800-9842-fc0038a6b4a4",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "0bf3781e-8b0d-453e-a5a2-2cc99fbeb23f",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "0c308fef-8ce5-4217-a8d4-8e6ff00c8e14",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "c00b6d25-f8f1-4ae8-8daf-c3d55175a512",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "9faa2b78-1842-4326-bf7f-9975bf04dc2c",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f9951eb5-f647-4589-b74a-0d148727e832",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "ebdadaec-08f6-4f38-aee9-e2069fbee3c6",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "cfdcb02f-233e-4e64-958e-f20640ee82e6",
+                  "text": "Community Wellness and Healthcare workers I can contact for help",
+                  "type": "display"
+                },
+                {
+                  "linkId": "23c3d8c3-29b3-4a06-bfdd-025c72ec3c62",
+                  "type": "group",
+                  "item": [
+                    {
+                      "linkId": "a57b5b34-12e5-4ec8-8215-7f316267323a",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "7c97e638-8169-462a-94a6-1256c6589f2d",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "d617b1e1-ea22-4863-a878-627f6b81963e",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "2f57af32-d401-418f-809b-e7a80c7e515f",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "c0655b11-8f21-47ed-8ede-95498c2e8200",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "a3c767fa-9139-49e6-a41c-a5989339fbad",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "6fe11677-757e-44bf-968f-4329ec8dcec6",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "a57b5b34-12e5-4ec8-8215-7f316267323a",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "527c0166-cc35-4cc3-a9d9-7eeb0a54635e",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "20a5cad1-96ec-4483-b1fd-057e410b1b74",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "e8726638-cfdb-40ae-b72c-f1d594f64de5",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "a6750b5e-0bba-42b3-bef4-8d6bf6437c07",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "e7ba8485-5154-41b8-ac18-35410a83cd99",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "3eef12ed-7246-40e6-bdc5-7aae2a5646b2",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "0fe8f3be-6f0d-4ac0-89bb-b83d6e6d2c9f",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "527c0166-cc35-4cc3-a9d9-7eeb0a54635e",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "1d0ad825-09de-4018-a680-cd0e6bf0983d",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "79f77c63-5102-4f6f-a44f-488c6f1e7c08",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "9e11ce97-90e8-42f2-ba18-8c4f0720c131",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "20d43d1c-2e22-46d6-8439-0a5e18fd2e0b",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "cb75bba9-0bd8-4dce-ba2f-d1b21a97c2a0",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f203f44a-64f4-4e80-b4ba-b4c2ad96a764",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "5d40bb2b-92ea-467e-bcea-d67d1c4b334b",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "1d0ad825-09de-4018-a680-cd0e6bf0983d",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "13e2f934-82ed-4b23-af6e-95523dc3746a",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "abaea7a1-bc45-4a94-9410-a2f5ed7686a3",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "cf16ca6e-8b1b-467d-b807-fc5d50339f71",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "32065247-c655-4615-be6c-e83668489134",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "ce18eee3-aa64-4423-8db1-50fe7f00850d",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "0b5de366-8b98-49a1-a32b-8844283d3a17",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "0ff5e237-4fea-4f54-8e12-53505c960d8c",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "13e2f934-82ed-4b23-af6e-95523dc3746a",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "cebffdf4-8fd1-4829-884c-41cc42bc0111",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "b59372a9-0aeb-4ce9-94be-e5aff1054264",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "46c2861b-70a9-4fdf-94ea-e1a01cae3149",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f3edf2b5-eabc-41ed-ba8d-05b8110d8421",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "8a5b1c7d-e3ef-4443-85f1-fa5213d89f8d",
+                      "type": "string",
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f799e20c-f865-4625-9e8d-896c57f7bb13",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "0bcffb6a-7176-45cc-af64-4bf059d1b0f1",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "92728422-140b-4ae9-94b3-df4ee564ebf6",
+          "text": "National Hotline numbers",
+          "type": "group"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "ede6c7ce-817f-4448-a890-90d1f063bfca",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "0290bd22-5406-47fb-b4c6-25b4bcfc406c",
+          "text": "For Clinicians Only- Not to show patient",
+          "type": "display"
+        },
+        {
+          "linkId": "886317dc-d85e-45cc-a9da-7513b96d0d96",
+          "text": "Step 6A<br>Making the Environment safe",
+          "type": "group"
+        },
         {
           "extension": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
               "valueCodeableConcept": {
                 "coding": [
                   {
-                    "system": "http://hl7.org/fhir/questionnaire-display-category",
-                    "code": "instructions"
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "check-box",
+                    "display": "CheckBox"
                   }
                 ]
               }
             }
           ],
-          "linkId": "23.1",
-          "text":"Including this pregnancy. Also referred to as gravida.",
-          "type": "display"
+          "linkId": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+          "text": "The methods I have thought about using",
+          "type": "choice",
+          "repeats": true,
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "pill",
+                "display": "Taking Pills"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "toxin",
+                "display": "Toxins"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "cut",
+                "display": "Cutting"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "hang",
+                "display": "Hanging"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "weapon",
+                "display": "Weapon"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "jump",
+                "display": "Jumping"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "drown",
+                "display": "Drowning"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "other",
+                "display": "Other"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "4e21d80a-1e27-4155-b26c-1168e21b3f85",
+          "type": "string",
+          "enableWhen": [
+            {
+              "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+              "operator": "=",
+              "answerCoding": {
+                "code": "other"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "flyover",
+                        "display": "Fly-over"
+                      }
+                    ],
+                    "text": "Flyover"
+                  }
+                }
+              ],
+              "linkId": "fff3650d-5e75-4207-8e90-db75e48b8252",
+              "text": "Other",
+              "type": "display"
+            }
+          ]
         }
       ]
     },
     {
-      "linkId": "24",
-      "type": "dateTime",
-      "text": "What was the date and time of the ultrasound?",
-      "prefix": "10."
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "3c388508-e9ce-4c11-acbf-a2c9cc374a35",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "f3eded0b-765f-4a24-970c-184306591543",
+          "text": "For Clinicians Only- Not to show patient",
+          "type": "display"
+        },
+        {
+          "linkId": "28bc23d3-0053-46f6-9ffc-51c60762aa78",
+          "text": "Step 6B<br>Making the Environment safe",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "0b247120-23cf-45fc-9e4d-d959f0dda79f",
+              "text": "Taking pills- I will protect myself from this risk by:",
+              "type": "string",
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "pill"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3ab931b8-6bfd-4e5f-b86b-3c7377907331",
+              "text": "Toxins- I will protect myself from this risk by:",
+              "type": "string",
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "toxin"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "6f68c416-a5de-4f68-8ad0-33c6e85a9a68",
+              "text": "Cutting- I will protect myself from this risk by:",
+              "type": "string",
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "cut"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "22c11dbc-73e0-4470-9ef6-d9bd01f48c99",
+              "text": "Hanging- I will protect myself from this risk by:",
+              "type": "string",
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "hang"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "88e9b865-b81a-494b-aef2-39e803b94e73",
+              "text": "Weapon- I will protect myself from this risk by:",
+              "type": "string",
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "weapon"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "229e58ac-a18a-48dd-be10-f8b024a74eb3",
+              "text": "Jumping- I will protect myself from this risk by:",
+              "type": "string",
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "jump"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "53932020-eed8-46f4-8236-d548a6335a59",
+              "text": "Drowning- I will protect myself from this risk by:",
+              "type": "string",
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "drown"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "c5720a67-803f-4917-8261-3738de838418",
+              "text": "Other ways I will make my environment safer:",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "e18ac2d6-756a-4722-b9eb-f38a7aa7f603",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "9bf7ece9-9adc-4641-a3f0-7779a1b57b9c",
+          "text": "My Safety Plan<br>Warning signs",
+          "type": "group",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "open-choice",
+                        "display": "Open choice"
+                      }
+                    ],
+                    "text": "Open choice"
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%resource.descendants().where(linkId='33ae3bce-ebd5-4dbc-b40c-a4cbc30736e6').answer.value"
+                  }
+                }
+              ],
+              "linkId": "65252389-fa9e-4ef4-93ca-e952c77c4c05",
+              "type": "choice",
+              "repeats": true,
+              "answerOption": [
+                {
+                  "valueCoding": {
+                    "code": "hopeless",
+                    "display": "Feeling hopeless"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "empty",
+                    "display": "Feeling empty"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "lonely",
+                    "display": "Feeling lonely and alone"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "failed",
+                    "display": "Feeling that you failed"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "guilty",
+                    "display": "Feeling guilty or ashamed"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "useless",
+                    "display": "Feeling useless/has no purpose"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "angry",
+                    "display": "Angry and feel like nothing is going to change/get better"
+                  }
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "03262db7-5865-48c0-b61d-dfbd57c0a252",
+                  "text": "Thought or Emotions",
+                  "type": "display"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "open-choice",
+                        "display": "Open choice"
+                      }
+                    ],
+                    "text": "Open choice"
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%resource.descendants().where(linkId='4a1c4c0d-158f-494c-a33f-1f7f8e41f21f').answer.value"
+                  }
+                }
+              ],
+              "linkId": "5056d0ba-67ac-4eab-b05d-d42941f7b264",
+              "type": "choice",
+              "repeats": true,
+              "answerOption": [
+                {
+                  "valueCoding": {
+                    "code": "alcohol",
+                    "display": "Alcohol"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "drugs",
+                    "display": "Drugs"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "isolation",
+                    "display": "Isolation"
+                  }
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "3a4ee0a8-ee5d-46e8-8ea9-5a28ef84d860",
+                  "text": "Behaviors",
+                  "type": "display"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "open-choice",
+                        "display": "Open choice"
+                      }
+                    ],
+                    "text": "Open choice"
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%resource.descendants().where(linkId='658e8c22-d6ba-480a-81e0-dc4b6164de13').answer.value"
+                  }
+                }
+              ],
+              "linkId": "176aeeb0-e173-482a-b3eb-60f59bc04f98",
+              "type": "choice",
+              "repeats": true,
+              "answerOption": [
+                {
+                  "valueCoding": {
+                    "code": "pain",
+                    "display": "Pain"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "insomnia",
+                    "display": "Insomnia"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "increased-sleep",
+                    "display": "Increased sleep"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "lack-of-appetite",
+                    "display": "Lack of appetite"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "tiredness",
+                    "display": "Tiredness"
+                  }
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "ed31b1e9-02c9-4b30-9062-968b1cd164f2",
+                  "text": "Physical Signs",
+                  "type": "display"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%warning-other"
+                  }
+                }
+              ],
+              "linkId": "cece37bc-897b-4b48-a9c9-59ecc9f997f7",
+              "type": "text",
+              "repeats": true,
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "a9b5b488-c28b-4423-bd1a-8bffcb03686c",
+                  "text": "Other Signs",
+                  "type": "display"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "fbbbd222-d0d3-406a-9877-744c27444cd2",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "a0da8afa-7558-4a75-b4a0-89ade4e2ea20",
+          "text": "My Safety Plan<br>Internal Coping Strategies",
+          "type": "group",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "open-choice",
+                        "display": "Open choice"
+                      }
+                    ],
+                    "text": "Open choice"
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%resource.descendants().where(linkId='2e03fdf1-5274-494d-88e9-dd4b41ec90e6').answer.value"
+                  }
+                }
+              ],
+              "linkId": "b676a0c2-cda0-4762-be79-2a94205ee68b",
+              "type": "choice",
+              "repeats": true,
+              "answerOption": [
+                {
+                  "valueCoding": {
+                    "code": "tv",
+                    "display": "Watching TV"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "music",
+                    "display": "Listening to music"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "social-media",
+                    "display": "Social Media"
+                  }
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "e1f64e35-69f4-40ea-b067-d410634ea20e",
+                  "text": "Entertainment",
+                  "type": "display"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "open-choice",
+                        "display": "Open choice"
+                      }
+                    ],
+                    "text": "Open choice"
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%resource.descendants().where(linkId='d0aa3679-e465-4225-85d6-5822efb10eba').answer.value"
+                  }
+                }
+              ],
+              "linkId": "a25cb682-be35-4909-965e-01b8c2d036a2",
+              "type": "choice",
+              "repeats": true,
+              "answerOption": [
+                {
+                  "valueCoding": {
+                    "code": "walk",
+                    "display": "Walking"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "walk-at-park",
+                    "display": "Walking in the park"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "exercise",
+                    "display": "Exercise"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "gym",
+                    "display": "Going to the Gym"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "play-sports",
+                    "display": "Playing sports"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "gardening",
+                    "display": "Gardening"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "meditation",
+                    "display": "Meditation"
+                  }
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "b4b37213-6d56-4457-a703-160a86cb3989",
+                  "text": "Physical Activities",
+                  "type": "display"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                        "code": "open-choice",
+                        "display": "Open choice"
+                      }
+                    ],
+                    "text": "Open choice"
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%resource.descendants().where(linkId='e6262800-1e24-4348-9bf2-9bb070d2f20a').answer.value"
+                  }
+                }
+              ],
+              "linkId": "b7e42cdb-a42b-4d22-b7a6-204de5305351",
+              "type": "choice",
+              "repeats": true,
+              "answerOption": [
+                {
+                  "valueCoding": {
+                    "code": "video-games",
+                    "display": "Video Games"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "cooking",
+                    "display": "Cooking"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "painting",
+                    "display": "Painting"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "crafting",
+                    "display": "Crafting"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "code": "cleaning",
+                    "display": "Cleaning"
+                  }
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "7814f7e5-7b30-4244-bb6b-da75321fff5b",
+                  "text": "Indoor Activities and Hobbies",
+                  "type": "display"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%coping-self-care"
+                  }
+                }
+              ],
+              "linkId": "87dab385-fe6b-44ce-b6b2-5771c41d82c8",
+              "type": "text",
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "01743432-e6b9-4063-8fa7-72eab90f4600",
+                  "text": "Self care",
+                  "type": "display"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%coping-other"
+                  }
+                }
+              ],
+              "linkId": "991ba845-38e5-4622-8528-dfeefbf20d3d",
+              "type": "text",
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "flyover"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "linkId": "9f0b6129-44df-4699-8b3c-55263bea93a2",
+                  "text": "Other Activities",
+                  "type": "display"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "b42118cf-a226-4dec-acd7-029426fde8f4",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "030c90a4-9655-4c6b-86b7-8bd90c63937e",
+          "text": "My Safety Plan<br>People and Social Settings that provide distraction",
+          "type": "group"
+        },
+        {
+          "linkId": "9c479bac-97da-4f91-a4fb-5a3ea64c3680",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "8dec0e64-2f57-432f-9302-8e7e1ff14bbf",
+              "text": "Who can I contact to take my mind off problems and feel better",
+              "type": "display"
+            },
+            {
+              "linkId": "fb212f57-24a8-4a50-8d51-3a98d23a597e",
+              "type": "group",
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-1-name"
+                      }
+                    }
+                  ],
+                  "linkId": "808ba31c-cd29-4743-8801-dfce357d5956",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "e16e8ec5-e3f1-4e62-af04-8977c9204c39",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-1-number"
+                      }
+                    }
+                  ],
+                  "linkId": "c396a3af-6f0d-4a8e-a42b-4f47bbce5f46",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "96207694-d0f4-4554-9ce2-f8ec53c8887e",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "2a598f8a-a044-4df5-a93f-e506f13fb485",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "808ba31c-cd29-4743-8801-dfce357d5956",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-2-name"
+                      }
+                    }
+                  ],
+                  "linkId": "5846d53f-171d-47c4-89ad-4016c3be8233",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "a4b262ff-5842-46ac-ba84-361bb55069c2",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-2-number"
+                      }
+                    }
+                  ],
+                  "linkId": "62b0eb17-46e5-4c50-a133-087cc190a123",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "747eb35e-cade-41ce-bae7-ce09cb468e05",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "d92a8385-797e-4d21-ac8c-fd434ad72440",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "5846d53f-171d-47c4-89ad-4016c3be8233",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-3-name"
+                      }
+                    }
+                  ],
+                  "linkId": "5151ea93-a0f2-478d-adb6-f31374107b52",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "2ec2803f-e995-4ea2-8fb6-53d6eee2a3e0",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-3-number"
+                      }
+                    }
+                  ],
+                  "linkId": "8a9424b0-c893-4371-b5c9-bc0008be14b4",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "4ebac97d-4c84-4371-8b0a-5f27ef7b5f68",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "b1806749-2f61-4da7-afcd-a16fd027e1df",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "5151ea93-a0f2-478d-adb6-f31374107b52",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-4-name"
+                      }
+                    }
+                  ],
+                  "linkId": "69d5aec4-65d3-44b1-99ba-badd201769c5",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "c9fcbefd-ec07-4406-87a9-ec0765a87703",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-4-number"
+                      }
+                    }
+                  ],
+                  "linkId": "fc5c673b-41d4-4352-86bb-043c73ed9807",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "e33c1257-b963-4ec7-8ba5-f9049cecda1c",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "13c2ca95-2057-4fe3-a334-6a80b21055e2",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "69d5aec4-65d3-44b1-99ba-badd201769c5",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-5-name"
+                      }
+                    }
+                  ],
+                  "linkId": "83dfd82f-0277-459d-abe3-e8795750f288",
+                  "type": "string",
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "267e8450-c414-403f-a27c-5ce7cae6efd4",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%person-5-number"
+                      }
+                    }
+                  ],
+                  "linkId": "df53c378-27fe-483d-a630-f7b171f72980",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "9201e9b2-c70c-4cf2-b4ed-5c59dea0e96f",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "d6ac3906-adca-4ea6-ba94-eee8c11096b0",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "c9d6a596-5402-4cea-9d4c-1192f09caa0f",
+              "text": "Who can I contact to take my mind off problems and feel better",
+              "type": "display"
+            },
+            {
+              "linkId": "ef444616-72e6-478b-8031-08265d4dd4d5",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "ce0fdd41-6b09-4104-9998-a04c5dd9a5b7",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%place-1"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "c7ca9074-4ab1-4f02-b752-7205ebf259c2",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "9f531e61-26cf-4223-8653-39c24d6dd478",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%place-2"
+                      }
+                    }
+                  ],
+                  "enableWhen": [
+                    {
+                      "question": "ce0fdd41-6b09-4104-9998-a04c5dd9a5b7",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "f2a54d9b-9541-40bc-8744-5fd9d7f0a5a9",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "f1fef9d7-2ab9-4ead-9c24-c4dc9c7ed4cc",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%place-3"
+                      }
+                    }
+                  ],
+                  "enableWhen": [
+                    {
+                      "question": "9f531e61-26cf-4223-8653-39c24d6dd478",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "22b116c8-27b0-44bf-a492-616691faeb57",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "40d6a87f-9498-4cfd-b233-4610e6de08c2",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%place-4"
+                      }
+                    }
+                  ],
+                  "enableWhen": [
+                    {
+                      "question": "f1fef9d7-2ab9-4ead-9c24-c4dc9c7ed4cc",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "aa79c8e0-2914-433c-a7f0-1a5b4d00810b",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                },
+                {
+                  "linkId": "bfe595d6-325f-492a-b3b6-cc5541e18c3f",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%place-5"
+                      }
+                    }
+                  ],
+                  "enableWhen": [
+                    {
+                      "question": "40d6a87f-9498-4cfd-b233-4610e6de08c2",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "4a1d3ae4-0e07-4d1b-942b-20443ca401d6",
+                      "text": "Places, groups, social media, or events",
+                      "type": "display"
+                    }
+                  ],
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "f21aab8c-5dc0-46b7-8bbb-112c7af6afb1",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "8394433f-c4d2-4081-8078-b15526bc8199",
+          "text": "My Safety Plan<br>Family members or friends who may offer help",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "a024df63-da7f-40a3-b67a-06a941164084",
+              "text": "Who can I tell that I am in crisis and need support:",
+              "type": "display"
+            },
+            {
+              "linkId": "56906002-ab27-497f-a500-b658fc138522",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "36dd1467-a7a1-428c-bdca-17d352a79904",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-1-name"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "0367b705-82b9-455a-a28e-e828a555cf29",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "ce56c71d-9ea4-4c8e-9e9a-d1da93bac1d4",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-1-number"
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "018a39b9-c95b-4217-be0a-c6537453d5a6",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "8891cd7b-ad1c-4030-afe4-6752cd273cf4",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-1-barrier"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "c535b910-1f74-4177-828f-02f637db01b0",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "b99f3c9c-e3a2-47be-ab36-a794fa4839c6",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "d1efad02-3686-4ce3-a96d-68d8c638ff77",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "c1d9c871-c1f8-41cc-8c54-edd4e5b162fe",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-2-name"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "65078b6f-3308-45f4-889d-a90a9f2a86dd",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "e9c42647-eefb-42bd-9080-f83630729606",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-2-number"
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "2f2324b0-2c36-4cd7-9e85-79c41f8520c5",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "fdd7c3c3-f2c3-43bd-8a80-6b48aa2b9604",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-2-barrier"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "ed58cbca-5611-4193-bd6a-24a2eca411d9",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "f8257d17-0214-46ea-8976-7bdf273dfbd0",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "544a444d-b101-4d56-9351-00bca8ec749e",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "cf896559-dff5-4704-94a0-6a6aedee53c5",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-3-name"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "767cbc5e-de6e-4cf9-beda-0d389599f333",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "72e5c1b7-7ce9-49bd-834b-d98b73ba7090",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-3-number"
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "2f516369-889b-4ed8-b3ac-bcb73540cac3",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "11aadd88-0cf9-48b2-939d-2b3e28191c5f",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-3-barrier"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "1fd7a64b-caed-4032-a636-29f0a22e0608",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "568cdb06-4c58-4d6f-ac17-b7effdf31b8c",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "e9e056c2-0469-4523-a28f-1000fed1a4f1",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "9aeae470-6ea4-4e7f-9644-ed0375fb6369",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-4-name"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "5325df10-9c0d-4876-998f-00e51a4d1e79",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "e4a1be29-fe8b-4423-91bc-6b4f5d730e6b",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-4-number"
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "7014d719-ed5a-4359-b7b1-b59eedae7cbd",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "d46d2ca1-c1bf-459d-8cea-25e2ae21fa9e",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-4-barrier"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "cf73ab9a-abf9-44d2-8212-f907105f6f33",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "f28d91d7-aa0d-4aea-a1aa-199413cda2f1",
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "0399b747-eb74-48cf-aa07-6e9b57ee0883",
+                  "operator": "exists",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "98407058-4855-44cc-ac45-6e0d0c072fdd",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-5-name"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "71ad4a87-975a-4541-a98a-3354eb106c01",
+                      "text": "Name",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "ac3206dd-b60b-4cb1-a559-3a770a685668",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-5-number"
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "phone-number",
+                            "display": "Phone number"
+                          }
+                        ],
+                        "text": "Phone number"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "31db99b2-e007-4027-924e-aa48b3531b5a",
+                      "text": "Phone number",
+                      "type": "display"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "36231517-23df-4bbd-8e05-61649dcbeb4c",
+                  "type": "string",
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                      "valueExpression": {
+                        "expression": "%family-5-barrier"
+                      }
+                    }
+                  ],
+                  "item": [
+                    {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "flyover",
+                                "display": "Fly-over"
+                              }
+                            ],
+                            "text": "Flyover"
+                          }
+                        }
+                      ],
+                      "linkId": "8a4c9346-9d07-45f6-9ab3-d83f7d9d0ccf",
+                      "text": "Barriers to contact",
+                      "type": "display"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "c11ea1b4-13df-4267-aa58-512beae0fbf2",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "cb35bee5-1fde-48c3-b4f7-6ded06420258",
+          "text": "My Safety Plan<br>Professionals that can help",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "25c25d3c-1369-448f-9480-0905f6563109",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "428e8e6c-2588-4352-9300-0e4ffd2186e4",
+                  "text": "Hospitals, Clinics and Doctors I can contact for help",
+                  "type": "display"
+                },
+                {
+                  "linkId": "5fc685f9-5c68-4431-bfb6-1b4451cdaf9b",
+                  "type": "group",
+                  "item": [
+                    {
+                      "linkId": "40fbe8d0-4380-4efc-bb04-26fc7d3714eb",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-1-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f6bfa91e-64af-4861-af15-16cdc47cb2ba",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "e45b778d-ee8c-4ee9-81f4-8927006160f9",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-1-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "5f12ea5f-5b2c-4504-bc8a-050c249d863e",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "ae4fa455-f173-435a-bb1b-4df1d1316bd9",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-1-address"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "6c4c22a6-93b6-49d8-aa9f-6ff7180f2224",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "001127c2-406f-4399-981a-895fd09478ed",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "40fbe8d0-4380-4efc-bb04-26fc7d3714eb",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "3785a264-8bd5-44ab-bf08-8aa33735c0eb",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-2-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "c10ee58c-e1a5-449e-8bb9-90c5391ccda8",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "08b5e17c-5e14-4b19-ac93-9e479cd2a2bb",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-2-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "06e46010-f9a1-4053-a458-d0f2a2ba7061",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "28b2e31a-ee4d-4e99-8974-b616145311eb",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-2-address"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "2afbc102-b7c1-41b0-ad88-0f04f6959ff5",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "4e59ee7f-0d37-4324-8938-4acc0aa18dbc",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "3785a264-8bd5-44ab-bf08-8aa33735c0eb",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "6a273a98-82ca-4d36-ade0-ce98f7899972",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-3-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f00a7f30-cfc6-4059-8541-bdf3b98d0fb7",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "07c2e8dc-b48b-4bc7-b21b-c196cce32709",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-3-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f43b03c7-aac0-44fe-b685-dfe875380d3a",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "8c1ac4fe-1d76-4436-8f34-d315c6c17b9c",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-3-address"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "fb9383f8-33d9-4835-82a8-e561c549a765",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "53afb961-fff4-46b8-97fb-adaa41a79979",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "6a273a98-82ca-4d36-ade0-ce98f7899972",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "86da79f0-44cb-417d-ab20-c7ecc6f8f7c8",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-4-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "058de5ea-9313-421f-8150-ba7453409098",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "3314932c-64e4-4192-b583-eb31e87da1d0",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-4-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "7120eefc-0ccc-4179-9abd-11da78980f1b",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "4d334b16-ea16-4299-94ed-32e84ef97021",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-4-address"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "8973d0d8-d362-4180-a0aa-858b2478703d",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "f7181e49-ef13-46ff-9ab6-974902e684bd",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "86da79f0-44cb-417d-ab20-c7ecc6f8f7c8",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "40d8ef64-02f0-42ae-9478-77651bd26dfa",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-5-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "9e8638d8-1706-486d-952b-ef15fd2177dc",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "9b1b11e8-608f-4ea9-911b-88aae467ac27",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-5-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "ba85c008-7109-4eb5-af31-7c9ebeff0d01",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "54b75d55-1c43-4552-acbf-d9754831add8",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%hospital-5-address"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "b7c5d0a5-2ec1-4588-83bb-f1adec400522",
+                          "text": "Address",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "4410bcf3-d571-4108-bae4-0805d09de1d6",
+              "type": "group",
+              "item": [
+                {
+                  "linkId": "c49c3edd-4ace-4819-a8a3-bfa2ad61283d",
+                  "text": "Community Wellness and Healthcare workers I can contact for help",
+                  "type": "display"
+                },
+                {
+                  "linkId": "477dabd1-eb5c-4c2d-8c41-30e9f195c149",
+                  "type": "group",
+                  "item": [
+                    {
+                      "linkId": "a320b787-4cba-457f-9c60-67ff76c7020f",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-1-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "996ffea0-339e-42a2-a694-58355e37f274",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "706fc36f-efef-4bf9-827e-7dc100cc92bc",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-1-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "f1281975-b8dd-48ab-8f8b-03199bd4c475",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "6bbdb2cf-e7f6-443a-8f4e-841e16bb9b75",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-1-workplace"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "292c2207-ce18-4f6f-b587-555c888767d8",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "f7778d51-11b0-4c53-b26d-cd7e759c7d60",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "a320b787-4cba-457f-9c60-67ff76c7020f",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "1895c0a7-b090-4f49-9b0c-08dca9a7b225",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-2-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "561b33f0-035d-4100-8106-a25ff8b6626a",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "1a00c7b7-e80d-4e90-8ed4-efd8f6d96268",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-2-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "776e2185-c947-4598-9bbe-d84037d774a8",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "41cce38a-ca5c-4e24-904a-25b1027336ed",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-2-workplace"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "bde02fb1-3225-4605-b718-48fb63075bdf",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "0e36b673-6619-4773-81cc-90754b3c1198",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "1895c0a7-b090-4f49-9b0c-08dca9a7b225",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "06f9231a-999b-4459-8260-6fbbcdfc5d81",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-3-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "2eae4954-e609-4e88-af17-3cc60a16a095",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "74d0f0df-e726-4c40-84ce-efece882818b",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-3-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "3ec343e3-b0b5-44a1-9054-9c802b835944",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "d5194db0-0546-4bd1-96d8-d56457930c03",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-3-workplace"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "d94a0eea-b516-4523-bf5b-7757337a6464",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "123756ae-cd98-480a-8b80-f1a2e63eb8ba",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "06f9231a-999b-4459-8260-6fbbcdfc5d81",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "2f44652f-df2d-476e-933d-75b6ed55f5f2",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-4-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "d0b5248c-a2fe-43f4-af7f-f154f42a6586",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "7b51625b-73b9-472d-9c71-299beb26694f",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-4-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "2e80cb15-d586-4155-8502-0d65aca456e5",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "ec54e447-c981-4dd2-aaa4-659f8e494248",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-4-workplace"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "d36c5d61-0fbf-4436-8687-abd43594686c",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "linkId": "6eeae909-d604-4cb5-991c-862797d58eff",
+                  "type": "group",
+                  "enableWhen": [
+                    {
+                      "question": "2f44652f-df2d-476e-933d-75b6ed55f5f2",
+                      "operator": "exists",
+                      "answerBoolean": true
+                    }
+                  ],
+                  "item": [
+                    {
+                      "linkId": "5a79866d-f1fb-4bd8-b4c4-f18c982bef3c",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-5-name"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "6442c7a6-a105-4638-a63a-9b5b43ac0821",
+                          "text": "Name",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "45772f3f-c610-408b-942b-359769945cf4",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-5-number"
+                          }
+                        },
+                        {
+                          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "phone-number",
+                                "display": "Phone number"
+                              }
+                            ],
+                            "text": "Phone number"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "fb54061e-6a1a-40d5-b359-79643809239a",
+                          "text": "Phone number",
+                          "type": "display"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "7ca03155-c9ec-45e1-8cd0-5b86fa444ad0",
+                      "type": "string",
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                          "valueExpression": {
+                            "expression": "%comm-5-workplace"
+                          }
+                        }
+                      ],
+                      "item": [
+                        {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                              "valueCodeableConcept": {
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "flyover",
+                                    "display": "Fly-over"
+                                  }
+                                ],
+                                "text": "Flyover"
+                              }
+                            }
+                          ],
+                          "linkId": "a0d79152-095b-4fff-a25e-c34a18325bb4",
+                          "text": "Workplace",
+                          "type": "display"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "64de49e3-c988-440e-8dc0-1dad98ef2019",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "dadb95df-77c5-4d73-8fd1-b41c7d5d30fe",
+          "text": "My Safety Plan<br>Making the environment safe",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "a3670632-ce8f-468a-b2f3-6934245d3531",
+              "text": "Taking pills- I will protect myself from this risk by:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-pill"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "pill"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "68608473-77e6-4341-9f1b-d4d18b17d3de",
+              "text": "Toxins- I will protect myself from this risk by:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-toxin"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "toxin"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "20cae99e-ab90-4d75-92a2-c0af5dd60942",
+              "text": "Cutting- I will protect myself from this risk by:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-cut"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "cut"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "dfa1f239-2a4c-40bd-ab15-561f6d87febf",
+              "text": "Hanging- I will protect myself from this risk by:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-hang"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "hang"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "d3340d7e-9b84-4559-8a11-bed5a662a6f2",
+              "text": "Weapon- I will protect myself from this risk by:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-weapon"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "weapon"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "24e98b7c-2b1c-4ebe-946f-bcb77bc2aa36",
+              "text": "Jumping- I will protect myself from this risk by:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-jump"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "jump"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "ea95a315-f903-4351-87ed-c1e7e7b74198",
+              "text": "Drowning- I will protect myself from this risk by:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-drown"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "eb2ada21-64aa-4402-a35d-db63ea066b34",
+                  "operator": "=",
+                  "answerCoding": {
+                    "code": "drown"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "f14c3c34-f80a-4481-9d9c-9b05267d4c39",
+              "text": "Other ways I will make my environment safer:",
+              "type": "string",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "expression": "%env-other"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%moderate-or-high-risk-w-plan-approval"
+          }
+        }
+      ],
+      "linkId": "2dc2e7e4-a0dd-4b82-bbfa-de6dabaf7219",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "e0140e84-f711-42da-8c61-9a605756e164",
+          "text": "Provide the client with a copy of their Safety Plan",
+          "type": "group"
+        },
+        {
+          "linkId": "1c107ad7-b5d0-45f0-befd-c0d1695b9d69",
+          "text": "[PDF report]",
+          "type": "display"
+        },
+        {
+          "linkId": "9ea8d78b-3288-4ec8-8288-459c03df64f0",
+          "text": "Has the client been given a copy of their Safety Plan?",
+          "type": "boolean"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "page",
+                "display": "Page"
+              }
+            ],
+            "text": "Page"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%show-end-pages"
+          }
+        }
+      ],
+      "linkId": "3e4d06af-36c6-40e5-b3d7-f15e7e8c7972",
+      "type": "group",
+      "item": [
+        {
+          "linkId": "abe2d10f-8c9c-4f42-ad6b-92acbaf27774",
+          "text": "Conclude session and describe follow-up",
+          "type": "group"
+        },
+        {
+          "linkId": "e37c8e82-3a74-40c0-9b58-314fa522437b",
+          "text": "Thank you!",
+          "type": "display"
+        }
+      ]
     }
   ]
 }

--- a/catalog/src/main/assets/layout_paginated.json
+++ b/catalog/src/main/assets/layout_paginated.json
@@ -1,5 +1,39 @@
 {
   "resourceType": "Questionnaire",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q1",
+        "language": "text/fhirpath",
+        "expression": "%resource.descendants().where(linkId='7cc2e8a9-197a-42ea-9431-ba01eefc6511').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "q1-boolean-safe",
+        "language": "text/fhirpath",
+        "expression": "iif(%q1-boolean.exists(), %q1-boolean, false)"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "basic-questions-exists",
+        "language": "text/fhirpath",
+        "expression": "%q1-boolean.exists() and %q2-boolean.exists() and %q3-boolean.exists() and %q4-boolean.exists() and %q5a-boolean.exists() and %q6a-boolean.exists() and %q6b-boolean.exists() and (%q6c-boolean.exists() or %q7-boolean.exists())"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "low-risk",
+        "language": "text/fhirpath",
+        "expression": "((%q1-boolean or %q1-boolean.not()) or (%q2-boolean or %q2-boolean.not())) and (%moderate-risk-helper.not() and %high-risk-helper.not() and %severe-risk-helper.not())"
+      }
+    }
+  ],
   "item": [
     {
       "linkId": "1",
@@ -21,143 +55,23 @@
       ],
       "item": [
         {
-          "linkId": "1.1",
-          "type": "display",
-          "text": "Personal information",
-          "prefix": "1."
-        },
-        {
-          "linkId": "1.2",
-          "type": "string",
-          "required": true,
-          "item": [
-            {
-              "linkId": "1.2.1",
-              "text": "First Name",
-              "type": "display",
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                  "valueCodeableConcept": {
-                    "coding": [
-                      {
-                        "system": "http://hl7.org/fhir/questionnaire-item-control",
-                        "code": "flyover",
-                        "display": "Fly-over"
-                      }
-                    ],
-                    "text": "Flyover"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "linkId": "1.3",
-          "type": "string",
-          "item": [
-            {
-              "linkId": "1.3.1",
-              "text": "Family Name",
-              "type": "display",
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                  "valueCodeableConcept": {
-                    "coding": [
-                      {
-                        "system": "http://hl7.org/fhir/questionnaire-item-control",
-                        "code": "flyover",
-                        "display": "Fly-over"
-                      }
-                    ],
-                    "text": "Flyover"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "linkId": "1.4",
-          "type": "integer",
-          "item": [
-            {
-              "linkId": "1.4.1",
-              "text": "ID number",
-              "type": "display",
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                  "valueCodeableConcept": {
-                    "coding": [
-                      {
-                        "system": "http://hl7.org/fhir/questionnaire-item-control",
-                        "code": "flyover",
-                        "display": "Fly-over"
-                      }
-                    ],
-                    "text": "Flyover"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "linkId": "1.5",
-          "type": "integer",
-          "item": [
-            {
-              "linkId": "1.5.1",
-              "text": "Mobile number",
-              "type": "display",
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                  "valueCodeableConcept": {
-                    "coding": [
-                      {
-                        "system": "http://hl7.org/fhir/questionnaire-item-control",
-                        "code": "flyover",
-                        "display": "Fly-over"
-                      }
-                    ],
-                    "text": "Flyover"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "linkId": "1.6",
-          "type": "choice",
-          "repeats": true,
+          "linkId": "a-birthdate",
+          "text": "Birth Date",
+          "type": "boolean",
           "extension": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "check-box",
-                    "display": "Checkbox"
-                  }
-                ],
-                "text": "Checkbox"
-              }
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "code",
-                "display": "Receive SMS reminders"
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+              "valueExpression": {
+                "language": "text/fhirpath",
+                "expression": "%q1"
               }
             }
           ]
+        },
+        {
+          "linkId": "7cc2e8a9-197a-42ea-9431-ba01eefc6511",
+          "text": "In the past month, have you wished you were dead or wished you could go to sleep and not wake up?",
+          "type": "boolean"
         }
       ]
     },
@@ -180,37 +94,17 @@
         }
       ],
       "item": [
+
         {
-          "linkId": "2.1",
-          "type": "date",
-          "text": "Date of birth",
-          "prefix": "2.",
-          "required": true
-        },
-        {
-          "linkId": "2.2",
-          "type": "choice",
-          "repeats": true,
+          "linkId": "a-birthdate-2",
+          "text": "Birth Date",
+          "type": "boolean",
           "extension": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                    "code": "check-box",
-                    "display": "Checkbox"
-                  }
-                ],
-                "text": "Checkbox"
-              }
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "code1",
-                "display": "Unknown birthday"
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+              "valueExpression": {
+                "language": "text/fhirpath",
+                "expression": "%q1"
               }
             }
           ]

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -95,7 +95,8 @@ class QuestionnaireFragment : Fragment() {
       view.findViewById<RecyclerView>(R.id.questionnaire_review_recycler_view)
     val paginationPreviousButton = view.findViewById<View>(R.id.pagination_previous_button)
     paginationPreviousButton.setOnClickListener { viewModel.goToPreviousPage() }
-    val paginationNextButton = view.findViewById<View>(R.id.pagination_next_button)
+    val circularProgressIndicator = view.findViewById<View>(R.id.progress_circular_next_button)
+    val paginationNextButton = view.findViewById<Button>(R.id.pagination_next_button)
     paginationNextButton.setOnClickListener { viewModel.goToNextPage() }
     view.findViewById<Button>(R.id.cancel_questionnaire).setOnClickListener {
       QuestionnaireCancelDialogFragment()
@@ -146,6 +147,7 @@ class QuestionnaireFragment : Fragment() {
     questionnaireReviewRecyclerView.layoutManager = LinearLayoutManager(view.context)
 
     // Listen to updates from the view model.
+    viewModel.pages = viewModel.getQuestionnairePages()
     viewLifecycleOwner.lifecycleScope.launchWhenCreated {
       viewModel.questionnaireStateFlow.collect { state ->
         when (val displayMode = state.displayMode) {
@@ -194,6 +196,8 @@ class QuestionnaireFragment : Fragment() {
               paginationPreviousButton.isEnabled = displayMode.pagination.hasPreviousPage
               paginationNextButton.visibility = View.VISIBLE
               paginationNextButton.isEnabled = displayMode.pagination.hasNextPage
+              circularProgressIndicator.visibility = if (displayMode.pagination.isLoadingNextPage) View.VISIBLE else View.GONE
+              paginationNextButton.text = if (displayMode.pagination.isLoadingNextPage) "" else "Next"
             } else {
               paginationPreviousButton.visibility = View.GONE
               paginationNextButton.visibility = View.GONE

--- a/datacapture/src/main/res/layout/questionnaire_fragment.xml
+++ b/datacapture/src/main/res/layout/questionnaire_fragment.xml
@@ -109,15 +109,39 @@
             android:text="@string/button_pagination_previous"
         />
 
-        <Button
-            android:id="@+id/pagination_next_button"
-            style="?attr/questionnaireButtonStyle"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
-            android:layout_marginVertical="@dimen/action_button_margin_vertical"
-            android:text="@string/button_pagination_next"
-        />
+            android:layout_marginVertical="@dimen/action_button_margin_vertical">
+
+            <Button
+                android:id="@+id/pagination_next_button"
+                style="?attr/questionnaireButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/button_pagination_next"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/progress_circular_next_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:trackThickness="2dp"
+                app:indicatorSize="18dp"
+                app:layout_constraintTop_toTopOf="@id/pagination_next_button"
+                app:layout_constraintStart_toStartOf="@id/pagination_next_button"
+                app:layout_constraintEnd_toEndOf="@id/pagination_next_button"
+                app:layout_constraintBottom_toBottomOf="@id/pagination_next_button"
+                android:visibility="visible"
+                app:indicatorColor="@android:color/white"
+                android:indeterminate="true" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <Button
             android:id="@+id/review_mode_button"

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -1704,6 +1704,7 @@ class QuestionnaireViewModelTest {
         )
       }
     val viewModel = createQuestionnaireViewModel(questionnaire)
+    viewModel.pages = viewModel.getQuestionnairePages()
     viewModel.runViewModelBlocking {
       viewModel.goToNextPage()
       assertThat(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponentsTest.kt
@@ -1381,7 +1381,7 @@ class MoreQuestionnaireItemComponentsTest {
         )
       }
     val item2 = Questionnaire.QuestionnaireItemComponent().apply { linkId = "B" }
-    assertThat(item2.isReferencedBy(item1)).isTrue()
+    assertThat(item2.isExpressionReferencedBy(item1)).isTrue()
   }
 
   @Test
@@ -1398,7 +1398,7 @@ class MoreQuestionnaireItemComponentsTest {
         )
       }
     val item2 = Questionnaire.QuestionnaireItemComponent().apply { linkId = "B" }
-    assertThat(item2.isReferencedBy(item1)).isFalse()
+    assertThat(item2.isExpressionReferencedBy(item1)).isFalse()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/fhirpath/ExpressionEvaluatorTest.kt
@@ -541,8 +541,8 @@ class ExpressionEvaluatorTest {
 
     val result =
       expressionEvaluator.evaluateCalculatedExpressions(
-        questionnaire.item.elementAt(1),
-        questionnaireResponse.item.elementAt(1),
+          questionnaire.item.elementAt(1),
+          questionnaireResponse.item.elementAt(1),
       )
 
     assertThat(result.first().second.first().asStringValue())
@@ -613,8 +613,8 @@ class ExpressionEvaluatorTest {
 
       val result =
         expressionEvaluator.evaluateCalculatedExpressions(
-          questionnaire.item.elementAt(1),
-          questionnaireResponse.item.elementAt(1),
+            questionnaire.item.elementAt(1),
+            questionnaireResponse.item.elementAt(1),
         )
 
       assertThat(result.first().second.first().asStringValue())


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2274

**Description**
- Limiting calculation of calculatedExpression to the current page
- Move the execution of getQuestionnairePages to background thread (can take 2 seconds if the questionnaire has ~30 enableWhenExpression that's also using variableExpression)
- Show circular progress bar on the next page button until the background process is complete

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
