### PR TITLE
Generate API docs site during build

### DIFF
--- a/build-docs.bash
+++ b/build-docs.bash
@@ -17,8 +17,17 @@
 
 set -euox pipefail
 
+rm -rf site/
 mkdir -p site/
 
-# TODO Replace this with mkdocs generation
-# TODO Fix https://github.com/google/android-fhir/issues/2237 and generate API JavaDoc
-cp -R docs/* site/
+# TODO https://github.com/google/android-fhir/issues/2232 Add mkdocs generation
+
+./gradlew dokkaHtml
+mkdir -p site/api/
+mv docs/data-capture site/api/
+mv docs/engine site/api/
+mv docs/knowledge site/api/
+mv docs/workflow site/api/
+
+cp -R docs/index.html site/
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,10 +6,11 @@
 
 <h2>API Docs</h2>
 <ul>
-  <li><a href="engine/">engine</a></li>
-  <li><a href="data-capture/">data-capture</a></li>
-  <li><a href="workflow/">workflow</a></li>
-</ul>  
+  <li><a href="api/engine/">engine</a></li>
+  <li><a href="api/data-capture/">data-capture</a></li>
+  <li><a href="api/workflow/">workflow</a></li>
+  <li><a href="api/knowledge/">knowledge</a></li>
+</ul>
 
 </body>
 </html>


### PR DESCRIPTION
Part of #2232.

Enabled by #2463, this generates the Kotlin API docs on https://google.github.io/android-fhir/ during the CI build. (They were "static" before, and just deployed from what was in the `docs/` directory, with this, they are "built". This is the 1st step towards generating more documentation during the build in a future next step.)

Originally raised as #2483, but that PR for some strange reason didn't update even though I (force) pushed new commit.

@williamito or @santosh-pingle or @MJ1998 or @jingtang10  OK for you?

~Includes #2463, but just for testing; when this works, I'll merge that, and then rebase this to not include that anymore.~

~I'm marking this one as draft as I'm still testing this - please do not merge as long as it's in Draft.~