### PR TITLE
Updated the nested query to be able to use the index for searching instead of a full table scan

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/MoreSearch.kt
@@ -293,6 +293,7 @@ internal fun Search.getQuery(
     filterArgs.addAll(it.args)
   }
   val whereArgs = mutableListOf<Any>()
+  val nestedArgs = mutableListOf<Any>()
   val query =
     when {
         isCount -> {
@@ -311,11 +312,12 @@ internal fun Search.getQuery(
         nestedContext != null -> {
           whereArgs.add(nestedContext.param.paramName)
           val start = "${nestedContext.parentType.name}/".length + 1
+          nestedArgs.add(nestedContext.parentType.name)
           //  spotless:off
         """
         SELECT resourceUuid
         FROM ResourceEntity a
-        WHERE a.resourceId IN (
+        WHERE a.resourceType = ? AND a.resourceId IN (
         SELECT substr(a.index_value, $start)
         FROM ReferenceIndexEntity a
         $sortJoinStatement
@@ -342,7 +344,7 @@ internal fun Search.getQuery(
       .split("\n")
       .filter { it.isNotBlank() }
       .joinToString("\n") { it.trim() }
-  return SearchQuery(query, sortArgs + type.name + whereArgs + filterArgs + limitArgs)
+  return SearchQuery(query, nestedArgs + sortArgs + type.name + whereArgs + filterArgs + limitArgs)
 }
 
 private val Order?.sqlString: String

--- a/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/search/SearchTest.kt
@@ -1827,7 +1827,7 @@ class SearchTest {
         AND a.resourceUuid IN (
         SELECT resourceUuid
         FROM ResourceEntity a
-        WHERE a.resourceId IN (
+        WHERE a.resourceType = ? AND a.resourceId IN (
         SELECT substr(a.index_value, 9)
         FROM ReferenceIndexEntity a
         WHERE a.resourceType = ? AND a.index_name = ?
@@ -1844,6 +1844,7 @@ class SearchTest {
     assertThat(query.args)
       .isEqualTo(
         listOf(
+          ResourceType.Patient.name,
           ResourceType.Patient.name,
           ResourceType.Condition.name,
           Condition.SUBJECT.paramName,
@@ -1906,7 +1907,7 @@ class SearchTest {
         AND a.resourceUuid IN (
         SELECT resourceUuid
         FROM ResourceEntity a
-        WHERE a.resourceId IN (
+        WHERE a.resourceType = ? AND a.resourceId IN (
         SELECT substr(a.index_value, 9)
         FROM ReferenceIndexEntity a
         WHERE a.resourceType = ? AND a.index_name = ?
@@ -1931,6 +1932,7 @@ class SearchTest {
           ResourceType.Patient.name,
           Patient.ADDRESS_COUNTRY.paramName,
           "IN",
+          ResourceType.Patient.name,
           ResourceType.Immunization.name,
           Immunization.PATIENT.paramName,
           ResourceType.Immunization.name,
@@ -1974,7 +1976,7 @@ class SearchTest {
         AND a.resourceUuid IN (
         SELECT resourceUuid
         FROM ResourceEntity a
-        WHERE a.resourceId IN (
+        WHERE a.resourceType = ? AND a.resourceId IN (
         SELECT substr(a.index_value, 9)
         FROM ReferenceIndexEntity a
         WHERE a.resourceType = ? AND a.index_name = ?
@@ -1986,7 +1988,7 @@ class SearchTest {
         )  AND a.resourceUuid IN(
         SELECT resourceUuid
         FROM ResourceEntity a
-        WHERE a.resourceId IN (
+        WHERE a.resourceType = ? AND a.resourceId IN (
         SELECT substr(a.index_value, 9)
         FROM ReferenceIndexEntity a
         WHERE a.resourceType = ? AND a.index_name = ?
@@ -2004,12 +2006,14 @@ class SearchTest {
       .isEqualTo(
         listOf(
           ResourceType.Patient.name,
+          ResourceType.Patient.name,
           ResourceType.Condition.name,
           Condition.SUBJECT.paramName,
           ResourceType.Condition.name,
           Condition.CODE.paramName,
           "44054006",
           "http://snomed.info/sct",
+          ResourceType.Patient.name,
           ResourceType.Condition.name,
           Condition.SUBJECT.paramName,
           ResourceType.Condition.name,


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**
Fixes #2331

**Description**
Search query generated because of the [has](https://github.com/google/android-fhir/blob/master/engine/src/main/java/com/google/android/fhir/search/NestedSearch.kt#L42C42-L42C45) block was resulting in a full table scan instead of using an index.

The new query now is able to use this [composite index](https://github.com/google/android-fhir/blob/master/engine/src/main/java/com/google/android/fhir/db/impl/entities/ResourceEntity.kt#L30) of `resourceType` and `resourceId`.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix 

**Tested Search request** 

```
fhirEngine.search<Patient> {
  filter(TokenClientParam("active"), { value = of(true) })
  has(resourceType = ResourceType.Condition, referenceParam = Condition.SUBJECT) {
    filter(
      Condition.CODE,
      { value = of(Coding().apply { system = "http://snomed.info/sct"; code = "77386006" }) },
    )
    filter(
      Condition.CLINICAL_STATUS,
      { value = of(Coding().apply { system = "http://terminology.hl7.org/CodeSystem/condition-clinical"; code = "active" }) },
    )
  }
  sort(DateClientParam("_lastUpdated"), Order.DESCENDING)
  count = 10
  from = 0
}
```
The following table shows the time it took  to run the above search request in the demo app for multiple iterations.
| Iteration | Before | After |
|----------|-------|------|
|1|18.15 s| 226 ms|
|2|14.73 s|299 ms|
|3|16.23 s|197 ms|

**Generated Query** 

_**Before change**_

```
SELECT 
  a.serializedResource 
FROM 
  ResourceEntity a 
  LEFT JOIN DateIndexEntity b ON a.resourceType = b.resourceType 
  AND a.resourceUuid = b.resourceUuid 
  AND b.index_name = '_lastUpdated' 
  LEFT JOIN DateTimeIndexEntity c ON a.resourceType = c.resourceType 
  AND a.resourceUuid = c.resourceUuid 
  AND c.index_name = '_lastUpdated' 
WHERE 
  a.resourceType = 'Patient' 
  AND a.resourceUuid IN (
    SELECT 
      resourceUuid 
    FROM 
      TokenIndexEntity 
    WHERE 
      resourceType = 'Patient' 
      AND index_name = 'active' 
      AND index_value = 'true'
  ) 
  AND a.resourceUuid IN (
    SELECT 
      resourceUuid 
    FROM 
      ResourceEntity a 
    WHERE 
      a.resourceId IN (
        SELECT 
          substr(a.index_value, 9) 
        FROM 
          ReferenceIndexEntity a 
        WHERE 
          a.resourceType = 'Condition' 
          AND a.index_name = 'subject' 
          AND a.resourceUuid IN (
            SELECT 
              resourceUuid 
            FROM 
              TokenIndexEntity 
            WHERE 
              resourceType = 'Condition' 
              AND index_name = 'code' 
              AND (
                index_value = '77386006' 
                AND IFNULL(index_system, '') = 'http://snomed.info/sct'
              )
          ) 
          AND a.resourceUuid IN (
            SELECT 
              resourceUuid 
            FROM 
              TokenIndexEntity 
            WHERE 
              resourceType = 'Condition' 
              AND index_name = 'clinical-status' 
              AND (
                index_value = 'active' 
                AND IFNULL(index_system, '') = 'http://terminology.hl7.org/CodeSystem/condition-clinical'
              )
          )
      )
  ) 
ORDER BY 
  b.index_from DESC, 
  c.index_from DESC 
LIMIT 
  10 OFFSET 0
```

**_After Change_**

```
SELECT 
  a.serializedResource 
FROM 
  ResourceEntity a 
  LEFT JOIN DateIndexEntity b ON a.resourceType = b.resourceType 
  AND a.resourceUuid = b.resourceUuid 
  AND b.index_name = '_lastUpdated' 
  LEFT JOIN DateTimeIndexEntity c ON a.resourceType = c.resourceType 
  AND a.resourceUuid = c.resourceUuid 
  AND c.index_name = '_lastUpdated' 
WHERE 
  a.resourceType = 'Patient' 
  AND a.resourceUuid IN (
    SELECT 
      resourceUuid 
    FROM 
      TokenIndexEntity 
    WHERE 
      resourceType = 'Patient' 
      AND index_name = 'active' 
      AND index_value = 'true'
  ) 
  AND a.resourceUuid IN (
    SELECT 
      resourceUuid 
    FROM 
      ResourceEntity a 
    WHERE 
      a.resourceType = 'Patient' AND a.resourceId IN (
        SELECT 
          substr(a.index_value, 9) 
        FROM 
          ReferenceIndexEntity a 
        WHERE 
          a.resourceType = 'Condition' 
          AND a.index_name = 'subject' 
          AND a.resourceUuid IN (
            SELECT 
              resourceUuid 
            FROM 
              TokenIndexEntity 
            WHERE 
              resourceType = 'Condition' 
              AND index_name = 'code' 
              AND (
                index_value = '77386006' 
                AND IFNULL(index_system, '') = 'http://snomed.info/sct'
              )
          ) 
          AND a.resourceUuid IN (
            SELECT 
              resourceUuid 
            FROM 
              TokenIndexEntity 
            WHERE 
              resourceType = 'Condition' 
              AND index_name = 'clinical-status' 
              AND (
                index_value = 'active' 
                AND IFNULL(index_system, '') = 'http://terminology.hl7.org/CodeSystem/condition-clinical'
              )
          )
      )
  ) 
ORDER BY 
  b.index_from DESC, 
  c.index_from DESC 
LIMIT 
  10 OFFSET 0
```

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
