### PR TITLE
Date Picker Constraint Issue Fix.

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactoryEspressoTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.fhir.datacapture.views.factories
+
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.fhir.datacapture.R
+import com.google.android.fhir.datacapture.test.TestActivity
+import com.google.android.fhir.datacapture.test.utilities.clickIcon
+import com.google.android.fhir.datacapture.validation.MAX_VALUE_EXTENSION_URL
+import com.google.android.fhir.datacapture.validation.MIN_VALUE_EXTENSION_URL
+import com.google.android.fhir.datacapture.validation.NotValidated
+import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
+import org.hamcrest.CoreMatchers
+import org.hl7.fhir.r4.model.DateType
+import org.hl7.fhir.r4.model.Extension
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DatePickerViewHolderFactoryEspressoTest {
+  @Rule
+  @JvmField
+  var activityScenarioRule: ActivityScenarioRule<TestActivity> =
+    ActivityScenarioRule(TestActivity::class.java)
+
+  private lateinit var parent: FrameLayout
+  private lateinit var viewHolder: QuestionnaireItemViewHolder
+
+  @Before
+  fun setUp() {
+    activityScenarioRule.scenario.onActivity { activity -> parent = FrameLayout(activity) }
+    viewHolder = DatePickerViewHolderFactory.create(parent)
+    setTestLayout(viewHolder.itemView)
+  }
+
+  @Test
+  fun shouldSelectMinDateFromConstraint() {
+    val questionnaireItem = QuestionnaireItemComponent()
+    questionnaireItem.addExtension(
+      Extension().apply {
+        this.url = MIN_VALUE_EXTENSION_URL
+        setValue(DateType("2023-04-15"))
+      },
+    )
+    questionnaireItem.addExtension(
+      Extension().apply {
+        this.url = MAX_VALUE_EXTENSION_URL
+        setValue(DateType("2023-04-18"))
+      },
+    )
+    val questionnaireItemView =
+      QuestionnaireViewItem(
+        questionnaireItem,
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+    runOnUI { viewHolder.bind(questionnaireItemView) }
+    onView(withId(R.id.text_input_layout)).perform(clickIcon(true))
+    onView(CoreMatchers.allOf(withText("OK")))
+      .inRoot(isDialog())
+      .check(matches(isDisplayed()))
+      .perform(click())
+    onView(withText("04/15/2023")).check(matches(isDisplayed()))
+  }
+
+  /** Method to run code snippet on UI/main thread */
+  private fun runOnUI(action: () -> Unit) {
+    activityScenarioRule.scenario.onActivity { activity -> action() }
+  }
+
+  /** Method to set content view for test activity */
+  private fun setTestLayout(view: View) {
+    activityScenarioRule.scenario.onActivity { activity -> activity.setContentView(view) }
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+  }
+}


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2508

**Description**
The MaterialDatePicker Builder has been modified such that if the questionnaire item has the minimum date extension added then the MaterialDatePicker.setSelection() will have that minimum date from extension else it will get the local date. This way it will select the first valid date based on the constraints added for date.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug Fix

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
