### PR TITLE
Pack repeated groups even if there is only one group in the response

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -154,7 +154,9 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         // Retain the hierarchy and order of items within the questionnaire as specified in the
         // standard. See https://www.hl7.org/fhir/questionnaireresponse.html#notes.
         questionnaire.item.forEach {
-          questionnaireResponse.addItem(it.createQuestionnaireResponseItem())
+          if (it.type != Questionnaire.QuestionnaireItemType.GROUP || !it.repeats) {
+            questionnaireResponse.addItem(it.createQuestionnaireResponseItem())
+          }
         }
       }
     }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -158,7 +158,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         }
       }
     }
-    questionnaireResponse.packRepeatedGroups()
+    questionnaireResponse.packRepeatedGroups(questionnaire)
   }
 
   /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -848,7 +848,7 @@ internal inline fun <T> List<Questionnaire.QuestionnaireItemComponent>.zipByLink
  * QuestionnaireResponseItemComponent with same linkId. So these items are grouped with linkId and
  * associated with its questionnaire item linkId.
  */
-internal inline fun <T> List<Questionnaire.QuestionnaireItemComponent>.zipByLinkIdGroup(
+internal inline fun <T> List<Questionnaire.QuestionnaireItemComponent>.groupByAndZipByLinkId(
   questionnaireResponseItemList: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
   transform:
     (

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -848,21 +848,25 @@ internal inline fun <T> List<Questionnaire.QuestionnaireItemComponent>.zipByLink
  * QuestionnaireResponseItemComponent with same linkId. So these items are grouped with linkId and
  * associated with its questionnaire item linkId.
  */
-internal inline fun <T> List<Questionnaire.QuestionnaireItemComponent>.groupByAndZipByLinkId(
+internal inline fun <T> groupByAndZipByLinkId(
+  questionnaireItemList: List<Questionnaire.QuestionnaireItemComponent>,
   questionnaireResponseItemList: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
   transform:
     (
-      Questionnaire.QuestionnaireItemComponent,
+      List<Questionnaire.QuestionnaireItemComponent>,
       List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
     ) -> T,
 ): List<T> {
+  val linkIdToQuestionnaireItemListMap = questionnaireItemList.groupBy { it.linkId }
   val linkIdToQuestionnaireResponseItemListMap = questionnaireResponseItemList.groupBy { it.linkId }
-  return map { questionnaireItem ->
-    transform(
-      questionnaireItem,
-      linkIdToQuestionnaireResponseItemListMap[questionnaireItem.linkId] ?: emptyList(),
-    )
-  }
+  return (linkIdToQuestionnaireItemListMap.keys + linkIdToQuestionnaireResponseItemListMap.keys)
+    .distinct()
+    .map { linkId ->
+      transform(
+        linkIdToQuestionnaireItemListMap[linkId] ?: emptyList(),
+        linkIdToQuestionnaireResponseItemListMap[linkId] ?: emptyList(),
+      )
+    }
 }
 
 /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -860,7 +860,6 @@ internal inline fun <T> groupByAndZipByLinkId(
   val linkIdToQuestionnaireItemListMap = questionnaireItemList.groupBy { it.linkId }
   val linkIdToQuestionnaireResponseItemListMap = questionnaireResponseItemList.groupBy { it.linkId }
   return (linkIdToQuestionnaireItemListMap.keys + linkIdToQuestionnaireResponseItemListMap.keys)
-    .distinct()
     .map { linkId ->
       transform(
         linkIdToQuestionnaireItemListMap[linkId] ?: emptyList(),

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -840,6 +840,32 @@ internal inline fun <T> List<Questionnaire.QuestionnaireItemComponent>.zipByLink
 }
 
 /**
+ * Returns a list of values built from the elements of `this` and the
+ * `questionnaireResponseItemList` with the same linkId using the provided `transform` function
+ * applied to each pair of questionnaire item and questionnaire response item.
+ *
+ * In case of repeated group item, `questionnaireResponseItemList` will contain
+ * QuestionnaireResponseItemComponent with same linkId. So these items are grouped with linkId and
+ * associated with its questionnaire item linkId.
+ */
+internal inline fun <T> List<Questionnaire.QuestionnaireItemComponent>.zipByLinkIdGroup(
+  questionnaireResponseItemList: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
+  transform:
+    (
+      Questionnaire.QuestionnaireItemComponent,
+      List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
+    ) -> T,
+): List<T> {
+  val linkIdToQuestionnaireResponseItemListMap = questionnaireResponseItemList.groupBy { it.linkId }
+  return map { questionnaireItem ->
+    transform(
+      questionnaireItem,
+      linkIdToQuestionnaireResponseItemListMap[questionnaireItem.linkId] ?: emptyList(),
+    )
+  }
+}
+
+/**
  * Whether the corresponding [QuestionnaireResponse.QuestionnaireResponseItemComponent] should have
  * [QuestionnaireResponse.QuestionnaireResponseItemComponent]s nested under
  * [QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent]s.

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -49,13 +49,14 @@ private fun List<QuestionnaireResponse.QuestionnaireResponseItemComponent>.packR
     questionnaireResponseItems,
     ->
     questionnaireResponseItems.forEach { it ->
-      if (
-        questionnaireItem.type == Questionnaire.QuestionnaireItemType.GROUP &&
-          questionnaireItem.repeats
-      ) {
-        it.answer.forEach { it.item = it.item.packRepeatedGroups(questionnaireItem.item) }
+      if (questionnaireItem.type == Questionnaire.QuestionnaireItemType.GROUP) {
+        if (questionnaireItem.repeats) {
+          it.answer.forEach { it.item = it.item.packRepeatedGroups(questionnaireItem.item) }
+        } else {
+          it.item = it.item.packRepeatedGroups(questionnaireItem.item)
+        }
       } else {
-        it.item = it.item.packRepeatedGroups(questionnaireItem.item)
+        it.answer.forEach { it.item = it.item.packRepeatedGroups(questionnaireItem.item) }
       }
     }
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -30,12 +30,22 @@ val QuestionnaireResponse.allItems: List<QuestionnaireResponse.QuestionnaireResp
  * correctly. This is because they are flattened out and nested directly under the parent in the
  * FHIR data format.
  *
- * More details: https://build.fhir.org/questionnaireresponse.html#link.
+ * More details on the structure of questionnaire responses:
+ * https://build.fhir.org/questionnaireresponse.html#link.
+ *
+ * Specifically, this function will go through the items in the questionnaire response, and if
+ * multiple questionnaire response items exist for the same repeated group (identified by the link
+ * id), they will be converted into answers under the same questionnaire response item so that there
+ * is a 1:1 relationship from questionnaire item for the repeated group to questionnaire response
+ * item for the same repeated group.
  *
  * This function should be called before the questionnaire view model accepts an
  * application-provided questionnaire response.
  *
  * See also [unpackRepeatedGroups].
+ *
+ * @throws IllegalArgumentException if more than one sibling questionnaire items (nested under the
+ *   questionnaire root or the same parent item) share the same id
  */
 internal fun QuestionnaireResponse.packRepeatedGroups(questionnaire: Questionnaire) {
   item = item.packRepeatedGroups(questionnaire.item)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -42,13 +42,21 @@ internal fun QuestionnaireResponse.packRepeatedGroups(questionnaire: Questionnai
 }
 
 private fun List<QuestionnaireResponse.QuestionnaireResponseItemComponent>.packRepeatedGroups(
-  questionnaireitems: List<Questionnaire.QuestionnaireItemComponent>,
+  questionnaireItems: List<Questionnaire.QuestionnaireItemComponent>,
 ): List<QuestionnaireResponse.QuestionnaireResponseItemComponent> {
-  return questionnaireitems.zipByLinkIdGroup(this) { questionnaireItem, questionnaireResponseItems,
+  return questionnaireItems.groupByAndZipByLinkId(this) {
+    questionnaireItem,
+    questionnaireResponseItems,
     ->
     questionnaireResponseItems.forEach { it ->
-      it.item = it.item.packRepeatedGroups(questionnaireItem.item)
-      it.answer.forEach { it.item = it.item.packRepeatedGroups(questionnaireItem.item) }
+      if (
+        questionnaireItem.type == Questionnaire.QuestionnaireItemType.GROUP &&
+          questionnaireItem.repeats
+      ) {
+        it.answer.forEach { it.item = it.item.packRepeatedGroups(questionnaireItem.item) }
+      } else {
+        it.item = it.item.packRepeatedGroups(questionnaireItem.item)
+      }
     }
 
     if (

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -56,7 +56,7 @@ private fun List<QuestionnaireResponse.QuestionnaireResponseItemComponent>.packR
         questionnaireItem.repeats
     ) {
       QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-        this.linkId = linkId
+        this.linkId = questionnaireItem.linkId
         answer =
           questionnaireResponseItems.map {
             QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
@@ -233,7 +233,7 @@ object QuestionnaireResponseValidator {
     }
     checkQuestionnaireResponseItems(
       questionnaire.item,
-      questionnaireResponse.copy().apply { packRepeatedGroups() }.item,
+      questionnaireResponse.copy().apply { packRepeatedGroups(questionnaire) }.item,
     )
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -3705,88 +3705,85 @@ class QuestionnaireViewModelTest {
           "item": [
             {
               "linkId": "12.0",
-              "answer": [
+              "item": [
                 {
+                  "linkId": "12.6",
                   "item": [
                     {
-                      "linkId": "12.6",
+                      "linkId": "12.6.1",
+                      "answer": [
+                        {
+                          "valueCoding": {
+                            "code": "live-birth",
+                            "display": "Live Birth"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "12.6.3",
                       "item": [
                         {
-                          "linkId": "12.6.1",
+                          "linkId": "12.6.3.1",
                           "answer": [
                             {
                               "valueCoding": {
-                                "code": "live-birth",
-                                "display": "Live Birth"
+                                "code": "male",
+                                "display": "Male"
                               }
-                            }
-                          ]
-                        },
-                        {
-                          "linkId": "12.6.3",
-                          "item": [
-                            {
-                              "linkId": "12.6.3.1",
-                              "answer": [
-                                {
-                                  "valueCoding": {
-                                    "code": "male",
-                                    "display": "Male"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "linkId": "12.6.4",
-                          "item": [
-                            {
-                              "linkId": "12.6.4.1"
                             }
                           ]
                         }
                       ]
-                    }
-                  ]
-                },
-                {
-                  "item": [
+                    },
                     {
-                      "linkId": "12.6",
+                      "linkId": "12.6.4",
                       "item": [
                         {
-                          "linkId": "12.6.1",
+                          "linkId": "12.6.4.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {            
+              "linkId": "12.0",
+              "item": [
+                {
+                  "linkId": "12.6",
+                  "item": [
+                    {
+                      "linkId": "12.6.1",
+                      "answer": [
+                        {
+                          "valueCoding": {
+                            "code": "still-birth",
+                            "display": "Stillbirth"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "12.6.3",
+                      "item": [
+                        {
+                          "linkId": "12.6.3.1"
+                        }
+                      ]
+                    },
+                    {
+                      "linkId": "12.6.4",
+                      "item": [
+                        {
+                          "linkId": "12.6.4.1",
                           "answer": [
                             {
                               "valueCoding": {
-                                "code": "still-birth",
-                                "display": "Stillbirth"
+                                "code": "FSB",
+                                "display": "FSB"
                               }
-                            }
-                          ]
-                        },
-                        {
-                          "linkId": "12.6.3",
-                          "item": [
-                            {
-                              "linkId": "12.6.3.1"
-                            }
-                          ]
-                        },
-                        {
-                          "linkId": "12.6.4",
-                          "item": [
-                            {
-                              "linkId": "12.6.4.1",
-                              "answer": [
-                                {
-                                  "valueCoding": {
-                                    "code": "FSB",
-                                    "display": "FSB"
-                                  }
-                                }
-                              ]
                             }
                           ]
                         }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
@@ -94,9 +94,16 @@ class MoreQuestionnaireResponsesTest {
         )
       }
 
+    val questionnaireResponse =
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponseItemComponent().apply { linkId = "repeated-group" },
+        )
+      }
+
     assertResourceEquals(
+      questionnaireResponse,
       QuestionnaireResponse().apply { packRepeatedGroups(questionnaire) },
-      QuestionnaireResponse(),
     )
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Google LLC
+ * Copyright 2022-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,87 @@ class MoreQuestionnaireResponsesTest {
   }
 
   @Test
-  fun `should pack repeated groups`() {
+  fun `should pack repeated groups with single set of answers`() {
+    val questionnaire =
+      Questionnaire().apply {
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "repeated-group"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            repeats = true
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-question"
+                type = Questionnaire.QuestionnaireItemType.BOOLEAN
+              },
+            )
+          },
+        )
+      }
+
+    val questionnaireResponse =
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponseItemComponent().apply {
+            linkId = "repeated-group"
+            addItem(
+              QuestionnaireResponseItemComponent().apply {
+                linkId = "nested-question"
+                addAnswer(
+                  QuestionnaireResponseItemAnswerComponent().apply { value = BooleanType(true) },
+                )
+              },
+            )
+          },
+        )
+      }
+
+    val packedQuestionnaireResponse =
+      QuestionnaireResponse().apply {
+        addItem(
+          QuestionnaireResponseItemComponent().apply {
+            linkId = "repeated-group"
+            addAnswer(
+              QuestionnaireResponseItemAnswerComponent().apply {
+                addItem(
+                  QuestionnaireResponseItemComponent().apply {
+                    linkId = "nested-question"
+                    addAnswer(
+                      QuestionnaireResponseItemAnswerComponent().apply {
+                        value = BooleanType(true)
+                      },
+                    )
+                  },
+                )
+              },
+            )
+          },
+        )
+      }
+
+    questionnaireResponse.packRepeatedGroups(questionnaire)
+    assertResourceEquals(questionnaireResponse, packedQuestionnaireResponse)
+  }
+
+  @Test
+  fun `should pack repeated groups with multiple sets of answers`() {
+    val questionnaire =
+      Questionnaire().apply {
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "repeated-group"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            repeats = true
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-question"
+                type = Questionnaire.QuestionnaireItemType.BOOLEAN
+              },
+            )
+          },
+        )
+      }
+
     val questionnaireResponse =
       QuestionnaireResponse().apply {
         addItem(
@@ -143,12 +223,40 @@ class MoreQuestionnaireResponsesTest {
         )
       }
 
-    questionnaireResponse.packRepeatedGroups()
+    questionnaireResponse.packRepeatedGroups(questionnaire)
     assertResourceEquals(questionnaireResponse, packedQuestionnaireResponse)
   }
 
   @Test
-  fun `should not modify other items while packing repeated groups`() {
+  fun `should not modify non-repeated groups while packing repeated groups`() {
+    val questionnaire =
+      Questionnaire().apply {
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "non-repeated-group-1"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-question-1"
+                type = Questionnaire.QuestionnaireItemType.BOOLEAN
+              },
+            )
+          },
+        )
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "non-repeated-group-2"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-question-2"
+                type = Questionnaire.QuestionnaireItemType.BOOLEAN
+              },
+            )
+          },
+        )
+      }
+
     val questionnaireResponse =
       QuestionnaireResponse().apply {
         addItem(
@@ -209,7 +317,7 @@ class MoreQuestionnaireResponsesTest {
         )
       }
 
-    questionnaireResponse.packRepeatedGroups()
+    questionnaireResponse.packRepeatedGroups(questionnaire)
     assertResourceEquals(questionnaireResponse, packedQuestionnaireResponse)
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponsesTest.kt
@@ -75,6 +75,32 @@ class MoreQuestionnaireResponsesTest {
   }
 
   @Test
+  fun `should pack repeated groups with no answers`() {
+    val questionnaire =
+      Questionnaire().apply {
+        id = "a-questionnaire"
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "repeated-group"
+            type = Questionnaire.QuestionnaireItemType.GROUP
+            repeats = true
+            addItem(
+              QuestionnaireItemComponent().apply {
+                linkId = "nested-item"
+                type = Questionnaire.QuestionnaireItemType.BOOLEAN
+              },
+            )
+          },
+        )
+      }
+
+    assertResourceEquals(
+      QuestionnaireResponse().apply { packRepeatedGroups(questionnaire) },
+      QuestionnaireResponse(),
+    )
+  }
+
+  @Test
   fun `should pack repeated groups with single set of answers`() {
     val questionnaire =
       Questionnaire().apply {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
The current logic to pack repeated groups does not actually look at the questionnaire item at all. It simply packs multiple groups of the same id and assume they are from the same repeated group. This is fine unless if there is only one repeated group answer, the logic won't be able to distinguish this from non-repeated group.

The fix adds the questionnaire item to the logic so it packs if and only if it's a repeated group.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
