### PR TITLE
Make bottom navigation buttons scrollable.

### DIFF
--- a/datacapture/src/main/res/layout/questionnaire_fragment.xml
+++ b/datacapture/src/main/res/layout/questionnaire_fragment.xml
@@ -69,76 +69,84 @@
         style="?attr/questionnaireBottomNavContainerDividerStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@id/bottom_nav_container"
+        app:layout_constraintBottom_toTopOf="@id/bottom_nav_scrollView"
     />
 
-    <LinearLayout
-        android:id="@+id/bottom_nav_container"
-        style="?attr/questionnaireBottomNavContainerStyle"
+    <HorizontalScrollView
+        android:id="@+id/bottom_nav_scrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentBottom="true"
-        android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
     >
 
-        <Button
-            android:id="@+id/cancel_questionnaire"
-            style="?attr/questionnaireCancelButtonStyle"
-            android:layout_width="wrap_content"
+    <LinearLayout
+            android:id="@+id/bottom_nav_container"
+            style="?attr/questionnaireBottomNavContainerStyle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
-            android:layout_marginVertical="@dimen/action_button_margin_vertical"
-            android:text="@string/cancel_questionnaire"
-        />
+            android:layout_alignParentTop="true"
+            android:layout_alignParentBottom="true"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+        >
+
+        <Button
+                android:id="@+id/cancel_questionnaire"
+                style="?attr/questionnaireCancelButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
+                android:layout_marginVertical="@dimen/action_button_margin_vertical"
+                android:text="@string/cancel_questionnaire"
+            />
 
         <View
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-        />
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+            />
 
         <Button
-            android:id="@+id/pagination_previous_button"
-            style="?attr/questionnaireButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
-            android:layout_marginVertical="@dimen/action_button_margin_vertical"
-            android:text="@string/button_pagination_previous"
-        />
+                android:id="@+id/pagination_previous_button"
+                style="?attr/questionnaireButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
+                android:layout_marginVertical="@dimen/action_button_margin_vertical"
+                android:text="@string/button_pagination_previous"
+            />
 
         <Button
-            android:id="@+id/pagination_next_button"
-            style="?attr/questionnaireButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
-            android:layout_marginVertical="@dimen/action_button_margin_vertical"
-            android:text="@string/button_pagination_next"
-        />
+                android:id="@+id/pagination_next_button"
+                style="?attr/questionnaireButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
+                android:layout_marginVertical="@dimen/action_button_margin_vertical"
+                android:text="@string/button_pagination_next"
+            />
 
         <Button
-            android:id="@+id/review_mode_button"
-            style="?attr/questionnaireButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
-            android:layout_marginVertical="@dimen/action_button_margin_vertical"
-            android:text="@string/button_review"
-        />
+                android:id="@+id/review_mode_button"
+                style="?attr/questionnaireButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
+                android:layout_marginVertical="@dimen/action_button_margin_vertical"
+                android:text="@string/button_review"
+            />
 
         <Button
-            android:id="@+id/submit_questionnaire"
-            style="?attr/questionnaireSubmitButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
-            android:layout_marginVertical="@dimen/action_button_margin_vertical"
-            android:text="@string/submit_questionnaire"
-        />
+                android:id="@+id/submit_questionnaire"
+                style="?attr/questionnaireSubmitButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
+                android:layout_marginVertical="@dimen/action_button_margin_vertical"
+                android:text="@string/submit_questionnaire"
+            />
 
     </LinearLayout>
+    </HorizontalScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2404 

**Description**
One approach is to add a HorizontalScrollView, allowing users to scroll and view partially hidden buttons. In this case, disabled buttons can also be shown.

**Alternative(s) considered**
Alternatively, you can choose to hide the disabled buttons, ensuring enough space for other buttons to be rendered on the screen. 
https://github.com/google/android-fhir/pull/2397 fix the issue indirectly

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
