### PR TITLE
Add argument to disable Submit anyway button in the questionnaire confirmation popup

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -114,15 +114,16 @@ class QuestionnaireFragment : Fragment() {
             errorViewModel.setQuestionnaireAndValidation(viewModel.questionnaire, validationMap)
             val validationErrorMessageDialog = QuestionnaireValidationErrorMessageDialogFragment()
             if (requireArguments().containsKey(EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON)) {
-              val validationErrorBundle = Bundle()
-              validationErrorBundle.putBoolean(
-                EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON,
-                requireArguments()
-                  .getBoolean(
+              validationErrorMessageDialog.arguments =
+                Bundle().apply {
+                  putBoolean(
                     EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON,
-                  ),
-              )
-              validationErrorMessageDialog.arguments = validationErrorBundle
+                    requireArguments()
+                      .getBoolean(
+                        EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON,
+                      ),
+                  )
+                }
             }
             validationErrorMessageDialog.show(
               requireActivity().supportFragmentManager,

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireFragment.kt
@@ -112,11 +112,22 @@ class QuestionnaireFragment : Fragment() {
           } else {
             val errorViewModel: QuestionnaireValidationErrorViewModel by activityViewModels()
             errorViewModel.setQuestionnaireAndValidation(viewModel.questionnaire, validationMap)
-            QuestionnaireValidationErrorMessageDialogFragment()
-              .show(
-                requireActivity().supportFragmentManager,
-                QuestionnaireValidationErrorMessageDialogFragment.TAG,
+            val validationErrorMessageDialog = QuestionnaireValidationErrorMessageDialogFragment()
+            if (requireArguments().containsKey(EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON)) {
+              val validationErrorBundle = Bundle()
+              validationErrorBundle.putBoolean(
+                EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON,
+                requireArguments()
+                  .getBoolean(
+                    EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON,
+                  ),
               )
+              validationErrorMessageDialog.arguments = validationErrorBundle
+            }
+            validationErrorMessageDialog.show(
+              requireActivity().supportFragmentManager,
+              QuestionnaireValidationErrorMessageDialogFragment.TAG,
+            )
           }
         }
       }
@@ -407,6 +418,11 @@ class QuestionnaireFragment : Fragment() {
       args.add(EXTRA_SHOW_NAVIGATION_IN_DEFAULT_LONG_SCROLL to value)
     }
 
+    /** Setter to show/hide the Submit anyway button. This button is visible by default. */
+    fun setShowSubmitAnywayButton(value: Boolean) = apply {
+      args.add(EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON to value)
+    }
+
     @VisibleForTesting fun buildArgs() = bundleOf(*args.toTypedArray())
 
     /** @return A [QuestionnaireFragment] with provided [Bundle] arguments. */
@@ -508,6 +524,12 @@ class QuestionnaireFragment : Fragment() {
 
     internal const val EXTRA_SHOW_NAVIGATION_IN_DEFAULT_LONG_SCROLL =
       "show-navigation-in-default-long-scroll"
+
+    /**
+     * A [Boolean] extra to show or hide the Submit anyway button in the questionnaire. Default is
+     * true.
+     */
+    internal const val EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON = "show-submit-anyway-button"
 
     fun builder() = Builder()
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,17 +51,23 @@ internal class QuestionnaireValidationErrorMessageDialogFragment(
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     isCancelable = false
-    return MaterialAlertDialogBuilder(requireContext())
-      .setView(onCreateCustomView())
-      .setPositiveButton(R.string.questionnaire_validation_error_fix_button_text) { dialog, _ ->
+    val currentDialog =
+      MaterialAlertDialogBuilder(requireContext()).setView(onCreateCustomView()).setPositiveButton(
+        R.string.questionnaire_validation_error_fix_button_text,
+      ) { dialog, _ ->
         setFragmentResult(RESULT_CALLBACK, bundleOf(RESULT_KEY to RESULT_VALUE_FIX))
         dialog?.dismiss()
       }
-      .setNegativeButton(R.string.questionnaire_validation_error_submit_button_text) { dialog, _ ->
+    if (arguments == null || requireArguments().getBoolean(EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON, true)) {
+      currentDialog.setNegativeButton(R.string.questionnaire_validation_error_submit_button_text) {
+        dialog,
+        _,
+        ->
         setFragmentResult(RESULT_CALLBACK, bundleOf(RESULT_KEY to RESULT_VALUE_SUBMIT))
         dialog?.dismiss()
       }
-      .create()
+    }
+    return currentDialog.create()
   }
 
   @VisibleForTesting
@@ -97,6 +103,12 @@ internal class QuestionnaireValidationErrorMessageDialogFragment(
     const val RESULT_KEY = "result"
     const val RESULT_VALUE_FIX = "result_fix"
     const val RESULT_VALUE_SUBMIT = "result_submit"
+
+    /**
+     * A [Boolean] extra to show or hide the Submit anyway button in the questionnaire. Default is
+     * true.
+     */
+    internal const val EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON = "show-submit-anyway-button"
   }
 }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
@@ -80,10 +80,6 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
     }
   }
 
-  /**
-   * Test method to ensure that Submit anyway button is visible when its value is set as true in the
-   * fragment arguments
-   */
   @Test
   fun `check alertDialog when submit anyway button argument is true should show Submit anyway button`() {
     runTest {
@@ -116,10 +112,6 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
     }
   }
 
-  /**
-   * Test method to ensure that Submit anyway button is visible when no fragment arguments are
-   * passed
-   */
   @Test
   fun `check alertDialog when no arguments are passed should show Submit anyway button`() {
     runTest {
@@ -146,10 +138,6 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
     }
   }
 
-  /**
-   * Test method to ensure that Submit anyway button is not visible when it's value is set as false
-   * in the fragment arguments
-   */
   @Test
   fun `check alertDialog when submit anyway button argument is false should hide Submit anyway button`() {
     runTest {

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
@@ -16,15 +16,20 @@
 
 package com.google.android.fhir.datacapture
 
+import android.os.Bundle
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentFactory
+import androidx.fragment.app.testing.launchFragment
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.fragment.app.testing.withFragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.fhir.datacapture.validation.QuestionnaireResponseValidator
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
@@ -72,6 +77,105 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
       assertThat(result.findViewById<TextView>(R.id.dialog_subtitle).text)
         .isEqualTo("Fix the following questions:")
       assertThat(result.findViewById<TextView>(R.id.body).text).isEqualTo("• First Name")
+    }
+  }
+
+  /**
+   * Test method to ensure that Submit anyway button is visible when its value is set as true in the
+   * fragment arguments
+   */
+  @Test
+  fun checkAlertDialog_submitAnywayButtonIsTrue_shouldShowSubmitAnywayButton() {
+    runTest {
+      val questionnaireValidationErrorMessageDialogArguments = Bundle()
+      questionnaireValidationErrorMessageDialogArguments.putBoolean(
+        QuestionnaireValidationErrorMessageDialogFragment.EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON,
+        true,
+      )
+      with(
+        launchFragment<QuestionnaireValidationErrorMessageDialogFragment>(
+          themeResId = R.style.Theme_Questionnaire,
+          fragmentArgs = questionnaireValidationErrorMessageDialogArguments,
+        ),
+      ) {
+        onFragment { fragment ->
+          assertThat(fragment.dialog).isNotNull()
+          assertThat(fragment.requireDialog().isShowing).isTrue()
+          val alertDialog = fragment.dialog as? AlertDialog
+          val context = InstrumentationRegistry.getInstrumentation().targetContext
+          val positiveButtonText =
+            context.getString(R.string.questionnaire_validation_error_fix_button_text)
+          val negativeButtonText =
+            context.getString(R.string.questionnaire_validation_error_submit_button_text)
+          assertThat(alertDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.text)
+            .isEqualTo(positiveButtonText)
+          assertThat(alertDialog?.getButton(AlertDialog.BUTTON_NEGATIVE)?.text)
+            .isEqualTo(negativeButtonText)
+        }
+      }
+    }
+  }
+
+  /**
+   * Test method to ensure that Submit anyway button is visible when no fragment arguments are
+   * passed
+   */
+  @Test
+  fun checkAlertDialog_noArgsPassed_shouldShowSubmitAnywayButton() {
+    runTest {
+      with(
+        launchFragment<QuestionnaireValidationErrorMessageDialogFragment>(
+          themeResId = R.style.Theme_Questionnaire,
+        ),
+      ) {
+        onFragment { fragment ->
+          assertThat(fragment.dialog).isNotNull()
+          assertThat(fragment.requireDialog().isShowing).isTrue()
+          val alertDialog = fragment.dialog as? AlertDialog
+          val context = InstrumentationRegistry.getInstrumentation().targetContext
+          val positiveButtonText =
+            context.getString(R.string.questionnaire_validation_error_fix_button_text)
+          val negativeButtonText =
+            context.getString(R.string.questionnaire_validation_error_submit_button_text)
+          assertThat(alertDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.text)
+            .isEqualTo(positiveButtonText)
+          assertThat(alertDialog?.getButton(AlertDialog.BUTTON_NEGATIVE)?.text)
+            .isEqualTo(negativeButtonText)
+        }
+      }
+    }
+  }
+
+  /**
+   * Test method to ensure that Submit anyway button is not visible when it's value is set as false
+   * in the fragment arguments
+   */
+  @Test
+  fun checkAlertDialog_submitAnywayButtonIsFalse_shouldHideSubmitAnywayButton() {
+    runTest {
+      val validationErrorBundle = Bundle()
+      validationErrorBundle.putBoolean(
+        QuestionnaireValidationErrorMessageDialogFragment.EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON,
+        false,
+      )
+      with(
+        launchFragment<QuestionnaireValidationErrorMessageDialogFragment>(
+          themeResId = R.style.Theme_Questionnaire,
+          fragmentArgs = validationErrorBundle,
+        ),
+      ) {
+        onFragment { fragment ->
+          assertThat(fragment.dialog).isNotNull()
+          assertThat(fragment.requireDialog().isShowing).isTrue()
+          val alertDialog = fragment.dialog as? AlertDialog
+          val context = InstrumentationRegistry.getInstrumentation().targetContext
+          val positiveButtonText =
+            context.getString(R.string.questionnaire_validation_error_fix_button_text)
+          assertThat(alertDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.text)
+            .isEqualTo(positiveButtonText)
+          assertEquals(alertDialog?.getButton(AlertDialog.BUTTON_NEGATIVE)?.text, "")
+        }
+      }
     }
   }
 

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
@@ -85,7 +85,7 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
    * fragment arguments
    */
   @Test
-  fun checkAlertDialog_submitAnywayButtonIsTrue_shouldShowSubmitAnywayButton() {
+  fun `check alertDialog when submit anyway button argument is true should show Submit anyway button`() {
     runTest {
       val questionnaireValidationErrorMessageDialogArguments = Bundle()
       questionnaireValidationErrorMessageDialogArguments.putBoolean(
@@ -121,7 +121,7 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
    * passed
    */
   @Test
-  fun checkAlertDialog_noArgsPassed_shouldShowSubmitAnywayButton() {
+  fun `check alertDialog when no arguments are passed should show Submit anyway button`() {
     runTest {
       with(
         launchFragment<QuestionnaireValidationErrorMessageDialogFragment>(
@@ -151,7 +151,7 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
    * in the fragment arguments
    */
   @Test
-  fun checkAlertDialog_submitAnywayButtonIsFalse_shouldHideSubmitAnywayButton() {
+  fun `check alertDialog when submit anyway button argument is false should hide Submit anyway button`() {
     runTest {
       val validationErrorBundle = Bundle()
       validationErrorBundle.putBoolean(


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2444 

**Description**
Add bundle argument `EXTRA_SHOW_SUBMIT_ANYWAY_BUTTON` in `QuestionnaireFragment.kt` and `QuestionnaireValidationErrorMessageDialogFragment.kt` to optionally disable submit anyway if it's not needed. Default value for the same is `true`. 

Defines a setter in `QuestionnaireFragment.kt` so that it's value can be easily set while creating an instance of QuestionnaireFragment. Add Relevant test methods for the same

**Alternative(s) considered**
N/A

**Type**
Bug fix

**Screenshots (if applicable)**
N/A

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
