### PR TITLE
Added Support for optionExclusive Extension in Popup

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,10 +109,12 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     val questionnaireViewItem =
       QuestionnaireViewItem(
         answerOptions(true, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5")
-          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-            value = Coding().apply { display = "Coding Exclusive" }
-            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-          }),
+          .addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value = Coding().apply { display = "Coding Exclusive" }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            },
+          ),
         responseOptions(),
         validationResult = NotValidated,
         answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
@@ -137,10 +139,12 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     val questionnaireViewItem =
       QuestionnaireViewItem(
         answerOptions(true, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5")
-          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-            value = Coding().apply { display = "Coding Exclusive" }
-            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-          }),
+          .addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value = Coding().apply { display = "Coding Exclusive" }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            },
+          ),
         responseOptions(),
         validationResult = NotValidated,
         answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
@@ -165,14 +169,18 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     val questionnaireViewItem =
       QuestionnaireViewItem(
         answerOptions(true, "Coding 1", "Coding 2", "Coding 3")
-          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-            value = Coding().apply { display = "Coding Exclusive 1" }
-            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-          })
-          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-            value = Coding().apply { display = "Coding Exclusive 2" }
-            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-          }),
+          .addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value = Coding().apply { display = "Coding Exclusive 1" }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            },
+          )
+          .addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value = Coding().apply { display = "Coding Exclusive 2" }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            },
+          ),
         responseOptions(),
         validationResult = NotValidated,
         answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
@@ -197,14 +205,18 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     val questionnaireViewItem =
       QuestionnaireViewItem(
         answerOptions(true, "Coding 1", "Coding 2", "Coding 3")
-          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-            value = Coding().apply { display = "Coding Exclusive 1" }
-            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-          })
-          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-            value = Coding().apply { display = "Coding Exclusive 2" }
-            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-          }),
+          .addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value = Coding().apply { display = "Coding Exclusive 1" }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            },
+          )
+          .addAnswerOption(
+            Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+              value = Coding().apply { display = "Coding Exclusive 2" }
+              extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+            },
+          ),
         responseOptions(),
         validationResult = NotValidated,
         answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
@@ -491,19 +503,22 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
   fun selectOther_selectExclusive_shouldHideAddAnotherAnswer() {
     val questionnaireItem =
       answerOptions(
-        true,
-        "Coding 1",
-        "Coding 2",
-        "Coding 3",
-        "Coding 4",
-        "Coding 5",
-        "Coding 6",
-        "Coding 7",
-        "Coding 8",
-      ).addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-        value = Coding().apply { display = "Coding Exclusive" }
-        extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-      })
+          true,
+          "Coding 1",
+          "Coding 2",
+          "Coding 3",
+          "Coding 4",
+          "Coding 5",
+          "Coding 6",
+          "Coding 7",
+          "Coding 8",
+        )
+        .addAnswerOption(
+          Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          },
+        )
 
     questionnaireItem.addExtension(openChoiceType)
     val questionnaireViewItem =
@@ -529,19 +544,22 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
   fun selectOther_clickAddAnotherAnswer_selectExclusive_shouldHideAddAnotherAnswerWithEditText() {
     val questionnaireItem =
       answerOptions(
-        true,
-        "Coding 1",
-        "Coding 2",
-        "Coding 3",
-        "Coding 4",
-        "Coding 5",
-        "Coding 6",
-        "Coding 7",
-        "Coding 8",
-      ).addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
-        value = Coding().apply { display = "Coding Exclusive" }
-        extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
-      })
+          true,
+          "Coding 1",
+          "Coding 2",
+          "Coding 3",
+          "Coding 4",
+          "Coding 5",
+          "Coding 6",
+          "Coding 7",
+          "Coding 8",
+        )
+        .addAnswerOption(
+          Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          },
+        )
 
     questionnaireItem.addExtension(openChoiceType)
     val questionnaireViewItem =

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
@@ -35,6 +35,7 @@ import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.DisplayItemControlType
 import com.google.android.fhir.datacapture.extensions.EXTENSION_ITEM_CONTROL_SYSTEM
 import com.google.android.fhir.datacapture.extensions.EXTENSION_ITEM_CONTROL_URL
+import com.google.android.fhir.datacapture.extensions.EXTENSION_OPTION_EXCLUSIVE_URL
 import com.google.android.fhir.datacapture.extensions.ItemControlTypes
 import com.google.android.fhir.datacapture.test.TestActivity
 import com.google.android.fhir.datacapture.test.utilities.assertQuestionnaireResponseAtIndex
@@ -52,6 +53,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.google.common.truth.StringSubject
 import com.google.common.truth.Truth.assertThat
 import org.hamcrest.Matchers.not
+import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Extension
@@ -93,6 +95,62 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
 
     endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
     clickOnTextInDialog("Coding 1")
