### PR TITLE
Move `README.md` content to the doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ healthcare applications using the [HL7® FHIR® standard](https://www.hl7.org/fh
 aims to accelerate the adoption of FHIR by making it easy to incorporate FHIR into new and existing
 mobile applications.
 
-See [documentation](google.github.io/android-fhir/).
+See [documentation](https://google.github.io/android-fhir/).
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -7,44 +7,7 @@ healthcare applications using the [HL7® FHIR® standard](https://www.hl7.org/fh
 aims to accelerate the adoption of FHIR by making it easy to incorporate FHIR into new and existing
 mobile applications.
 
-## Libraries
-
-The SDK contains the following libraries:
-
-| Library              | Latest release                                                                                                                                                                                                                    | Code                                                                  | Docs                                                                                | Min SDK                    | Summary                                                                                                                                                    |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Data Capture Library | [![Google Maven](https://badgen.net/maven/v/metadata-url/dl.google.com/dl/android/maven2/com/google/android/fhir/data-capture/maven-metadata.xml)](https://maven.google.com/web/index.html?#com.google.android.fhir:data-capture) | [code](https://github.com/google/android-fhir/tree/master/datacapture)| [docs](https://google.github.io/android-fhir/use/SDCL/) | Android 7.0 (API level 24) | Collect, validate, and process healthcare data on Android                                                                                                  |
-| FHIR Engine Library  | [![Google Maven](https://badgen.net/maven/v/metadata-url/dl.google.com/dl/android/maven2/com/google/android/fhir/engine/maven-metadata.xml)](https://maven.google.com/web/index.html?#com.google.android.fhir:engine)             | [code](https://github.com/google/android-fhir/tree/master/engine)     | [docs](https://google.github.io/android-fhir/use/FEL/)             | Android 7.0 (API level 24) | Store and manage FHIR resources locally on Android and synchronize with FHIR server                                                                        |
-| Workflow Library     | [![Google Maven](https://badgen.net/maven/v/metadata-url/dl.google.com/dl/android/maven2/com/google/android/fhir/workflow/maven-metadata.xml)](https://maven.google.com/web/index.html?#com.google.android.fhir:workflow)         | [code](https://github.com/google/android-fhir/tree/master/workflow)   | [docs](https://google.github.io/android-fhir/use/WFL/)                | Android 7.0 (API level 24) | Provide decision support and analytics in clinical workflow on Android including implementation of specific FHIR operations ($measure_evaluate and $apply) |
-
-## Demo apps
-
-This repository also contains the following demo apps:
-
-| Demo app                            | Code                                                               | Docs                                                              |
-| ----------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| FHIR Engine Demo App                | [code](https://github.com/google/android-fhir/tree/master/demo)    | [docs](https://google.github.io/android-fhir/use/FEL/Demo-app/)   |
-| Structured Data Capture Catalog App | [code](https://github.com/google/android-fhir/tree/master/catalog) | [docs](https://google.github.io/android-fhir/use/SDCL/Demo-app/)  |
-
-**These applications are provided for demo purposes only. Do NOT use in production.**
-
-## Contributing
-
-The development of the SDK began as a collaborative effort between Google, [The World Health Organization](https://www.who.int/), and [Ona](https://ona.io/). Since then, a consortium of application developers have been contributing to the project.
-
-To contribute to the project, please see [Contributing](https://google.github.io/android-fhir/contrib/) to get started.
-
-## Feedback and getting help
-
-You can create a [GitHub issue](https://github.com/google/android-fhir/issues) for bugs and feature requests.
-
-In case you find any security bug, please do NOT create a GitHub issue. Instead, email us at <android-fhir-sdk-feedback@google.com>.
-
-If you want to provide any feedback or discuss use cases you can:
-
-* email us at <android-fhir-sdk-feedback@google.com>
-* start a [GitHub discussion](https://github.com/google/android-fhir/discussions)
-* start a new topic in [android](https://chat.fhir.org/#narrow/stream/276344-android), [questionnaire](https://chat.fhir.org/#narrow/stream/179255-questionnaire), [implementers](https://chat.fhir.org/#narrow/stream/179166-implementers), or [WHO SMART guidelines](https://chat.fhir.org/#narrow/stream/310477-who-smart-guidelines) stream in the [FHIR Zulip chat](https://chat.fhir.org/)
+See [documentation](google.github.io/android-fhir/).
 
 ## Disclaimer
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,44 @@
+# Developer Community
+
+The development of the Android FHIR SDK began as a collaborative effort between
+Google, [The World Health Organization](https://www.who.int/), and [Ona](https://ona.io/). Since
+then, a consortium of app developers have been contributing to the project.
+
+## Developers Call
+
+We host a fortnightly Android FHIR SDK Developers Call every other Thursday.
+
+> OHS Developers Call: Android FHIR SDK
+> Every other Thursday · 10:00 – 11:00
+> Time zone: Europe/London
+> Google Meet joining info
+> Video call link: https://meet.google.com/woo-hecp-ufr
+> Or dial: (GB) +44 20 3956 2102 PIN: 937 593 189#
+> More phone numbers: https://tel.meet/woo-hecp-ufr?pin=8022014824840
+
+Subscribe to
+the [OHS Developer Community Calendar](https://calendar.google.com/calendar/u/0?cid=Y19lMjAzMzkyMjY5MDFjYzM1MGE1YTVkNmEyODhkOTgxNDc0MTZlYzk0MzViNGU2OTAyMTgwNTMwM2QxNDgzNmEzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+to see event details and other OHS events.
+
+Ask to join the [OHS Developers Google Group](ohs-developers-external@google.com) to receive the
+Google Calendar invitation and the latest updates.
+
+## Raise an issue
+
+Create a [GitHub issue](https://github.com/google/android-fhir/issues) for bugs and feature
+requests.
+
+In case you find any security bug, do NOT create a GitHub issue. Instead, email us
+at <android-fhir@google.com>.
+
+## Start a discussion
+
+Start a [GitHub discussion](https://github.com/google/android-fhir/discussions) for discussions
+directly related to the Android FHIR SDK.
+Use [android](https://chat.fhir.org/#narrow/stream/276344-android), [questionnaire](https://chat.fhir.org/#narrow/stream/179255-questionnaire), [implementers](https://chat.fhir.org/#narrow/stream/179166-implementers),
+or [WHO SMART guidelines](https://chat.fhir.org/#narrow/stream/310477-who-smart-guidelines) stream
+in the [FHIR Zulip chat](https://chat.fhir.org/) for more general FHIR-related discussions.
+
+## Contact Us
+
+Email <android-fhir@google.com> to contact the team directly.

--- a/docs/community.md
+++ b/docs/community.md
@@ -20,8 +20,8 @@ Subscribe to
 the [OHS Developer Community Calendar](https://calendar.google.com/calendar/u/0?cid=Y19lMjAzMzkyMjY5MDFjYzM1MGE1YTVkNmEyODhkOTgxNDc0MTZlYzk0MzViNGU2OTAyMTgwNTMwM2QxNDgzNmEzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
 to see event details and other OHS events.
 
-Ask to join the [OHS Developers Google Group](ohs-developers-external@google.com) to receive the
-Google Calendar invitation and the latest updates.
+Ask to join the [OHS Developers Google Group](mailto:ohs-developers-external@google.com) to receive
+the Google Calendar invitation and the latest updates.
 
 ## Raise an issue
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -8,12 +8,12 @@ then, a consortium of app developers have been contributing to the project.
 
 We host a fortnightly Android FHIR SDK Developers Call every other Thursday.
 
-> OHS Developers Call: Android FHIR SDK
-> Every other Thursday · 10:00 – 11:00
-> Time zone: Europe/London
-> Google Meet joining info
-> Video call link: https://meet.google.com/woo-hecp-ufr
-> Or dial: (GB) +44 20 3956 2102 PIN: 937 593 189#
+> OHS Developers Call: Android FHIR SDK  
+> Every other Thursday · 10:00 – 11:00  
+> Time zone: Europe/London  
+> Google Meet joining info  
+> Video call link: https://meet.google.com/woo-hecp-ufr  
+> Or dial: (GB) +44 20 3956 2102 PIN: 937 593 189#  
 > More phone numbers: https://tel.meet/woo-hecp-ufr?pin=8022014824840
 
 Subscribe to

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,27 +14,26 @@ Use the following table for documentation and resources to get started with each
 | Workflow Library             | [![Google Maven](https://badgen.net/maven/v/metadata-url/dl.google.com/dl/android/maven2/com/google/android/fhir/workflow/maven-metadata.xml)](https://maven.google.com/web/index.html?#com.google.android.fhir:workflow)     | [code](https://github.com/google/android-fhir/tree/master/workflow)   | [docs](use/WFL/index.md)                | |  Provides decision support and analytics in clinical workflow on Android including implementation of specific FHIR operations ($measure_evaluate and $apply) |
 | Knowledge Manager Library    | [![Google Maven](https://badgen.net/maven/v/metadata-url/dl.google.com/dl/android/maven2/com/google/android/fhir/knowledge/maven-metadata.xml)](https://maven.google.com/web/index.html?#com.google.android.fhir:knowledge)    | [code](https://github.com/google/android-fhir/tree/master/knowledge)  |        | | Manages knowledge resources locally on Android and supports other libraries with knowledge resources                                               |
 
-## Project information
+This repository also contains the following demo apps:
 
-* [Project roadmap](contrib/roadmap.md)
-* [FAQs](faq.md)
+| Demo app                            | Code                                                               | Docs                                                              |
+| ----------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| FHIR Engine Demo App                | [code](https://github.com/google/android-fhir/tree/master/demo)    | [docs](https://google.github.io/android-fhir/use/FEL/Demo-app/)   |
+| Structured Data Capture Catalog App | [code](https://github.com/google/android-fhir/tree/master/catalog) | [docs](https://google.github.io/android-fhir/use/SDCL/Demo-app/)  |
+
+**These applications are for demo purposes only. Do NOT use in production.**
+
+Use the sidebar to navigate to other sections of the site.
 
 ## Resources
 
-### FHIR and implementation guides
+FHIR and implementation guides:
 
 * [HL7 FHIR](https://www.hl7.org/fhir/)
 * [Structured Data Capture](http://hl7.org/fhir/us/sdc/)
 * [Clinical Quality Lanugage (CQL)](https://cql.hl7.org/)
 
-### More on mobile health landscape
+More on mobile health landscape:
 
 * [Digital Health Atlas](https://digitalhealthatlas.org/)
 * [Global Goods Guidebook](https://digitalsquare.org/global-goods-guidebook)
-
-### Community
-
-* [Zulip FHIR chat](https://chat.fhir.org/) has the following streams that are relevant to this codebase:
-  * [#android](https://chat.fhir.org/#narrow/stream/276344-android)
-  * [#implementers](https://chat.fhir.org/#narrow/stream/179166-implementers)
-  * [#questionnaire](https://chat.fhir.org/#narrow/stream/179255-questionnaire) for the SDC library and gallery

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -6,7 +6,6 @@ copyright: Copyright 2024 The Android FHIR SDK Authors
 
 nav:
   - Home: index.md
-  - faq.md
   - Users:
       - FHIR Engine Library:
           - Introduction: use/FEL/index.md
@@ -48,7 +47,9 @@ nav:
       - Codespaces: contrib/codespaces.md
       - Documentation: contrib/docs.md
       - contrib/dependencies.md
-      - Roadmap: contrib/roadmap.md
+  - Roadmap: contrib/roadmap.md
+  - Community: community.md
+  - faq.md
 
 # The following settings were originally partially inspired by
 # https://github.com/enola-dev/enola/blob/main/mkdocs.yaml


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
- Move the duplicated content from the README.md file to the doc site
- Add community page in the doc site to centralize all community information
- Move roadmap page to the top level navigation (it was nested under contributors)

**Alternative(s) considered**
NA

**Type**
Documentation

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
