### PR TITLE
Add dialog extension

### DIFF
--- a/catalog/src/main/assets/component_modal.json
+++ b/catalog/src/main/assets/component_modal.json
@@ -2,6 +2,21 @@
   "resourceType": "Questionnaire",
   "item": [
     {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                "code": "lookup",
+                "display": "Lookup"
+              }
+            ],
+            "text": "Lookup"
+          }
+        }
+      ],
       "linkId": "1.1",
       "type": "choice",
       "repeats": true,
@@ -43,48 +58,6 @@
           "valueCoding": {
             "code": "diarrhoea",
             "display": "Diarrhoea"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "fever",
-            "display": "Fever"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "injury",
-            "display": "Injury"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "jaundice",
-            "display": "Jaundice"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "mental-health",
-            "display": "Mental health"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "nausea",
-            "display": "Nausea"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "pain",
-            "display": "Pain"
-          }
-        },
-        {
-          "valueCoding": {
-            "code": "bleeding",
-            "display": "Bleeding"
           }
         }
       ]

--- a/catalog/src/main/assets/component_modal.json
+++ b/catalog/src/main/assets/component_modal.json
@@ -9,12 +9,15 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "lookup",
-                "display": "Lookup"
+                "code": "check-box",
+                "display": "Check Box"
               }
             ],
-            "text": "Lookup"
+            "text": "Check box"
           }
+        },
+        {
+          "url": "https://github.com/google/android-fhir/dialog"
         }
       ],
       "linkId": "1.1",

--- a/catalog/src/main/assets/component_modal.json
+++ b/catalog/src/main/assets/component_modal.json
@@ -17,7 +17,7 @@
           }
         },
         {
-          "url": "https://github.com/google/android-fhir/dialog"
+          "url": "https://github.com/google/android-fhir/StructureDefinition/dialog"
         }
       ],
       "linkId": "1.1",

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
@@ -25,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.fhir.datacapture.contrib.views.PhoneNumberViewHolderFactory
 import com.google.android.fhir.datacapture.extensions.inflate
 import com.google.android.fhir.datacapture.extensions.itemControl
+import com.google.android.fhir.datacapture.extensions.shouldUseDialog
 import com.google.android.fhir.datacapture.views.NavigationViewHolder
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
 import com.google.android.fhir.datacapture.views.factories.AttachmentViewHolderFactory
