### PR TITLE
Hide the bottom navigation container if there are no visible buttons.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -22,7 +22,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.LinearLayout
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.res.use
@@ -182,8 +181,6 @@ class QuestionnaireFragment : Fragment() {
             paginationPreviousButton.visibility = View.GONE
             paginationNextButton.visibility = View.GONE
 
-            updateBottomNavigationContainerVisibility()
-
             // Hide progress indicator
             questionnaireProgressIndicator.visibility = View.GONE
           }
@@ -211,8 +208,6 @@ class QuestionnaireFragment : Fragment() {
               paginationPreviousButton.visibility = View.GONE
               paginationNextButton.visibility = View.GONE
             }
-
-            updateBottomNavigationContainerVisibility()
 
             // Set progress indicator
             questionnaireProgressIndicator.visibility = View.VISIBLE
@@ -253,7 +248,6 @@ class QuestionnaireFragment : Fragment() {
             cancelButton.visibility = View.GONE
             reviewModeButton.visibility = View.GONE
             reviewModeEditButton.visibility = View.GONE
-            requireView().findViewById<View>(R.id.bottom_nav_container).visibility = View.GONE
           }
         }
       }
@@ -295,28 +289,6 @@ class QuestionnaireFragment : Fragment() {
             "Unknown fragment result $result",
           )
       }
-    }
-  }
-
-  private fun updateBottomNavigationContainerVisibility() {
-    val bottomNavigationContainer =
-      requireView().findViewById<LinearLayout>(R.id.bottom_nav_container)
-    val submitButton = requireView().findViewById<Button>(R.id.submit_questionnaire)
-    val cancelButton = requireView().findViewById<Button>(R.id.cancel_questionnaire)
-    val reviewModeButton = requireView().findViewById<View>(R.id.review_mode_button)
-    val paginationPreviousButton = requireView().findViewById<View>(R.id.pagination_previous_button)
-    val paginationNextButton = requireView().findViewById<View>(R.id.pagination_next_button)
-
-    if (
-      submitButton.visibility == View.GONE &&
-        cancelButton.visibility == View.GONE &&
-        reviewModeButton.visibility == View.GONE &&
-        paginationPreviousButton.visibility == View.GONE &&
-        paginationNextButton.visibility == View.GONE
-    ) {
-      bottomNavigationContainer.visibility = View.GONE
-    } else {
-      bottomNavigationContainer.visibility = View.VISIBLE
     }
   }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.LinearLayout
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.res.use
@@ -178,6 +179,8 @@ class QuestionnaireFragment : Fragment() {
             paginationPreviousButton.visibility = View.GONE
             paginationNextButton.visibility = View.GONE
 
+            updateBottomNavigationContainerVisibility()
+
             // Hide progress indicator
             questionnaireProgressIndicator.visibility = View.GONE
           }
@@ -205,6 +208,8 @@ class QuestionnaireFragment : Fragment() {
               paginationPreviousButton.visibility = View.GONE
               paginationNextButton.visibility = View.GONE
             }
+
+            updateBottomNavigationContainerVisibility()
 
             // Set progress indicator
             questionnaireProgressIndicator.visibility = View.VISIBLE
@@ -245,6 +250,7 @@ class QuestionnaireFragment : Fragment() {
             cancelButton.visibility = View.GONE
             reviewModeButton.visibility = View.GONE
             reviewModeEditButton.visibility = View.GONE
+            requireView().findViewById<View>(R.id.bottom_nav_container).visibility = View.GONE
           }
         }
       }
@@ -286,6 +292,28 @@ class QuestionnaireFragment : Fragment() {
             "Unknown fragment result $result",
           )
       }
+    }
+  }
+
+  private fun updateBottomNavigationContainerVisibility() {
+    val bottomNavigationContainer =
+      requireView().findViewById<LinearLayout>(R.id.bottom_nav_container)
+    val submitButton = requireView().findViewById<Button>(R.id.submit_questionnaire)
+    val cancelButton = requireView().findViewById<Button>(R.id.cancel_questionnaire)
+    val reviewModeButton = requireView().findViewById<View>(R.id.review_mode_button)
+    val paginationPreviousButton = requireView().findViewById<View>(R.id.pagination_previous_button)
+    val paginationNextButton = requireView().findViewById<View>(R.id.pagination_next_button)
+
+    if (
+      submitButton.visibility == View.GONE &&
+        cancelButton.visibility == View.GONE &&
+        reviewModeButton.visibility == View.GONE &&
+        paginationPreviousButton.visibility == View.GONE &&
+        paginationNextButton.visibility == View.GONE
+    ) {
+      bottomNavigationContainer.visibility = View.GONE
+    } else {
+      bottomNavigationContainer.visibility = View.VISIBLE
     }
   }
 

