### PR TITLE
Handle empty repeated group header.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -154,11 +154,9 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
           }
         // Retain the hierarchy and order of items within the questionnaire as specified in the
         // standard. See https://www.hl7.org/fhir/questionnaireresponse.html#notes.
-        questionnaire.item.forEach {
-          if (it.type != Questionnaire.QuestionnaireItemType.GROUP || !it.repeats) {
-            questionnaireResponse.addItem(it.createQuestionnaireResponseItem())
-          }
-        }
+        questionnaire.item
+          .filterNot { it.isRepeatedGroup }
+          .forEach { questionnaireResponse.addItem(it.createQuestionnaireResponseItem()) }
       }
     }
     questionnaireResponse.packRepeatedGroups(questionnaire)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -915,7 +915,9 @@ fun Questionnaire.QuestionnaireItemComponent.createQuestionnaireResponseItem():
         !repeats
     ) {
       this@createQuestionnaireResponseItem.item.forEach {
-        this.addItem(it.createQuestionnaireResponseItem())
+        if (!it.isRepeatedGroup) {
+          this.addItem(it.createQuestionnaireResponseItem())
+        }
       }
     }
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -87,13 +87,11 @@ private fun List<QuestionnaireResponse.QuestionnaireResponseItemComponent>.packR
           QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
             this.linkId = questionnaireItem.linkId
             answer =
-              questionnaireResponseItems
-                .map {
-                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                    item = it.item
-                  }
+              questionnaireResponseItems.map {
+                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                  item = it.item
                 }
-                .filter { it.item.isNotEmpty() }
+              }
           },
         )
       } else {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -87,11 +87,13 @@ private fun List<QuestionnaireResponse.QuestionnaireResponseItemComponent>.packR
           QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
             this.linkId = questionnaireItem.linkId
             answer =
-              questionnaireResponseItems.map {
-                QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                  item = it.item
+              questionnaireResponseItems
+                .map {
+                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                    item = it.item
+                  }
                 }
-              }
+                .filter { it.item.isNotEmpty() }
           },
         )
       } else {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #726 

**Description**
In paginated layout, empty repeated group header was shown.

issue : 
It was creating empty answer component for repeated group item while packing repeated group header.
fix : 
1. do not create empty response item component for repeated group header. 
2. do not filter empty answer component for repeated group  



**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
