### PR TITLE
Only copy nested items to childless answers

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.fhir.datacapture
 
+import android.annotation.SuppressLint
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -328,7 +329,7 @@ internal object DiffCallbacks {
               QUESTIONS.areContentsTheSame(oldItem, newItem)
           }
           is QuestionnaireAdapterItem.RepeatedGroupHeader -> {
-            newItem is QuestionnaireAdapterItem.RepeatedGroupHeader &&
+            if (newItem is QuestionnaireAdapterItem.RepeatedGroupHeader) {
               // The `onDeleteClicked` function is a function closure generated in the questionnaire
               // viewmodel with a reference to the parent questionnaire view item. When it is
               // invoked, it deletes the current repeated group instance from the parent
@@ -344,7 +345,12 @@ internal object DiffCallbacks {
               // version includes a different `onDeleteClicked` function referencing a parent item
               // with a different list of children. As a result clicking the delete function might
               // result in deleting from an old list.
-              (oldItem.onDeleteClicked == newItem.onDeleteClicked)
+              @SuppressLint("DiffUtilEquals")
+              val onDeleteClickedCallbacksEqual = oldItem.onDeleteClicked == newItem.onDeleteClicked
+              onDeleteClickedCallbacksEqual
+            } else {
+              false
+            }
           }
           is QuestionnaireAdapterItem.Navigation -> {
             newItem is QuestionnaireAdapterItem.Navigation &&

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
@@ -329,7 +329,22 @@ internal object DiffCallbacks {
           }
           is QuestionnaireAdapterItem.RepeatedGroupHeader -> {
             newItem is QuestionnaireAdapterItem.RepeatedGroupHeader &&
-              oldItem.responses == newItem.responses
+              // The `onDeleteClicked` function is a function closure generated in the questionnaire
+              // viewmodel with a reference to the parent questionnaire view item. When it is
+              // invoked, it deletes the current repeated group instance from the parent
+              // questionnaire view item by removing it from the list of children in the parent
+              // questionnaire view.
+              // In other words, although the `onDeleteClicked` function is not a data field, it is
+              // a function closure with references to data structures. Because
+              // `RepeatedGroupHeader` does not include any other data fields besides the index, it
+              // is particularly important to distinguish between different `RepeatedGroupHeader`s
+              // by the `onDeleteClicked` function.
+              // If this check is not here, an old RepeatedGroupHeader might be mistakenly
+              // considered up-to-date and retained in the recycler view even though a newer
+              // version includes a different `onDeleteClicked` function referencing a parent item
+              // with a different list of children. As a result clicking the delete function might
+              // result in deleting from an old list.
+              (oldItem.onDeleteClicked == newItem.onDeleteClicked)
           }
           is QuestionnaireAdapterItem.Navigation -> {
             newItem is QuestionnaireAdapterItem.Navigation &&

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -28,8 +28,8 @@ import ca.uhn.fhir.parser.IParser
 import com.google.android.fhir.datacapture.enablement.EnablementEvaluator
 import com.google.android.fhir.datacapture.expressions.EnabledAnswerOptionsEvaluator
 import com.google.android.fhir.datacapture.extensions.EntryMode
-import com.google.android.fhir.datacapture.extensions.addNestedItemsToAnswer
 import com.google.android.fhir.datacapture.extensions.allItems
+import com.google.android.fhir.datacapture.extensions.copyNestedItemsToChildlessAnswers
 import com.google.android.fhir.datacapture.extensions.cqfExpression
 import com.google.android.fhir.datacapture.extensions.createQuestionnaireResponseItem
 import com.google.android.fhir.datacapture.extensions.entryMode
@@ -361,7 +361,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
         }
       }
       if (questionnaireItem.shouldHaveNestedItemsUnderAnswers) {
-        questionnaireResponseItem.addNestedItemsToAnswer(questionnaireItem)
+        questionnaireResponseItem.copyNestedItemsToChildlessAnswers(questionnaireItem)
 
         // If nested items are added to the answer, the enablement evaluator needs to be
         // reinitialized in order for it to rebuild the pre-order map and parent map of

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponseItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponseItemComponents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,14 +38,24 @@ private fun QuestionnaireResponse.QuestionnaireResponseItemComponent.appendDesce
 }
 
 /**
- * Add nested items under the provided `questionnaireItem` to each answer in the questionnaire
- * response item. The hierarchy and order of nested items will be retained as specified in the
- * standard.
+ * Copies nested items under `questionnaireItem` to each answer without children. The hierarchy and
+ * order of nested items will be retained as specified in the standard.
+ *
+ * Existing answers with nested items will not be modified because the nested items may contain
+ * answers already.
+ *
+ * This should be used when
+ * - a new answer is added to a question with nested questions, or
+ * - a new answer is added to a repeated group (in which case this indicates a new instance of the
+ *   repeated group will be added to the final questionnaire response).
  *
  * See https://www.hl7.org/fhir/questionnaireresponse.html#notes for more details.
  */
-fun QuestionnaireResponse.QuestionnaireResponseItemComponent.addNestedItemsToAnswer(
+internal fun QuestionnaireResponse.QuestionnaireResponseItemComponent
+  .copyNestedItemsToChildlessAnswers(
   questionnaireItem: Questionnaire.QuestionnaireItemComponent,
 ) {
-  answer.forEach { it.item = questionnaireItem.getNestedQuestionnaireResponseItems() }
+  answer
+    .filter { it.item.isEmpty() }
+    .forEach { it.item = questionnaireItem.createNestedQuestionnaireResponseItems() }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/GroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/GroupViewHolderFactory.kt
@@ -22,7 +22,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.extensions.createNestedQuestionnaireResponseItems
 import com.google.android.fhir.datacapture.extensions.tryUnwrapContext
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.NotValidated
@@ -62,12 +61,8 @@ internal object GroupViewHolderFactory :
         addItemButton.setOnClickListener {
           context.lifecycleScope.launch {
             questionnaireViewItem.addAnswer(
-              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
-                // TODO(jingtang10): This can be removed since we already do this in the
-                // answerChangedCallback in the QuestionnaireViewModel.
-                item =
-                  questionnaireViewItem.questionnaireItem.createNestedQuestionnaireResponseItems()
-              },
+              // Nested items will be added in answerChangedCallback in the QuestionnaireViewModel
+              QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent(),
             )
           }
         }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/GroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/GroupViewHolderFactory.kt
@@ -22,7 +22,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.google.android.fhir.datacapture.R
-import com.google.android.fhir.datacapture.extensions.getNestedQuestionnaireResponseItems
+import com.google.android.fhir.datacapture.extensions.createNestedQuestionnaireResponseItems
 import com.google.android.fhir.datacapture.extensions.tryUnwrapContext
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.NotValidated
@@ -65,7 +65,8 @@ internal object GroupViewHolderFactory :
               QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                 // TODO(jingtang10): This can be removed since we already do this in the
                 // answerChangedCallback in the QuestionnaireViewModel.
-                item = questionnaireViewItem.questionnaireItem.getNestedQuestionnaireResponseItems()
+                item =
+                  questionnaireViewItem.questionnaireItem.createNestedQuestionnaireResponseItems()
               },
             )
           }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireViewModelTest.kt
