### PR TITLE
Remove duplicate knowledge repository instance in the workflow library

### DIFF
--- a/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
+++ b/workflow/src/main/java/com/google/android/fhir/workflow/FhirOperator.kt
@@ -51,7 +51,7 @@ internal constructor(
   knowledgeManager: KnowledgeManager,
 ) {
   init {
-    check(fhirContext.version.version == FhirVersionEnum.R4) {
+    require(fhirContext.version.version == FhirVersionEnum.R4) {
       "R4 is the only supported version by FhirOperator"
     }
   }


### PR DESCRIPTION
**Description**
Merge the two instances of knowledge repository into one in the workflow library.

**Alternative(s) considered**
NA

**Type**
Code health

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
