### PR TITLE
Update CODEOWNERS to use group instead of individuals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,4 @@
 # This file lists people who get automatically added as Reviewers for Pull Requests.
-#
-# Note that we intentionally do NOT just include all committers here by using @google/android-fhir,
-# nor were we able to get it working using a group such as @google/android-fhir-reviewers;
-# details about why are described on https://github.com/google/android-fhir/issues/2320
-# and https://github.com/google/android-fhir/pull/2536.
-#
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These people for *ALL* Pull Requests:
 * @google/android-fhir-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These people for *ALL* Pull Requests:
-* @aditya-07 @jingtang10 @MJ1998 @santosh-pingle 
+* @google/android-fhir-reviewers
 
 # These for anything documentation related:
 docs/* @vorburger


### PR DESCRIPTION
**Description**
The "Enable auto assignment" option in teams were enabled, giving it another try 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one:  Other


**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