@@ -52,8 +52,8 @@ import com.google.android.fhir.datacapture.extensions.EXTENSION_SDC_QUESTIONNAIR
 import com.google.android.fhir.datacapture.extensions.EXTENSION_VARIABLE_URL
 import com.google.android.fhir.datacapture.extensions.EntryMode
 import com.google.android.fhir.datacapture.extensions.asStringValue
+import com.google.android.fhir.datacapture.extensions.createNestedQuestionnaireResponseItems
 import com.google.android.fhir.datacapture.extensions.entryMode
-import com.google.android.fhir.datacapture.extensions.getNestedQuestionnaireResponseItems
 import com.google.android.fhir.datacapture.extensions.logicalId
 import com.google.android.fhir.datacapture.extensions.maxValue
 import com.google.android.fhir.datacapture.testing.DataCaptureTestApplication
@@ -4332,7 +4332,7 @@ class QuestionnaireViewModelTest {
                 getQuestionnaireAdapterItemListA()
                   .asQuestion()
                   .questionnaireItem
-                  .getNestedQuestionnaireResponseItems()
+                  .createNestedQuestionnaireResponseItems()
             },
           )
         getQuestionnaireAdapterItemListB()
@@ -4343,7 +4343,7 @@ class QuestionnaireViewModelTest {
                 getQuestionnaireAdapterItemListB()
                   .asQuestion()
                   .questionnaireItem
-                  .getNestedQuestionnaireResponseItems()
+                  .createNestedQuestionnaireResponseItems()
             },
           )
       }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponseItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponseItemComponentsTest.kt