--- a/datacapture/src/main/res/layout/questionnaire_fragment.xml
+++ b/datacapture/src/main/res/layout/questionnaire_fragment.xml
@@ -84,8 +84,6 @@
         <Button
             android:id="@+id/cancel_questionnaire"
             style="?attr/questionnaireCancelButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/cancel_questionnaire"
@@ -97,8 +95,6 @@
         <Button
             android:id="@+id/pagination_previous_button"
             style="?attr/questionnaireButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_pagination_previous"
@@ -110,8 +106,6 @@
         <Button
             android:id="@+id/pagination_next_button"
             style="?attr/questionnaireButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_pagination_next"
@@ -123,8 +117,6 @@
         <Button
             android:id="@+id/review_mode_button"
             style="?attr/questionnaireButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_review"

--- a/datacapture/src/main/res/layout/questionnaire_fragment.xml
+++ b/datacapture/src/main/res/layout/questionnaire_fragment.xml
@@ -72,13 +72,11 @@
         app:layout_constraintBottom_toTopOf="@id/bottom_nav_container"
     />
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/bottom_nav_container"
         style="?attr/questionnaireBottomNavContainerStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentBottom="true"
         android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
     >
@@ -86,49 +84,68 @@
         <Button
             android:id="@+id/cancel_questionnaire"
             style="?attr/questionnaireCancelButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/cancel_questionnaire"
-        />
-
-        <View
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
         />
 
         <Button
             android:id="@+id/pagination_previous_button"
             style="?attr/questionnaireButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_pagination_previous"
+            app:layout_constraintStart_toEndOf="@+id/cancel_questionnaire"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
         />
 
         <Button
             android:id="@+id/pagination_next_button"
             style="?attr/questionnaireButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_pagination_next"
+            app:layout_constraintStart_toEndOf="@+id/pagination_previous_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
         />
 
         <Button
             android:id="@+id/review_mode_button"
             style="?attr/questionnaireButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_review"
+            app:layout_constraintStart_toEndOf="@+id/pagination_next_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
         />
 
         <Button
             android:id="@+id/submit_questionnaire"
             style="?attr/questionnaireSubmitButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/submit_questionnaire"
+            app:layout_constraintStart_toEndOf="@+id/review_mode_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
         />
 
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/datacapture/src/main/res/layout/questionnaire_fragment.xml
+++ b/datacapture/src/main/res/layout/questionnaire_fragment.xml
@@ -102,7 +102,7 @@
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_pagination_previous"
-            app:layout_constraintStart_toEndOf="@+id/cancel_questionnaire"
+            app:layout_constraintEnd_toStartOf="@+id/pagination_next_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
         />
@@ -115,7 +115,7 @@
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_pagination_next"
-            app:layout_constraintStart_toEndOf="@+id/pagination_previous_button"
+            app:layout_constraintEnd_toStartOf="@+id/submit_questionnaire"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
         />
@@ -128,7 +128,7 @@
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/button_review"
-            app:layout_constraintStart_toEndOf="@+id/pagination_next_button"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
         />
@@ -141,7 +141,7 @@
             android:layout_marginHorizontal="@dimen/action_button_margin_horizontal"
             android:layout_marginVertical="@dimen/action_button_margin_vertical"
             android:text="@string/submit_questionnaire"
-            app:layout_constraintStart_toEndOf="@+id/review_mode_button"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
         />

--- a/datacapture/src/main/res/values/dimens.xml
+++ b/datacapture/src/main/res/values/dimens.xml
@@ -23,7 +23,7 @@
 
     <!--  Action button  -->
     <dimen name="action_button_margin_horizontal">16dp</dimen>
-    <dimen name="action_button_margin_vertical">8dp</dimen>
+    <dimen name="action_button_margin_vertical">16dp</dimen>
 
     <!--  Header  -->
     <dimen name="error_text_at_header_margin_top">4dp</dimen>

--- a/datacapture/src/main/res/values/styles.xml
+++ b/datacapture/src/main/res/values/styles.xml
@@ -227,12 +227,6 @@
 
     <style name="Questionnaire.BottomNavContainerStyle" parent="">
       <item name="android:background">?attr/colorSurface</item>
-      <item
-            name="android:paddingTop"
-        >@dimen/bottom_container_padding_vertical</item>
-      <item
-            name="android:paddingBottom"
-        >@dimen/bottom_container_padding_vertical</item>
     </style>
 
     <style


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2446 

**Description**
If there is no button visible in the bottom navigation container then it was overlapping review mode recyclerview, as result screen was appearing blank.
Now issue is fixed by hiding bottomNavigation container if there is no children.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix
**Screenshots (if applicable)**

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
