### PR TITLE
Allow nullable expressions in library evaluator

### DIFF
--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
@@ -82,7 +82,7 @@ internal constructor(
    * @return a Parameters resource that contains an evaluation result for each expression requested.
    */
   @WorkerThread
-  fun evaluateLibrary(libraryUrl: String, expressions: Set<String>): IBaseParameters {
+  fun evaluateLibrary(libraryUrl: String, expressions: Set<String>?): IBaseParameters {
     return evaluateLibrary(libraryUrl, null, null, expressions)
   }
 
@@ -101,7 +101,7 @@ internal constructor(
   fun evaluateLibrary(
     libraryUrl: String,
     patientId: String,
-    expressions: Set<String>,
+    expressions: Set<String>?,
   ): IBaseParameters {
     return evaluateLibrary(libraryUrl, patientId, null, expressions)
   }
@@ -143,7 +143,7 @@ internal constructor(
     libraryUrl: String,
     patientId: String?,
     parameters: Parameters?,
-    expressions: Set<String>,
+    expressions: Set<String>?,
   ): IBaseParameters {
     return libraryProcessor.evaluate(
       /* url = */ libraryUrl,

--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
@@ -78,8 +78,11 @@ internal constructor(
    * from a worker thread or it may throw [BlockingMainThreadException] exception.
    *
    * @param libraryUrl the url of the Library to evaluate
-   * @param expressions names of expressions in the Library to evaluate.
+   * @param expressions names of expressions in the Library to evaluate. If null the result contains
+   *   all evaluations or variables in library.
    * @return a Parameters resource that contains an evaluation result for each expression requested.
+   *   Or if expressions param is null then result contains all evaluations or variables in given
+   *   library.
    */
   @WorkerThread
   fun evaluateLibrary(libraryUrl: String, expressions: Set<String>?): IBaseParameters {
@@ -94,8 +97,11 @@ internal constructor(
    *
    * @param libraryUrl the url of the Library to evaluate
    * @param patientId the Id of the patient to be evaluated
-   * @param expressions names of expressions in the Library to evaluate.
-   * @return a Parameters resource that contains an evaluation result for each expression requested
+   * @param expressions names of expressions in the Library to evaluate. If null the result contains
+   *   all evaluations or variables in library.
+   * @return a Parameters resource that contains an evaluation result for each expression requested.
+   *   Or if expressions param is null then result contains all evaluations or variables in given
+   *   library.
    */
   @WorkerThread
   fun evaluateLibrary(
@@ -114,14 +120,17 @@ internal constructor(
    *
    * @param libraryUrl the url of the Library to evaluate
    * @param parameters list of parameters to be passed to the CQL library
-   * @param expressions names of expressions in the Library to evaluate.
-   * @return a Parameters resource that contains an evaluation result for each expression requested
+   * @param expressions names of expressions in the Library to evaluate. If null the result contains
+   *   all evaluations or variables in library.
+   * @return a Parameters resource that contains an evaluation result for each expression requested.
+   *   Or if expressions param is null then result contains all evaluations or variables in given
+   *   library.
    */
   @WorkerThread
   fun evaluateLibrary(
     libraryUrl: String,
     parameters: Parameters,
-    expressions: Set<String>,
+    expressions: Set<String>?,
   ): IBaseParameters {
     return evaluateLibrary(libraryUrl, null, parameters, expressions)
   }
@@ -135,8 +144,11 @@ internal constructor(
    * @param libraryUrl the url of the Library to evaluate
    * @param patientId the Id of the patient to be evaluated, if applicable
    * @param parameters list of parameters to be passed to the CQL library, if applicable
-   * @param expressions names of expressions in the Library to evaluate.
-   * @return a Parameters resource that contains an evaluation result for each expression requested
+   * @param expressions names of expressions in the Library to evaluate. If null the result contains
+   *   all evaluations or variables in library.
+   * @return a Parameters resource that contains an evaluation result for each expression requested.
+   *   Or if expressions param is null then result contains all evaluations or variables in given
+   *   library.
    */
   @WorkerThread
   fun evaluateLibrary(


### PR DESCRIPTION
Fixes #[issue number]

**Description**
The methods [fhirOperator.evaluateLibrary](https://github.com/google/android-fhir/blob/master/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt#L85) do not allow passing null in expression which results in forcing user to output specific variables only. The evaluator  in cql allows passing null and when its null whole library  processing result is output. We have cases when we want the whole evaluation accessible.

See details in org.opencds.cqf.cql.engine.execution.CqlEngine#evaluate

![Screenshot from 2024-01-12 18-38-55](https://github.com/google/android-fhir/assets/4829880/4f12c680-7e1f-4736-ae86-317c51027fbc)

![Screenshot from 2024-01-12 18-39-09](https://github.com/google/android-fhir/assets/4829880/f5c5f5d4-87f8-490c-9bf4-b864989b07f4)

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix)

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
