### PR TITLE
Update PatchOrdering.kt

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PatchOrdering.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PatchOrdering.kt
@@ -126,21 +126,12 @@ internal object PatchOrdering {
   private fun PatchMapping.findOutgoingReferences(
     localChangeIdToReferenceMap: Map<Long, List<LocalChangeResourceReference>>,
   ): Set<Node> {
+    if (generatedPatch.type == Patch.Type.DELETE) return emptySet()
     val references = mutableSetOf<Node>()
-    when (generatedPatch.type) {
-      Patch.Type.INSERT,
-      Patch.Type.UPDATE, -> {
-        localChanges.forEach { localChange ->
-          localChange.token.ids.forEach { id ->
-            localChangeIdToReferenceMap[id]?.let {
-              references.addAll(it.map { it.resourceReferenceValue })
-            }
-          }
-        }
-      }
-      Patch.Type.DELETE -> {
-        // do nothing
-      }
+    localChanges.forEach { localChange ->
+        localChange.token.ids.flatMap { id ->
+            localChangeIdToReferenceMap[id]?.map { it.resourceReferenceValue } ?: emptyList()
+        }.let { references.addAll(it) }
     }
     return references
   }


### PR DESCRIPTION
**Description**
1. **Early Return for DELETE Type**
We immediately return an empty set if the patch type is DELETE, eliminating unnecessary nesting.
2. **Use of flatMap**
Instead of nested loops, we use flatMap to streamline the process of mapping IDs to their corresponding references. This reduces complexity and improves readability.
3. **Avoiding Redundant Calls**
The use of ?: emptyList() ensures that we handle cases where an ID might not be present in the map without additional checks.

**Type**
Code health

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
