### PR TITLE
Quantity unit options with initial quantity value

### DIFF
--- a/catalog/src/main/assets/behavior_calculated_expression.json
+++ b/catalog/src/main/assets/behavior_calculated_expression.json
@@ -19,13 +19,34 @@
       "linkId": "a-age-years",
       "text": "Age years",
       "type": "quantity",
-      "initial": [{
-        "valueQuantity": {
-          "unit": "years",
-          "system": "http://unitsofmeasure.org",
-          "code": "years"
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption",
+          "valueCoding": {
+            "system": "http://unitsofmeasure.org",
+            "code": "years",
+            "display": "years"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption",
+          "valueCoding": {
+            "system": "http://unitsofmeasure.org",
+            "code": "months",
+            "display": "months"
+          }
         }
-      }]
+      ],
+      "initial": [
+        {
+          "valueQuantity": {
+            "value": 1,
+            "unit": "years",
+            "system": "http://unitsofmeasure.org",
+            "code": "months"
+          }
+        }
+      ]
     }
   ]
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -581,6 +581,15 @@ internal val Questionnaire.QuestionnaireItemComponent.unitOption: List<Coding>
     return this.extension
       .filter { it.url == EXTENSION_QUESTIONNAIRE_UNIT_OPTION_URL }
       .map { it.value as Coding }
