### PR TITLE
Update CODEOWNERS to assign listed individuals instead of group as reviewers of PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,14 @@
-# Owners of the repository
-* @google/android-fhir @santosh-pingle
+# This file lists people who get automatically added as Reviewers for Pull Requests.
+#
+# Note that we intentionally do NOT just include all committers here by using @google/android-fhir,
+# nor were we able to get it working using a group such as @google/android-fhir-reviewers;
+# details about why are described on https://github.com/google/android-fhir/issues/2320
+# and https://github.com/google/android-fhir/pull/2536.
+#
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These people for *ALL* Pull Requests:
+* @aditya-07 @jingtang10 @MJ1998 @santosh-pingle 
+
+# These for anything documentation related:
+docs/* @vorburger


### PR DESCRIPTION
This initial list matches https://github.com/orgs/google/teams/android-fhir-reviewers.

We were not able to get @google/android-fhir-reviewers working; see https://github.com/google/android-fhir/pull/2536 for background, this PR is an alternative to that one.

See https://github.com/google/android-fhir/issues/2320 for overall motivation.

Fixes #2320.