### PR TITLE
Fix Codespace with chown /opt/android workaround (fixes #2614)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,13 +18,15 @@
     //   "platform": "33",
     //   "build_tools": "33.0.1"
     // }
-  }
+  },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "java -version",
+  // See https://github.com/google/android-fhir/issues/2614, which is blocked by
+  // https://github.com/akhildevelops/devcontainer-features/issues/9.
+  "postCreateCommand": "sudo chown -R vscode:vscode /opt/android/"
 
   // Configure tool-specific properties.
   // "customizations": {},


### PR DESCRIPTION
Fixes #2614

**Description**

This fixes #2614.

It works around https://github.com/akhildevelops/devcontainer-features/issues/9.

**Alternative(s) considered**

Wait for https://github.com/akhildevelops/devcontainer-features/issues/9 and then bump 0.0.2 to 0.0.3.

But no need, this works great - I've tested it.

**Type**
Choose one: **Bug fix** ~~Feature | Documentation | Testing | Code health | Builds | Releases | Other~~