### PR TITLE
Disable top-level navigation tabs on new website

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -23,11 +23,8 @@ theme:
       - navigation.footer
       - navigation.instant
       - navigation.tracking
-      - navigation.expand
       - navigation.path
       - navigation.top
-      - navigation.sections
-      - navigation.tabs
       - search.suggest
       - search.share
 


### PR DESCRIPTION
A simple 'full' menu on the left seems much clearer, actually.

This just changes the "look and feel" (content remains the same).

It also removes one entry which was a duplicate.

Follow-up to #2513 for #2232.

@MJ1998 LGTY?