### PR TITLE
Enable Magic Links to auto-link any links in docs (even if not <...>)

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -69,6 +69,10 @@ theme:
     - search.suggest
     - search.share
 
+markdown_extensions:
+  # https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/
+  - pymdownx.magiclink
+
 plugins:
   - search
   - git-revision-date-localized


### PR DESCRIPTION
This will fix e.g. the currently missing links on hyperlinks on https://google.github.io/android-fhir/contrib/git/#further-resources (and similar future occurrences).

Inspired by e.g. https://github.com/enola-dev/enola/blob/df45649e225e57131d3fe433577e3748bb46a8f5/mkdocs.yaml#L151.