### PR TITLE
Added Support for optionExclusive Extension in Popup

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
@@ -40,6 +40,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.itemAnswerOptionImage
+import com.google.android.fhir.datacapture.extensions.optionExclusive
 import com.google.android.fhir.datacapture.views.factories.OptionSelectOption
 import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemDialogSelectViewModel
 import com.google.android.fhir.datacapture.views.factories.SelectedOptions
@@ -263,6 +264,8 @@ private class OptionSelectAdapter(val multiSelectEnabled: Boolean) :
    * if "Other" was just deselected, or adding them if "Other" was just selected).
    */
   private fun submitSelectedChange(position: Int, selected: Boolean) {
+    val selectedItem = currentList[position]
+
     val newList: List<OptionSelectRow> =
       currentList
         .mapIndexed { index, row ->
@@ -272,8 +275,16 @@ private class OptionSelectAdapter(val multiSelectEnabled: Boolean) :
           } else {
             // This is some other row
             if (multiSelectEnabled) {
-              // In multi-select mode, the other rows don't need to change
-              row
+                // In multi-select mode,
+              if (selected && ((selectedItem is OptionSelectRow.Option && selectedItem.option.item.optionExclusive)
+                        || (row is OptionSelectRow.Option && row.option.item.optionExclusive))) {
+                // if the selected answer option has optionExclusive extension, then deselect other answer options.
+                // or if the selected answer option does not have optionExclusive extension, then deselect optionExclusive answer option.
+                row.withSelectedState(selected = false) ?: row
+              } else {
+                // the other rows don't need to change
+                row
+              }
             } else {
               // In single-select mode, we need to disable all of the other rows
               row.withSelectedState(selected = false) ?: row


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2436

**Description**
Add optionExclusive extension support for `answerOption` in Popup for more than 10 items.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature)

**Screenshots (if applicable)**
![answer-option-exclusive-in-popup](https://github.com/google/android-fhir/assets/19770825/ba99acfa-f537-44d6-a719-36b664744e97)


**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