+    clickOnText("Coding 3")
+    clickOnText("Coding 5")
+    clickOnText("Save")
+
+    assertDisplayedText().isEqualTo("Coding 1, Coding 3, Coding 5")
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding 1", "Coding 3", "Coding 5")
+  }
+
+  @Test
+  fun multipleChoice_selectMultiple_selectExclusive_clickSave_shouldSaveOnlyExclusiveOption() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        answerOptions(true, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5")
+          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          }),
+        responseOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
+      )
+
+    runOnUI { viewHolder.bind(questionnaireViewItem) }
+
+    endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
+    clickOnTextInDialog("Coding 1")
+    clickOnText("Coding 3")
+    clickOnText("Coding 5")
+    clickOnText("Coding Exclusive")
+    clickOnText("Save")
+
+    assertDisplayedText().isEqualTo("Coding Exclusive")
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding Exclusive")
+  }
+
+  @Test
+  fun multipleChoice_selectExclusive_selectMultiple_clickSave_shouldSaveWithoutExclusiveOption() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        answerOptions(true, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5")
+          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          }),
+        responseOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
+      )
+
+    runOnUI { viewHolder.bind(questionnaireViewItem) }
+
+    endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
+    clickOnTextInDialog("Coding Exclusive")
+    clickOnText("Coding 1")
     clickOnText("Coding 3")
     clickOnText("Coding 5")
     clickOnText("Save")

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
@@ -160,6 +160,70 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
   }
 
   @Test
+  fun multipleChoice_multipleOptionExclusive_selectMultiple_selectExclusive1_selectExclusive2_clickSave_shouldSaveOnlyLastSelectedExclusiveOption() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        answerOptions(true, "Coding 1", "Coding 2", "Coding 3")
+          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive 1" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          })
+          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive 2" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          }),
+        responseOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
+      )
+
+    runOnUI { viewHolder.bind(questionnaireViewItem) }
+
+    endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
+    clickOnTextInDialog("Coding 1")
+    clickOnText("Coding 3")
+    clickOnText("Coding Exclusive 1")
+    clickOnText("Coding Exclusive 2")
+    clickOnText("Save")
+
+    assertDisplayedText().isEqualTo("Coding Exclusive 2")
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding Exclusive 2")
+  }
+
+  @Test
+  fun multipleChoice_multipleOptionExclusive_selectExclusive1_selectExclusive2_selectMultiple_clickSave_shouldSaveWithoutAnyExclusiveOption() {
+    var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        answerOptions(true, "Coding 1", "Coding 2", "Coding 3")
+          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive 1" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          })
+          .addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+            value = Coding().apply { display = "Coding Exclusive 2" }
+            extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+          }),
+        responseOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, answers, _ -> answerHolder = answers },
+      )
+
+    runOnUI { viewHolder.bind(questionnaireViewItem) }
+
+    endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
+    clickOnTextInDialog("Coding Exclusive 1")
+    clickOnTextInDialog("Coding Exclusive 2")
+    clickOnText("Coding 1")
+    clickOnText("Coding 3")
+    clickOnText("Save")
+
+    assertDisplayedText().isEqualTo("Coding 1, Coding 3")
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding 1", "Coding 3")
+  }
+
+  @Test
   fun multipleChoice_SelectNothing_clickSave_shouldSaveNothing() {
     val questionnaireViewItem =
       QuestionnaireViewItem(
@@ -420,6 +484,85 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     onView(withId(R.id.add_another)).perform(click())
     onView(withId(R.id.add_another)).perform(delayMainThread())
     onView(withId(R.id.add_another)).check(matches(isDisplayed()))
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = 33)
+  fun selectOther_selectExclusive_shouldHideAddAnotherAnswer() {
+    val questionnaireItem =
+      answerOptions(
+        true,
+        "Coding 1",
+        "Coding 2",
+        "Coding 3",
+        "Coding 4",
+        "Coding 5",
+        "Coding 6",
+        "Coding 7",
+        "Coding 8",
+      ).addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+        value = Coding().apply { display = "Coding Exclusive" }
+        extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+      })
+
+    questionnaireItem.addExtension(openChoiceType)
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        questionnaireItem,
+        responseOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+
+    runOnUI { viewHolder.bind(questionnaireViewItem) }
+
+    endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
+    onView(withId(R.id.recycler_view))
+      .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(9))
+    clickOnTextInDialog("Other")
+    clickOnTextInDialog("Coding Exclusive")
+    onView(withId(R.id.add_another)).check(doesNotExist())
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = 33)
+  fun selectOther_clickAddAnotherAnswer_selectExclusive_shouldHideAddAnotherAnswerWithEditText() {
+    val questionnaireItem =
+      answerOptions(
+        true,
+        "Coding 1",
+        "Coding 2",
+        "Coding 3",
+        "Coding 4",
+        "Coding 5",
+        "Coding 6",
+        "Coding 7",
+        "Coding 8",
+      ).addAnswerOption(Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+        value = Coding().apply { display = "Coding Exclusive" }
+        extension = listOf(Extension(EXTENSION_OPTION_EXCLUSIVE_URL, BooleanType(true)))
+      })
+
+    questionnaireItem.addExtension(openChoiceType)
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        questionnaireItem,
+        responseOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+
+    runOnUI { viewHolder.bind(questionnaireViewItem) }
+
+    endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
+    onView(withId(R.id.recycler_view))
+      .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(9))
+    clickOnTextInDialog("Other")
+    onView(withId(R.id.add_another)).perform(delayMainThread())
+    onView(withId(R.id.add_another)).perform(click())
+    clickOnTextInDialog("Coding Exclusive")
+    onView(withId(R.id.add_another)).check(doesNotExist())
+    onView(withId(R.id.edit_text)).check(doesNotExist())
   }
 
   @Test