@@ -242,7 +243,10 @@ internal class QuestionnaireEditAdapter(
     val questionnaireItem = questionnaireViewItem.questionnaireItem
 
     // Use the view type that the client wants if they specified an itemControl
-    return questionnaireItem.itemControl?.viewHolderType
+    return when {
+      questionnaireItem.shouldUseDialog -> QuestionnaireViewHolderType.DIALOG_SELECT
+      else -> questionnaireItem.itemControl?.viewHolderType
+    }
     // Otherwise, choose a sensible UI element automatically
     ?: run {
         val numOptions = questionnaireViewItem.enabledAnswerOptions.size

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
@@ -242,7 +242,7 @@ internal class QuestionnaireEditAdapter(
   ): QuestionnaireViewHolderType {
     val questionnaireItem = questionnaireViewItem.questionnaireItem
 
-    // Use the view type that the client wants if they specified an itemControl
+    // Use the view type that the client wants if they specified an itemControl or dialog extension
     return when {
       questionnaireItem.shouldUseDialog -> QuestionnaireViewHolderType.DIALOG_SELECT
       else -> questionnaireItem.itemControl?.viewHolderType

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -188,6 +188,7 @@ enum class ItemControlTypes(
   CHECK_BOX("check-box", QuestionnaireViewHolderType.CHECK_BOX_GROUP),
   DROP_DOWN("drop-down", QuestionnaireViewHolderType.DROP_DOWN),
   OPEN_CHOICE("open-choice", QuestionnaireViewHolderType.DIALOG_SELECT),
+  LOOKUP("lookup", QuestionnaireViewHolderType.DIALOG_SELECT),
   RADIO_BUTTON("radio-button", QuestionnaireViewHolderType.RADIO_GROUP),
   SLIDER("slider", QuestionnaireViewHolderType.SLIDER),
   PHONE_NUMBER("phone-number", QuestionnaireViewHolderType.PHONE_NUMBER),

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -191,7 +191,6 @@ enum class ItemControlTypes(
   CHECK_BOX("check-box", QuestionnaireViewHolderType.CHECK_BOX_GROUP),
   DROP_DOWN("drop-down", QuestionnaireViewHolderType.DROP_DOWN),
   OPEN_CHOICE("open-choice", QuestionnaireViewHolderType.DIALOG_SELECT),
-  LOOKUP("lookup", QuestionnaireViewHolderType.DIALOG_SELECT),
   RADIO_BUTTON("radio-button", QuestionnaireViewHolderType.RADIO_GROUP),
   SLIDER("slider", QuestionnaireViewHolderType.SLIDER),
   PHONE_NUMBER("phone-number", QuestionnaireViewHolderType.PHONE_NUMBER),

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -61,7 +61,8 @@ internal const val EXTENSION_ITEM_CONTROL_URL_ANDROID_FHIR =
 internal const val EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR =
   "https://github.com/google/android-fhir/questionnaire-item-control"
 
-internal const val EXTENSION_DIALOG_URL_ANDROID_FHIR = "https://github.com/google/android-fhir/dialog"
+internal const val EXTENSION_DIALOG_URL_ANDROID_FHIR =
+  "https://github.com/google/android-fhir/dialog"
 
 // Below URLs exist and are supported by HL7
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -62,7 +62,7 @@ internal const val EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR =
   "https://github.com/google/android-fhir/questionnaire-item-control"
 
 internal const val EXTENSION_DIALOG_URL_ANDROID_FHIR =
-  "https://github.com/google/android-fhir/dialog"
+  "https://github.com/google/android-fhir/StructureDefinition/dialog"
 
 internal enum class StyleUrl(val url: String) {
   BASE("https://github.com/google/android-fhir/tree/master/datacapture/android-style"),

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -61,6 +61,8 @@ internal const val EXTENSION_ITEM_CONTROL_URL_ANDROID_FHIR =
 internal const val EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR =
   "https://github.com/google/android-fhir/questionnaire-item-control"
 
+internal const val EXTENSION_DIALOG_URL_ANDROID_FHIR = "https://github.com/google/android-fhir/dialog"
+
 // Below URLs exist and are supported by HL7
 
 internal const val EXTENSION_ANSWER_EXPRESSION_URL: String =
@@ -230,6 +232,15 @@ val QuestionnaireItemComponent.itemControlCode: String?
  */
 val QuestionnaireItemComponent.itemControl: ItemControlTypes?
   get() = ItemControlTypes.values().firstOrNull { it.extensionCode == itemControlCode }
+
+private val QuestionnaireItemComponent.hasDialogExtension: Boolean
+  get() = this.extension.any { it.url == EXTENSION_DIALOG_URL_ANDROID_FHIR }
+
+val QuestionnaireItemComponent.shouldUseDialog: Boolean
+  get() =
+    this.hasDialogExtension &&
+      (this.itemControl?.viewHolderType == QuestionnaireViewHolderType.CHECK_BOX_GROUP ||
+        this.itemControl?.viewHolderType == QuestionnaireViewHolderType.RADIO_GROUP)
 
 /**
  * The desired orientation for the list of choices.

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapterTest.kt
@@ -497,9 +497,8 @@ class QuestionnaireEditAdapterTest {
       .isEqualTo(QuestionnaireViewHolderType.DROP_DOWN.value)
   }
 
-  @Suppress("ktlint:standard:max-line-length")
   @Test
-  fun getItemViewType_choiceItemType_itemControlExtensionWithRadioButton_andDialogExtension_shouldReturnDialogSelectViewHolderType() {
+  fun `getItemViewType() with radio button and dialog extension should return dialog select view holder type`() {
     val questionnaireEditAdapter = QuestionnaireEditAdapter()
     val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().setType(Questionnaire.QuestionnaireItemType.CHOICE)
@@ -536,9 +535,8 @@ class QuestionnaireEditAdapterTest {
       .isEqualTo(QuestionnaireViewHolderType.DIALOG_SELECT.value)
   }
 
-  @Suppress("ktlint:standard:max-line-length")
   @Test
-  fun getItemViewType_choiceItemType_itemControlExtensionWithCheckBox_andDialogExtension_shouldReturnDialogSelectViewHolderType() {
+  fun `getItemViewType() with check box and dialog extension should return dialog select view holder type`() {
     val questionnaireEditAdapter = QuestionnaireEditAdapter()
     val questionnaireItem =
       Questionnaire.QuestionnaireItemComponent().setType(Questionnaire.QuestionnaireItemType.CHOICE)

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapterTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapterTest.kt
@@ -19,6 +19,7 @@ package com.google.android.fhir.datacapture
 import android.os.Build
 import android.widget.FrameLayout
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.fhir.datacapture.extensions.EXTENSION_DIALOG_URL_ANDROID_FHIR
 import com.google.android.fhir.datacapture.extensions.EXTENSION_ITEM_CONTROL_SYSTEM
 import com.google.android.fhir.datacapture.extensions.EXTENSION_ITEM_CONTROL_SYSTEM_ANDROID_FHIR
 import com.google.android.fhir.datacapture.extensions.EXTENSION_ITEM_CONTROL_URL
@@ -494,6 +495,84 @@ class QuestionnaireEditAdapterTest {
 
     assertThat(questionnaireEditAdapter.getItemViewType(0))
       .isEqualTo(QuestionnaireViewHolderType.DROP_DOWN.value)
+  }
+
+  @Suppress("ktlint:standard:max-line-length")
+  @Test
+  fun getItemViewType_choiceItemType_itemControlExtensionWithRadioButton_andDialogExtension_shouldReturnDialogSelectViewHolderType() {
+    val questionnaireEditAdapter = QuestionnaireEditAdapter()
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().setType(Questionnaire.QuestionnaireItemType.CHOICE)
+    questionnaireItem.apply {
+      addExtension(
+        Extension()
+          .setUrl(EXTENSION_ITEM_CONTROL_URL)
+          .setValue(
+            CodeableConcept()
+              .addCoding(
+                Coding()
+                  .setCode(ItemControlTypes.RADIO_BUTTON.extensionCode)
+                  .setDisplay("Radio Button")
+                  .setSystem(EXTENSION_ITEM_CONTROL_SYSTEM),
+              ),
+          ),
+      )
+      addExtension(Extension().setUrl(EXTENSION_DIALOG_URL_ANDROID_FHIR))
+    }
+    questionnaireEditAdapter.submitList(
+      listOf(
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireViewItem(
+            questionnaireItem,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _, _ -> },
+          ),
+        ),
+      ),
+    )
+
+    assertThat(questionnaireEditAdapter.getItemViewType(0))
+      .isEqualTo(QuestionnaireViewHolderType.DIALOG_SELECT.value)
+  }
+
+  @Suppress("ktlint:standard:max-line-length")
+  @Test
+  fun getItemViewType_choiceItemType_itemControlExtensionWithCheckBox_andDialogExtension_shouldReturnDialogSelectViewHolderType() {
+    val questionnaireEditAdapter = QuestionnaireEditAdapter()
+    val questionnaireItem =
+      Questionnaire.QuestionnaireItemComponent().setType(Questionnaire.QuestionnaireItemType.CHOICE)
+    questionnaireItem.apply {
+      addExtension(
+        Extension()
+          .setUrl(EXTENSION_ITEM_CONTROL_URL)
+          .setValue(
+            CodeableConcept()
+              .addCoding(
+                Coding()
+                  .setCode(ItemControlTypes.CHECK_BOX.extensionCode)
+                  .setDisplay("Check Box")
+                  .setSystem(EXTENSION_ITEM_CONTROL_SYSTEM),
+              ),
+          ),
+      )
+      addExtension(Extension().setUrl(EXTENSION_DIALOG_URL_ANDROID_FHIR))
+    }
+    questionnaireEditAdapter.submitList(
+      listOf(
+        QuestionnaireAdapterItem.Question(
+          QuestionnaireViewItem(
+            questionnaireItem,
+            QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+            validationResult = NotValidated,
+            answersChangedCallback = { _, _, _, _ -> },
+          ),
+        ),
+      ),
+    )
+
+    assertThat(questionnaireEditAdapter.getItemViewType(0))
+      .isEqualTo(QuestionnaireViewHolderType.DIALOG_SELECT.value)
   }
 
   // TODO: test errors thrown for unsupported types

--- a/docs/use/extensions.md
+++ b/docs/use/extensions.md
@@ -2,4 +2,4 @@
 
 This page lists [FHIR Extensions](http://hl7.org/fhir/extensibility.html) defined by the Android FHIR SDK.
 
-* UUID
+* Dialog extension (https://github.com/google/android-fhir/StructureDefinition/dialog)

--- a/docs/use/extensions.md
+++ b/docs/use/extensions.md
@@ -3,3 +3,5 @@
 This page lists [FHIR Extensions](http://hl7.org/fhir/extensibility.html) defined by the Android FHIR SDK.
 
 * Dialog extension (https://github.com/google/android-fhir/StructureDefinition/dialog)
+
+  This extension can only be used if the questionnaire item type is `choice` and has an item-control of type `check-box` or `radio-button`.


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2662

**Description**
- Define dialog extension https://github.com/google/android-fhir/dialog
- Use dialog: if the item control is checkbox or radio button, and has dialog extension

FHIR Chat discussion about adding `dialog` control type to Jira:
https://chat.fhir.org/#narrow/stream/179255-questionnaire/topic/dialog.20item.20control

**Alternative(s) considered**
N/A

**Type**
Feature

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
