### PR TITLE
Fix TextWatcher initialization in date picker widget

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
@@ -65,7 +65,7 @@ internal object DatePickerViewHolderFactory :
       private lateinit var textInputEditText: TextInputEditText
       override lateinit var questionnaireViewItem: QuestionnaireViewItem
       private lateinit var canonicalizedDatePattern: String
-      private lateinit var textWatcher: DatePatternTextWatcher
+      private var textWatcher: TextWatcher? = null
 
       override fun init(itemView: View) {
         header = itemView.findViewById(R.id.header)
@@ -108,7 +108,6 @@ internal object DatePickerViewHolderFactory :
         val datePattern = questionnaireViewItem.questionnaireItem.dateEntryFormatOrSystemDefault
         // Special character used in date pattern
         val datePatternSeparator = getDateSeparator(datePattern)
-        textWatcher = DatePatternTextWatcher(datePatternSeparator)
         canonicalizedDatePattern = canonicalizeDatePattern(datePattern)
 
         with(textInputLayout) {
@@ -142,6 +141,7 @@ internal object DatePickerViewHolderFactory :
         } else {
           displayValidationResult(questionnaireViewItem.validationResult)
         }
+        textWatcher = DatePatternTextWatcher(datePatternSeparator)
         textInputEditText.addTextChangedListener(textWatcher)
       }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2354 

**Description**
Initiate the TextWatcher after calling `textInputEditText.removeTextChangedListener(textWatcher)`

**Alternative(s) considered**
N/A

**Type**
Bug fix

**Screenshots (if applicable)**

[Screen_recording_20231210_222606.webm](https://github.com/google/android-fhir/assets/62053304/abe80a4e-1429-42d1-ab7a-bfe4ed63df24)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