--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest.kt
@@ -108,7 +108,7 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
-        answerOptions(true, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5")
+        answerOptions(true, "Coding 1", "Coding 2", "Coding 3")
           .addAnswerOption(
             Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
               value = Coding().apply { display = "Coding Exclusive" }
@@ -125,7 +125,6 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     endIconClickInTextInputLayout(R.id.multi_select_summary_holder)
     clickOnTextInDialog("Coding 1")
     clickOnText("Coding 3")
-    clickOnText("Coding 5")
     clickOnText("Coding Exclusive")
     clickOnText("Save")
 
@@ -138,7 +137,7 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     var answerHolder: List<QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent>? = null
     val questionnaireViewItem =
       QuestionnaireViewItem(
-        answerOptions(true, "Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5")
+        answerOptions(true, "Coding 1", "Coding 2", "Coding 3")
           .addAnswerOption(
             Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
               value = Coding().apply { display = "Coding Exclusive" }
@@ -156,11 +155,10 @@ class QuestionnaireItemDialogMultiSelectViewHolderFactoryEspressoTest {
     clickOnTextInDialog("Coding Exclusive")
     clickOnText("Coding 1")
     clickOnText("Coding 3")
-    clickOnText("Coding 5")
     clickOnText("Save")
 
-    assertDisplayedText().isEqualTo("Coding 1, Coding 3, Coding 5")
-    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding 1", "Coding 3", "Coding 5")
+    assertDisplayedText().isEqualTo("Coding 1, Coding 3")
+    assertQuestionnaireResponseAtIndex(answerHolder!!, "Coding 1", "Coding 3")
   }
 
   @Test

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
@@ -40,6 +40,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.itemAnswerOptionImage
+import com.google.android.fhir.datacapture.extensions.optionExclusive
 import com.google.android.fhir.datacapture.views.factories.OptionSelectOption
 import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemDialogSelectViewModel
 import com.google.android.fhir.datacapture.views.factories.SelectedOptions
@@ -263,6 +264,8 @@ private class OptionSelectAdapter(val multiSelectEnabled: Boolean) :
    * if "Other" was just deselected, or adding them if "Other" was just selected).
    */
   private fun submitSelectedChange(position: Int, selected: Boolean) {
+    val selectedItem = currentList[position]
+
     val newList: List<OptionSelectRow> =
       currentList
         .mapIndexed { index, row ->
@@ -272,8 +275,16 @@ private class OptionSelectAdapter(val multiSelectEnabled: Boolean) :
           } else {
             // This is some other row
             if (multiSelectEnabled) {
-              // In multi-select mode, the other rows don't need to change
-              row
+              // In multi-select mode,
+              if (selected && ((selectedItem is OptionSelectRow.Option && selectedItem.option.item.optionExclusive)
+                  || (row is OptionSelectRow.Option && row.option.item.optionExclusive))) {
+                // if the selected answer option has optionExclusive extension, then deselect other answer options.
+                // or if the selected answer option does not have optionExclusive extension, then deselect optionExclusive answer option.
+                row.withSelectedState(selected = false) ?: row
+              } else {
+                // the other rows don't need to change
+                row
+              }
             } else {
               // In single-select mode, we need to disable all of the other rows
               row.withSelectedState(selected = false) ?: row

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/OptionSelectDialogFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Google LLC
+ * Copyright 2022-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -276,10 +276,16 @@ private class OptionSelectAdapter(val multiSelectEnabled: Boolean) :
             // This is some other row
             if (multiSelectEnabled) {
               // In multi-select mode,
-              if (selected && ((selectedItem is OptionSelectRow.Option && selectedItem.option.item.optionExclusive)
-                  || (row is OptionSelectRow.Option && row.option.item.optionExclusive))) {
-                // if the selected answer option has optionExclusive extension, then deselect other answer options.
-                // or if the selected answer option does not have optionExclusive extension, then deselect optionExclusive answer option.
+              if (
+                selected &&
+                  ((selectedItem is OptionSelectRow.Option &&
+                    selectedItem.option.item.optionExclusive) ||
+                    (row is OptionSelectRow.Option && row.option.item.optionExclusive))
+              ) {
+                // if the selected answer option has optionExclusive extension, then deselect other
+                // answer options.
+                // or if the selected answer option does not have optionExclusive extension, then
+                // deselect optionExclusive answer option.
                 row.withSelectedState(selected = false) ?: row
               } else {
                 // the other rows don't need to change


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2436

**Description**
Add `optionExclusive` extension support for `answerOption` in Popup for more than 10 items.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature)

**Screenshots (if applicable)**
![answer-option-exclusive-in-popup](https://github.com/google/android-fhir/assets/19770825/ba99acfa-f537-44d6-a719-36b664744e97)

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
