### PR TITLE
Autoassign android-fhir-reviewers@ instead of all of android-fhir@ as reviewers of PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Owners of the repository
-* @google/android-fhir @santosh-pingle
+* @google/android-fhir-reviewers @santosh-pingle


### PR DESCRIPTION
Fixes #2320