@@ -104,8 +104,8 @@ class MoreQuestionnaireResponseItemComponentsTest {
     assertThat(nestedItems).hasSize(2)
     assertThat(nestedItems.map { it.linkId })
       .containsExactly("nested-question-1", "nested-question-2")
-    assertThat(nestedItems.first().answer.single().value).isNull()
-    assertThat(nestedItems.last().answer.single().value).isNull()
+    assertThat(nestedItems.first().answer).isEmpty()
+    assertThat(nestedItems.last().answer).isEmpty()
   }
 
   @Test

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponseItemComponentsTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponseItemComponentsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Google LLC
+ * Copyright 2022-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@
 package com.google.android.fhir.datacapture.extensions
 
 import com.google.common.truth.Truth.assertThat
+import org.hl7.fhir.r4.model.DecimalType
+import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
 import org.junit.Test
@@ -66,5 +70,101 @@ class MoreQuestionnaireResponseItemComponentsTest {
         questionnaireResponseItem21,
         questionnaireResponseItem22,
       )
+  }
+
+  @Test
+  fun `should copy nested item to childless answer`() {
+    val questionnaireItem =
+      QuestionnaireItemComponent().apply {
+        linkId = "question"
+        type = Questionnaire.QuestionnaireItemType.GROUP
+        repeats = true
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "nested-question-1"
+            type = Questionnaire.QuestionnaireItemType.INTEGER
+          },
+        )
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "nested-question-2"
+            type = Questionnaire.QuestionnaireItemType.DECIMAL
+          },
+        )
+      }
+    val questionnaireResponseItem =
+      QuestionnaireResponseItemComponent().apply {
+        linkId = "question"
+        addAnswer(QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent())
+      }
+
+    questionnaireResponseItem.copyNestedItemsToChildlessAnswers(questionnaireItem)
+
+    val nestedItems = questionnaireResponseItem.answer.single().item
+    assertThat(nestedItems).hasSize(2)
+    assertThat(nestedItems.map { it.linkId })
+      .containsExactly("nested-question-1", "nested-question-2")
+    assertThat(nestedItems.first().answer.single().value).isNull()
+    assertThat(nestedItems.last().answer.single().value).isNull()
+  }
+
+  @Test
+  fun `should not copy nested item to existing answer with children`() {
+    val questionnaireItem =
+      QuestionnaireItemComponent().apply {
+        linkId = "question"
+        type = Questionnaire.QuestionnaireItemType.GROUP
+        repeats = true
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "nested-question-1"
+            type = Questionnaire.QuestionnaireItemType.INTEGER
+          },
+        )
+        addItem(
+          QuestionnaireItemComponent().apply {
+            linkId = "nested-question-2"
+            type = Questionnaire.QuestionnaireItemType.DECIMAL
+          },
+        )
+      }
+    val questionnaireResponseItem =
+      QuestionnaireResponseItemComponent().apply {
+        linkId = "question"
+        addAnswer(
+          QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+            addItem(
+              QuestionnaireResponseItemComponent().apply {
+                linkId = "nested-question-1"
+                addAnswer(
+                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                    value = IntegerType(1)
+                  },
+                )
+              },
+            )
+            addItem(
+              QuestionnaireResponseItemComponent().apply {
+                linkId = "nested-question-2"
+                addAnswer(
+                  QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                    value = DecimalType(1.0)
+                  },
+                )
+              },
+            )
+          },
+        )
+      }
+
+    questionnaireResponseItem.copyNestedItemsToChildlessAnswers(questionnaireItem)
+
+    val nestedItems = questionnaireResponseItem.answer.single().item
+    assertThat(nestedItems).hasSize(2)
+    assertThat(nestedItems.map { it.linkId })
+      .containsExactly("nested-question-1", "nested-question-2")
+    assertThat(nestedItems.first().answer.single().valueIntegerType.value).isEqualTo(1)
+    assertThat(nestedItems.last().answer.single().valueDecimalType.value.toString())
+      .isEqualTo("1.0")
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2590

**Description**
At the moment we are copying nested items to answers with nested items. This would wipe out any existing answers to nested questions.

This PR makes sure we only copy nested items to new answers. It also improves documentation significantly and adds tests.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
