### PR TITLE
Upload design to support intermeidate progresses

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,19 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!--
- Copyright 2020 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="RemoteRepositoriesConfiguration">
     <remote-repository>
@@ -24,20 +9,7 @@
     <remote-repository>
       <option name="id" value="jboss.community" />
       <option name="name" value="JBoss Community repository" />
-      <option
-          name="url"
-          value="https://repository.jboss.org/nexus/content/repositories/public/"
-      />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="BintrayJCenter" />
-      <option name="name" value="BintrayJCenter" />
-      <option name="url" value="https://jcenter.bintray.com/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="Google" />
-      <option name="name" value="Google" />
-      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="MavenRepo" />
@@ -45,17 +17,19 @@
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="maven" />
-      <option name="name" value="maven" />
-      <option
-          name="url"
-          value="https://oss.sonatype.org/content/repositories/snapshots"
-      />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="Gradle Central Plugin Repository" />
       <option name="name" value="Gradle Central Plugin Repository" />
       <option name="url" value="https://plugins.gradle.org/m2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots" />
     </remote-repository>
   </component>
 </project>

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -19,9 +19,9 @@ package com.google.android.fhir
 import com.google.android.fhir.db.ResourceNotFoundException
 import com.google.android.fhir.search.Search
 import com.google.android.fhir.sync.ConflictResolver
+import com.google.android.fhir.sync.upload.IUploader
 import com.google.android.fhir.sync.upload.LocalChangesFetchMode
 import com.google.android.fhir.sync.upload.SyncUploadProgress
-import com.google.android.fhir.sync.upload.UploadSyncResult
 import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.Flow
 import org.hl7.fhir.r4.model.Resource
@@ -63,7 +63,7 @@ interface FhirEngine {
    */
   suspend fun syncUpload(
     localChangesFetchMode: LocalChangesFetchMode,
-    upload: (suspend (List<LocalChange>) -> UploadSyncResult),
+    uploader: IUploader,
   ): Flow<SyncUploadProgress>
 
   /**

--- a/engine/src/main/java/com/google/android/fhir/sync/FhirSynchronizer.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/FhirSynchronizer.kt
@@ -21,8 +21,8 @@ import com.google.android.fhir.DatastoreUtil
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.sync.download.DownloadState
 import com.google.android.fhir.sync.download.Downloader
+import com.google.android.fhir.sync.upload.IUploader
 import com.google.android.fhir.sync.upload.LocalChangesFetchMode
-import com.google.android.fhir.sync.upload.Uploader
 import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -48,7 +48,7 @@ data class ResourceSyncException(val resourceType: ResourceType, val exception: 
 internal class FhirSynchronizer(
   context: Context,
   private val fhirEngine: FhirEngine,
-  private val uploader: Uploader,
+  private val uploader: IUploader,
   private val downloader: Downloader,
   private val conflictResolver: ConflictResolver,
 ) {
@@ -119,7 +119,7 @@ internal class FhirSynchronizer(
   private suspend fun upload(): SyncResult {
     val exceptions = mutableListOf<ResourceSyncException>()
     val localChangesFetchMode = LocalChangesFetchMode.AllChanges
-    fhirEngine.syncUpload(localChangesFetchMode, uploader::upload).collect { progress ->
+    fhirEngine.syncUpload(localChangesFetchMode, uploader).collect { progress ->
       progress.uploadError?.let { exceptions.add(it) }
         ?: setSyncState(
           SyncJobStatus.InProgress(

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/IUploader.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/IUploader.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.sync.upload
+
+import com.google.android.fhir.LocalChange
+import kotlinx.coroutines.flow.Flow
+
+interface IUploader {
+  val uploadRequestResultFlows: Flow<UploadRequestResult>
+
+  suspend fun upload(localChanges: List<LocalChange>)
+}

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/UploadRequestResult.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/UploadRequestResult.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.sync.upload
+
+import com.google.android.fhir.LocalChangeToken
+import com.google.android.fhir.sync.ResourceSyncException
+import org.hl7.fhir.r4.model.Resource
+
+open class UploadRequestResult {
+  data class Success(val token: LocalChangeToken, val resource: Resource) : UploadRequestResult()
+
+  data class Failure(val syncError: ResourceSyncException, val localChangeToken: LocalChangeToken) :
+    UploadRequestResult()
+}

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/patch/Patch.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/patch/Patch.kt
@@ -17,6 +17,7 @@
 package com.google.android.fhir.sync.upload.patch
 
 import com.google.android.fhir.LocalChange
+import com.google.android.fhir.LocalChangeToken
 import java.time.Instant
 import org.hl7.fhir.r4.model.Resource
 
@@ -34,6 +35,7 @@ data class Patch(
   val type: Type,
   /** json string with local changes */
   val payload: String,
+  val token: LocalChangeToken,
 ) {
   enum class Type(val value: Int) {
     INSERT(1), // create a new resource. payload is the entire resource json.

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PerResourcePatchGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PerResourcePatchGenerator.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.fge.jsonpatch.JsonPatch
 import com.google.android.fhir.LocalChange
 import com.google.android.fhir.LocalChange.Type
+import com.google.android.fhir.LocalChangeToken
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -86,6 +87,7 @@ internal object PerResourcePatchGenerator : PatchGenerator {
       payload = payload,
       versionId = localChanges.first().versionId,
       timestamp = localChanges.last().timestamp,
+      token = LocalChangeToken(localChanges.flatMap { it.token.ids }),
     )
 
   /** Update a JSON object with a JSON patch (RFC 6902). */


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2355 

[Nah this needs to improve]

**Description**
I want to use an Uploader instance instead of upload lambda in the syncUpload FhirEngine API. This Uploader maintains a flow called `uploadRequestResultFlow` where uploader emits `UploadRequestResult`s.
This way I can collect all `UploadRequestResult`s in syncUpload irrespective of which batch the results belong. This also seems to be a better approach than collecting these results inside the while loop.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
