### PR TITLE
Configurable drop down answer option.

### DIFF
--- a/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/DropDownViewHolderFactoryEspressoTest.kt
+++ b/datacapture/src/androidTest/java/com/google/android/fhir/datacapture/test/views/DropDownViewHolderFactoryEspressoTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -347,6 +347,33 @@ class DropDownViewHolderFactoryEspressoTest {
       .isEqualTo("Reference")
     assertThat((answerHolder!!.single().value as Reference).display).isEqualTo("Reference")
     assertThat((answerHolder!!.single().value as Reference).id).isEqualTo("ref_2")
+  }
+
+  @Test
+  fun shouldSetDefaultValueFromInitialProperty() {
+    val questionnaireViewItem =
+      QuestionnaireViewItem(
+        answerOptions("Coding 1", "Coding 2", "Coding 3", "Coding 4", "Coding 5"),
+        responseOptions(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      )
+    questionnaireViewItem.questionnaireItem.addInitial(
+      Questionnaire.QuestionnaireItemInitialComponent().apply {
+        this.value = StringType("Select Answer")
+      },
+    )
+    runOnUI {
+      viewHolder.bind(questionnaireViewItem)
+      viewHolder.itemView.findViewById<AutoCompleteTextView>(R.id.auto_complete).showDropDown()
+    }
+    onView(withId(R.id.auto_complete)).perform(delayMainThread())
+    onView(withText("Select Answer"))
+      .inRoot(isPlatformPopup())
+      .check(matches(isDisplayed()))
+      .perform(click())
+    assertThat(viewHolder.itemView.findViewById<TextView>(R.id.auto_complete).text.toString())
+      .isEqualTo("Select Answer")
   }
 
   /** Method to run code snippet on UI/main thread */

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DropDownViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DropDownViewHolderFactory.kt
@@ -67,6 +67,12 @@ internal object DropDownViewHolderFactory :
           hint = questionnaireViewItem.enabledDisplayItems.localizedFlyoverSpanned
           helperText = getRequiredOrOptionalText(questionnaireViewItem, context)
         }
+        val initialAnswerString =
+          if (questionnaireViewItem.questionnaireItem.hasInitial()) {
+            questionnaireViewItem.questionnaireItem.initial.first().valueStringType.valueAsString
+          } else {
+            context.getString(R.string.hyphen)
+          }
         val answerOptionList =
           this.questionnaireViewItem.enabledAnswerOptions
             .map {
@@ -80,8 +86,8 @@ internal object DropDownViewHolderFactory :
         answerOptionList.add(
           0,
           DropDownAnswerOption(
-            context.getString(R.string.hyphen),
-            context.getString(R.string.hyphen),
+            initialAnswerString,
+            initialAnswerString,
             null,
           ),
         )


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2505

**Description**
In the DropDownViewHolderFactory the hyphen("-") is being set as the default answer option to the drop down. Instead of setting it a fixed answer I have made it configurable. To change the default answer option the questionnaire item representing the drop down item will have the initial property which will have a valueString. The default answer option will be filled with the initial property value if available else it will be filled hyphen("-"). 
This approach ensures that the configuration will be done via questionnaire itself and the code need be changed everytime to change a default answer option.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug Fix.

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
