### PR TITLE
Cleanup the text during the re-bind of the Decimal and Integer view holders.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Google LLC
+ * Copyright 2022-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,11 +52,15 @@ internal object EditTextDecimalViewHolderFactory :
 
         val decimalStringToDisplay = questionnaireItemViewItemDecimalAnswer ?: draftAnswer
 
-        if (
-          decimalStringToDisplay?.toDoubleOrNull() !=
+        if (decimalStringToDisplay.isNullOrEmpty()) {
+          textInputEditText.setText("")
+        } else if (
+          questionnaireItemViewItemDecimalAnswer?.toDoubleOrNull() !=
             textInputEditText.text.toString().toDoubleOrNull()
         ) {
           textInputEditText.setText(decimalStringToDisplay)
+        } else if (draftAnswer != null && draftAnswer != textInputEditText.text.toString()) {
+          textInputEditText.setText(draftAnswer)
         }
         // Update error message if draft answer present
         if (draftAnswer != null) {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactory.kt
@@ -47,18 +47,15 @@ internal object EditTextDecimalViewHolderFactory :
       ) {
         val questionnaireItemViewItemDecimalAnswer =
           questionnaireViewItem.answers.singleOrNull()?.valueDecimalType?.value?.toString()
-
         val draftAnswer = questionnaireViewItem.draftAnswer?.toString()
 
-        val decimalStringToDisplay = questionnaireItemViewItemDecimalAnswer ?: draftAnswer
-
-        if (decimalStringToDisplay.isNullOrEmpty()) {
+        if (questionnaireItemViewItemDecimalAnswer.isNullOrEmpty() && draftAnswer.isNullOrEmpty()) {
           textInputEditText.setText("")
         } else if (
           questionnaireItemViewItemDecimalAnswer?.toDoubleOrNull() !=
             textInputEditText.text.toString().toDoubleOrNull()
         ) {
-          textInputEditText.setText(decimalStringToDisplay)
+          textInputEditText.setText(questionnaireItemViewItemDecimalAnswer)
         } else if (draftAnswer != null && draftAnswer != textInputEditText.text.toString()) {
           textInputEditText.setText(draftAnswer)
         }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Google LLC
+ * Copyright 2022-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,12 @@ internal object EditTextIntegerViewHolderFactory :
         // is different from what the user is typing. We compare the two fields as integers to
         // avoid shifting focus if the text values are different, but their integer representation
         // is the same (e.g. "001" compared to "1")
-        if ((text?.toIntOrNull() != textInputEditText.text.toString().toIntOrNull())) {
+        if (text.isNullOrEmpty()) {
+          textInputEditText.setText("")
+        } else if (answer?.toIntOrNull() != textInputEditText.text.toString().toIntOrNull()) {
           textInputEditText.setText(text)
+        } else if (draftAnswer != null && draftAnswer != textInputEditText.text.toString()) {
+          textInputEditText.setText(draftAnswer)
         }
 
         // Update error message if draft answer present

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
@@ -64,16 +64,14 @@ internal object EditTextIntegerViewHolderFactory :
           questionnaireViewItem.answers.singleOrNull()?.valueIntegerType?.value?.toString()
         val draftAnswer = questionnaireViewItem.draftAnswer?.toString()
 
-        val text = answer ?: draftAnswer
-
         // Update the text on the UI only if the value of the saved answer or draft answer
         // is different from what the user is typing. We compare the two fields as integers to
         // avoid shifting focus if the text values are different, but their integer representation
         // is the same (e.g. "001" compared to "1")
-        if (text.isNullOrEmpty()) {
+        if (answer.isNullOrEmpty() && draftAnswer.isNullOrEmpty()) {
           textInputEditText.setText("")
         } else if (answer?.toIntOrNull() != textInputEditText.text.toString().toIntOrNull()) {
-          textInputEditText.setText(text)
+          textInputEditText.setText(answer)
         } else if (draftAnswer != null && draftAnswer != textInputEditText.text.toString()) {
           textInputEditText.setText(draftAnswer)
         }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -446,5 +446,39 @@ class EditTextDecimalViewHolderFactoryTest {
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).helperText)
       .isNull()
+  }
+
+  @Test
+  fun `bind again should remove previous text`() {
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+    viewHolder.bind(questionnaireViewItem)
+    viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).apply {
+      setText("1.1.1.1")
+      clearFocus()
+    }
+    viewHolder.itemView.clearFocus()
+
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      ),
+    )
+
+    assertThat(
+        viewHolder.itemView
+          .findViewById<TextInputEditText>(R.id.text_input_edit_text)
+          .text
+          .toString(),
+      )
+      .isEqualTo("")
   }
 }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactoryTest.kt
@@ -450,19 +450,23 @@ class EditTextDecimalViewHolderFactoryTest {
 
   @Test
   fun `bind again should remove previous text`() {
-    val questionnaireViewItem =
+    viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
         answersChangedCallback = { _, _, _, _ -> },
+        draftAnswer = "1.1.1.1",
+      ),
+    )
+
+    assertThat(
+        viewHolder.itemView
+          .findViewById<TextInputEditText>(R.id.text_input_edit_text)
+          .text
+          .toString(),
       )
-    viewHolder.bind(questionnaireViewItem)
-    viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).apply {
-      setText("1.1.1.1")
-      clearFocus()
-    }
-    viewHolder.itemView.clearFocus()
+      .isEqualTo("1.1.1.1")
 
     viewHolder.bind(
       QuestionnaireViewItem(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
@@ -372,19 +372,23 @@ class EditTextIntegerViewHolderFactoryTest {
 
   @Test
   fun `bind again should remove previous text`() {
-    val questionnaireViewItem =
+    viewHolder.bind(
       QuestionnaireViewItem(
         Questionnaire.QuestionnaireItemComponent(),
         QuestionnaireResponse.QuestionnaireResponseItemComponent(),
         validationResult = NotValidated,
         answersChangedCallback = { _, _, _, _ -> },
+        draftAnswer = "9999999999",
+      ),
+    )
+
+    assertThat(
+        viewHolder.itemView
+          .findViewById<TextInputEditText>(R.id.text_input_edit_text)
+          .text
+          .toString(),
       )
-    viewHolder.bind(questionnaireViewItem)
-    viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).apply {
-      setText("9999999999")
-      clearFocus()
-    }
-    viewHolder.itemView.clearFocus()
+      .isEqualTo("9999999999")
 
     viewHolder.bind(
       QuestionnaireViewItem(

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -368,5 +368,39 @@ class EditTextIntegerViewHolderFactoryTest {
 
     assertThat(viewHolder.itemView.findViewById<TextInputLayout>(R.id.text_input_layout).helperText)
       .isNull()
+  }
+
+  @Test
+  fun `bind again should remove previous text`() {
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+    viewHolder.bind(questionnaireViewItem)
+    viewHolder.itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).apply {
+      setText("9999999999")
+      clearFocus()
+    }
+    viewHolder.itemView.clearFocus()
+
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent(),
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      ),
+    )
+
+    assertThat(
+        viewHolder.itemView
+          .findViewById<TextInputEditText>(R.id.text_input_edit_text)
+          .text
+          .toString(),
+      )
+      .isEqualTo("")
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2401

**Description**
Updated the code to
1. Set the draft answer correctly.
2. Clear the answers when possible rebind occurs ( no draft or answer is available to be set).

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
