### PR TITLE
Add missing response items to repeated group child items

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -419,7 +419,8 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
    * Adds empty [QuestionnaireResponseItemComponent]s to `responseItems` so that each
    * [QuestionnaireItemComponent] in `questionnaireItems` has at least one corresponding
    * [QuestionnaireResponseItemComponent]. This is because user-provided [QuestionnaireResponse]
-   * might not contain answers to unanswered or disabled questions. This function should only be used for unpacked questionnaire.
+   * might not contain answers to unanswered or disabled questions. This function should only be
+   * used for unpacked questionnaire.
    */
   @VisibleForTesting
   internal fun addMissingResponseItems(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -419,8 +419,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
    * Adds empty [QuestionnaireResponseItemComponent]s to `responseItems` so that each
    * [QuestionnaireItemComponent] in `questionnaireItems` has at least one corresponding
    * [QuestionnaireResponseItemComponent]. This is because user-provided [QuestionnaireResponse]
-   * might not contain answers to unanswered or disabled questions. Note : this only applies to
-   * [QuestionnaireItemComponent]s nested under a group.
+   * might not contain answers to unanswered or disabled questions. This function should only be used for unpacked questionnaire.
    */
   @VisibleForTesting
   internal fun addMissingResponseItems(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -422,7 +422,8 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
    * might not contain answers to unanswered or disabled questions. Note : this only applies to
    * [QuestionnaireItemComponent]s nested under a group.
    */
-  private fun addMissingResponseItems(
+  @VisibleForTesting
+  internal fun addMissingResponseItems(
     questionnaireItems: List<QuestionnaireItemComponent>,
     responseItems: MutableList<QuestionnaireResponseItemComponent>,
   ) {
@@ -445,6 +446,14 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
             questionnaireItems = it.item,
             responseItems = responseItemMap[it.linkId]!!.single().item,
           )
+        }
+        if (it.type == Questionnaire.QuestionnaireItemType.GROUP && it.repeats) {
+          responseItemMap[it.linkId]!!.forEach { rItem ->
+            addMissingResponseItems(
+              questionnaireItems = it.item,
+              responseItems = rItem.item,
+            )
+          }
         }
         responseItems.addAll(responseItemMap[it.linkId]!!)
       }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2655

**Description**
If you have a questionnaire item inside a repeated group, but the related response item is missing, then you call `addMissingResponseItems`. The missing response item is still missing.

An exception will show if you try to call `forEachItemPair` function where you need to have the exact same size between questionnaire items and response items.

This PR fixes that.

**Alternative(s) considered**
N/A

**Type**
Bug fix

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