+      .ifEmpty {
+        // https://build.fhir.org/ig/HL7/sdc/behavior.html#initial
+        // quantity given as initial without value is for default unit reference purpose
+        if (this.hasInitial()) {
+          listOf(this.initialFirstRep.valueQuantity.toCoding())
+        } else {
+          listOf()
+        }
+      }
   }
 
 // ********************************************************************************************** //

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreTypes.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreTypes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,11 @@ internal fun StringType.toIdType(): IdType {
 /** Converts Coding to CodeType. */
 internal fun Coding.toCodeType(): CodeType {
   return CodeType(code)
+}
+
+/** Converts Quantity to Coding. */
+internal fun Quantity.toCoding(): Coding {
+  return Coding(this.system, this.code, this.unit)
 }
 
 fun Type.valueOrCalculateValue(): Type {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/QuantityViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/QuantityViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Google LLC
+ * Copyright 2022-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import androidx.core.widget.doAfterTextChanged
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.getRequiredOrOptionalText
 import com.google.android.fhir.datacapture.extensions.localizedFlyoverSpanned
+import com.google.android.fhir.datacapture.extensions.toCoding
 import com.google.android.fhir.datacapture.extensions.unitOption
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.NotValidated
@@ -112,6 +113,7 @@ internal object QuantityViewHolderFactory :
 
         textInputEditText.removeTextChangedListener(textWatcher)
         updateUI()
+
         textWatcher =
           textInputEditText.doAfterTextChanged { editable: Editable? ->
             handleInput(editable!!, null)
@@ -157,10 +159,8 @@ internal object QuantityViewHolderFactory :
         editable?.toString()?.let { decimal = it.toBigDecimalOrNull() }
         unitDropDown?.let { unit = it }
 
-        if (decimal == null && unit == null) {
+        if (decimal == null) {
           questionnaireViewItem.clearAnswer()
-        } else if (decimal == null) {
-          questionnaireViewItem.setDraftAnswer(unit)
         } else if (unit == null) {
           questionnaireViewItem.setDraftAnswer(decimal)
         } else {
@@ -189,6 +189,11 @@ internal object QuantityViewHolderFactory :
             Coding(it.system, it.code, it.unit)
           }
             ?: questionnaireViewItem.draftAnswer?.let { if (it is Coding) it else null }
+              ?: questionnaireViewItem.questionnaireItem
+              .takeIf { it.hasInitial() }
+              ?.initialFirstRep
+              ?.valueQuantity
+              ?.toCoding()
         unitAutoCompleteTextView.setText(unit?.display ?: "")
 
         val unitAdapter =

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponentsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1496,6 +1496,73 @@ class MoreQuestionnaireItemComponentsTest {
     Locale.setDefault(Locale.forLanguageTag("vi-VN"))
 
     assertThat(questionItemList.first().localizedFlyoverSpanned.toString()).isEqualTo("gợi ý")
+  }
+
+  @Test
+  fun `unitOption should return list of coding for multiple available unit options`() {
+    val question =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        addExtension(
+          EXTENSION_QUESTIONNAIRE_UNIT_OPTION_URL,
+          Coding("http://unit.org", "yr", "years"),
+        )
+        addExtension(
+          EXTENSION_QUESTIONNAIRE_UNIT_OPTION_URL,
+          Coding("http://unit.org", "mn", "months"),
+        )
+      }
+
+    val result = question.unitOption
+
+    assertThat(result).hasSize(2)
+    assertThat((result[0].equalsDeep(Coding("http://unit.org", "yr", "years"))))
+    assertThat((result[1].equalsDeep(Coding("http://unit.org", "mn", "months"))))
+  }
+
+  @Test
+  fun `unitOption should return list with single coding for single available unit option`() {
+    val question =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        addExtension(
+          EXTENSION_QUESTIONNAIRE_UNIT_OPTION_URL,
+          Coding("http://unit.org", "yr", "years"),
+        )
+      }
+
+    val result = question.unitOption
+
+    assertThat(result).hasSize(1)
+    assertThat((result[0].equalsDeep(Coding("http://unit.org", "yr", "years"))))
+  }
+
+  @Test
+  fun `unitOption should return empty list for no available unit option`() {
+    val question = Questionnaire.QuestionnaireItemComponent()
+
+    val result = question.unitOption
+
+    assertThat(result).hasSize(0)
+  }
+
+  @Test
+  fun `unitOption should return list with single coding when initial value of type quantity is defined`() {
+    val question =
+      Questionnaire.QuestionnaireItemComponent().apply {
+        addInitial(
+          Questionnaire.QuestionnaireItemInitialComponent(
+            Quantity().apply {
+              this.system = "http://unit.org"
+              this.code = "yr"
+              this.unit = "years"
+            },
+          ),
+        )
+      }
+
+    val result = question.unitOption
+
+    assertThat(result).hasSize(1)
+    assertThat((result[0].equalsDeep(Coding("http://unit.org", "yr", "years"))))
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreTypesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreTypesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Google LLC
+ * Copyright 2022-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,6 +203,18 @@ class MoreTypesTest {
   fun coding_toCodeType() {
     val code = Coding("fakeSystem", "fakeCode", "fakeDisplay").toCodeType()
     assertThat(code.equalsDeep(CodeType("fakeCode"))).isTrue()
+  }
+
+  @Test
+  fun `should return coding for quantity`() {
+    val quantity =
+      Quantity(1).apply {
+        this.code = "yr"
+        this.unit = "years"
+        this.system = "http://unit.org"
+      }
+    val result = quantity.toCoding()
+    assertThat(result.equalsDeep(Coding("http://unit.org", "yr", "years")))
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/QuantityViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/QuantityViewHolderFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,35 @@ class QuantityViewHolderFactoryTest {
             },
           )
         },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      ),
+    )
+
+    assertThat(
+        viewHolder.itemView
+          .findViewById<AutoCompleteTextView>(R.id.unit_auto_complete)
+          .text
+          .toString(),
+      )
+      .isEqualTo("kg")
+  }
+
+  @Test
+  fun `should set unit value from initial when answer is missing`() {
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply {
+          addInitial(
+            Questionnaire.QuestionnaireItemInitialComponent(
+              Quantity().apply {
+                this.unit = "kg"
+                this.code = "kilo"
+              },
+            ),
+          )
+        },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
         answersChangedCallback = { _, _, _, _ -> },
       ),


### PR DESCRIPTION
Fixes #2157 

**Description**
As per fhir specs https://build.fhir.org/ig/HL7/sdc/behavior.html#initial an initial without decimal part of quantity type can be used for default unit reference purpose. The QuantityViewHolderFactory is now handling the unitoption with initial quantity used to specify default unit.

**Type**
Choose one: (Bug fix)

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
