### PR TITLE
Decoupling Database Access in FHIR Patch Generation

### DIFF
--- a/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/db/impl/DatabaseImplTest.kt
@@ -559,8 +559,8 @@ class DatabaseImplTest {
     // Delete the patient created in setup as we only want to upload the patient in this test
     database.deleteUpdates(listOf(TEST_PATIENT_1))
     services.fhirEngine
-      .syncUpload(AllChangesSquashedBundlePut) {
-        it
+      .syncUpload(AllChangesSquashedBundlePut) { lcs, _ ->
+        lcs
           .first { it.resourceId == "remote-patient-3" }
           .let {
             flowOf(

--- a/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
+++ b/engine/src/main/java/com/google/android/fhir/FhirEngine.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.fhir
 
+import com.google.android.fhir.db.LocalChangeResourceReference
 import com.google.android.fhir.db.ResourceNotFoundException
 import com.google.android.fhir.search.Search
 import com.google.android.fhir.sync.ConflictResolver
@@ -121,7 +122,10 @@ interface FhirEngine {
   @Deprecated("To be deprecated.")
   suspend fun syncUpload(
     uploadStrategy: UploadStrategy,
-    upload: (suspend (List<LocalChange>) -> Flow<UploadRequestResult>),
+    upload:
+      (suspend (List<LocalChange>, List<LocalChangeResourceReference>) -> Flow<
+          UploadRequestResult,
+        >),
   ): Flow<SyncUploadProgress>
 
   /**

--- a/engine/src/main/java/com/google/android/fhir/db/Database.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/Database.kt
@@ -215,7 +215,7 @@ internal data class ResourceWithUUID<R>(
   val resource: R,
 )
 
-internal data class LocalChangeResourceReference(
+data class LocalChangeResourceReference(
   val localChangeId: Long,
   val resourceReferenceValue: String,
   val resourceReferencePath: String?,

--- a/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
+++ b/engine/src/main/java/com/google/android/fhir/impl/FhirEngineImpl.kt
@@ -22,6 +22,7 @@ import com.google.android.fhir.FhirEngineProvider
 import com.google.android.fhir.LocalChange
 import com.google.android.fhir.SearchResult
 import com.google.android.fhir.db.Database
+import com.google.android.fhir.db.LocalChangeResourceReference
 import com.google.android.fhir.logicalId
 import com.google.android.fhir.search.Search
 import com.google.android.fhir.search.count
@@ -124,7 +125,10 @@ internal class FhirEngineImpl(private val database: Database, private val contex
 
   override suspend fun syncUpload(
     uploadStrategy: UploadStrategy,
-    upload: (suspend (List<LocalChange>) -> Flow<UploadRequestResult>),
+    upload:
+      (suspend (List<LocalChange>, List<LocalChangeResourceReference>) -> Flow<
+          UploadRequestResult,
+        >),
   ): Flow<SyncUploadProgress> = flow {
     val resourceConsolidator =
       ResourceConsolidatorFactory.byHttpVerb(uploadStrategy.requestGeneratorMode, database)
@@ -140,8 +144,10 @@ internal class FhirEngineImpl(private val database: Database, private val contex
 
     while (localChangeFetcher.hasNext()) {
       val localChanges = localChangeFetcher.next()
+      val localChangeReferences =
+        database.getLocalChangeResourceReferences(localChanges.flatMap { it.token.ids })
       val uploadRequestResult =
-        upload(localChanges)
+        upload(localChanges, localChangeReferences)
           .onEach { result ->
             resourceConsolidator.consolidate(result)
             val newProgress =

--- a/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/FhirSyncWorker.kt
@@ -94,11 +94,7 @@ abstract class FhirSyncWorker(appContext: Context, workerParams: WorkerParameter
           uploader =
             Uploader(
               dataSource = dataSource,
-              patchGenerator =
-                PatchGeneratorFactory.byMode(
-                  getUploadStrategy().patchGeneratorMode,
-                  FhirEngineProvider.getFhirDatabase(applicationContext),
-                ),
+              patchGenerator = PatchGeneratorFactory.byMode(getUploadStrategy().patchGeneratorMode),
               requestGenerator =
                 UploadRequestGeneratorFactory.byMode(getUploadStrategy().requestGeneratorMode),
             ),

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/Uploader.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/Uploader.kt
@@ -17,6 +17,7 @@
 package com.google.android.fhir.sync.upload
 
 import com.google.android.fhir.LocalChange
+import com.google.android.fhir.db.LocalChangeResourceReference
 import com.google.android.fhir.sync.DataSource
 import com.google.android.fhir.sync.ResourceSyncException
 import com.google.android.fhir.sync.upload.patch.PatchGenerator
@@ -49,9 +50,12 @@ internal class Uploader(
   private val patchGenerator: PatchGenerator,
   private val requestGenerator: UploadRequestGenerator,
 ) {
-  suspend fun upload(localChanges: List<LocalChange>) =
+  suspend fun upload(
+    localChanges: List<LocalChange>,
+    localChangesReferences: List<LocalChangeResourceReference>,
+  ) =
     localChanges
-      .let { patchGenerator.generate(it) }
+      .let { patchGenerator.generate(it, localChangesReferences) }
       .let { requestGenerator.generateUploadRequests(it) }
       .asFlow()
       .transformWhile {

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PatchGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PatchGenerator.kt
@@ -17,7 +17,7 @@
 package com.google.android.fhir.sync.upload.patch
 
 import com.google.android.fhir.LocalChange
-import com.google.android.fhir.db.Database
+import com.google.android.fhir.db.LocalChangeResourceReference
 
 /**
  * Generates [Patch]es from [LocalChange]s and output [List<[StronglyConnectedPatchMappings]>] to
@@ -35,17 +35,17 @@ internal interface PatchGenerator {
    * NOTE: different implementations may have requirements on the size of [localChanges] and output
    * certain numbers of [Patch]es.
    */
-  suspend fun generate(localChanges: List<LocalChange>): List<StronglyConnectedPatchMappings>
+  suspend fun generate(
+    localChanges: List<LocalChange>,
+    localChangesReferences: List<LocalChangeResourceReference>,
+  ): List<StronglyConnectedPatchMappings>
 }
 
 internal object PatchGeneratorFactory {
-  fun byMode(
-    mode: PatchGeneratorMode,
-    database: Database,
-  ): PatchGenerator =
+  fun byMode(mode: PatchGeneratorMode): PatchGenerator =
     when (mode) {
       is PatchGeneratorMode.PerChange -> PerChangePatchGenerator
-      is PatchGeneratorMode.PerResource -> PerResourcePatchGenerator.with(database)
+      is PatchGeneratorMode.PerResource -> PerResourcePatchGenerator
     }
 }
 

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PatchOrdering.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PatchOrdering.kt
@@ -67,15 +67,20 @@ internal object PatchOrdering {
     get() = "${generatedPatch.resourceType}/${generatedPatch.resourceId}"
 
   /**
-   * Order the [PatchMapping] so that if the resource A has outgoing references {B,C} (CREATE) and
-   * {D} (UPDATE), then B,C needs to go before the resource A so that referential integrity is
-   * retained. Order of D shouldn't matter for the purpose of referential integrity.
+   * Orders the list of [PatchMapping]s to maintain referential integrity.
    *
-   * @return A ordered list of the [StronglyConnectedPatchMappings] containing:
-   * - [StronglyConnectedPatchMappings] with single value for the [PatchMapping] based on the
-   *   references to other [PatchMapping] if the mappings are acyclic
-   * - [StronglyConnectedPatchMappings] with multiple values for [PatchMapping]s based on the
-   *   references to other [PatchMapping]s if the mappings are cyclic.
+   * This function ensures that if resource A has a CREATE reference to resources B and C, then B
+   * and C appear before A in the ordered list. UPDATE references are not considered as they do not
+   * impact referential integrity.
+   *
+   * The function uses Strongly Connected Components (SCC) to handle cyclic dependencies.
+   *
+   * @return A list of [StronglyConnectedPatchMappings]:
+   *     - Each [StronglyConnectedPatchMappings] object represents an SCC.
+   *     - If the graph of references is acyclic, each [StronglyConnectedPatchMappings] will contain
+   *       a single [PatchMapping].
+   *     - If the graph has cycles, a [StronglyConnectedPatchMappings] object will contain multiple
+   *       [PatchMapping]s involved in the cycle.
    */
   fun List<PatchMapping>.sccOrderByReferences(
     localChangeResourceReferences: List<LocalChangeResourceReference>,

--- a/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PerChangePatchGenerator.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/upload/patch/PerChangePatchGenerator.kt
@@ -17,6 +17,7 @@
 package com.google.android.fhir.sync.upload.patch
 
 import com.google.android.fhir.LocalChange
+import com.google.android.fhir.db.LocalChangeResourceReference
 
 /**
  * Generates a [Patch] for each [LocalChange].
@@ -27,6 +28,7 @@ import com.google.android.fhir.LocalChange
 internal object PerChangePatchGenerator : PatchGenerator {
   override suspend fun generate(
     localChanges: List<LocalChange>,
+    localChangesReferences: List<LocalChangeResourceReference>,
   ): List<StronglyConnectedPatchMappings> =
     localChanges
       .map {

--- a/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
+++ b/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
@@ -24,6 +24,7 @@ import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.LocalChange
 import com.google.android.fhir.LocalChangeToken
 import com.google.android.fhir.SearchResult
+import com.google.android.fhir.db.LocalChangeResourceReference
 import com.google.android.fhir.search.Search
 import com.google.android.fhir.sync.ConflictResolver
 import com.google.android.fhir.sync.DataSource
@@ -158,10 +159,11 @@ internal object TestFhirEngineImpl : FhirEngine {
 
   override suspend fun syncUpload(
     uploadStrategy: UploadStrategy,
-    upload: suspend (List<LocalChange>) -> Flow<UploadRequestResult>,
+    upload:
+      suspend (List<LocalChange>, List<LocalChangeResourceReference>) -> Flow<UploadRequestResult>,
   ): Flow<SyncUploadProgress> = flow {
     emit(SyncUploadProgress(1, 1))
-    upload(getLocalChanges(ResourceType.Patient, "123")).collect {
+    upload(getLocalChanges(ResourceType.Patient, "123"), emptyList()).collect {
       when (it) {
         is UploadRequestResult.Success -> emit(SyncUploadProgress(0, 1))
         is UploadRequestResult.Failure -> emit(SyncUploadProgress(1, 1, it.uploadError))

--- a/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/impl/FhirEngineImplTest.kt
@@ -323,13 +323,13 @@ class FhirEngineImplTest {
     val emittedProgress = mutableListOf<SyncUploadProgress>()
 
     fhirEngine
-      .syncUpload(UploadStrategy.AllChangesSquashedBundlePut) {
-        localChanges.addAll(it)
+      .syncUpload(UploadStrategy.AllChangesSquashedBundlePut) { lcs, _ ->
+        localChanges.addAll(lcs)
         flowOf(
           UploadRequestResult.Success(
             listOf(
               ResourceUploadResponseMapping(
-                it,
+                lcs,
                 TEST_PATIENT_1,
               ),
             ),
@@ -356,10 +356,10 @@ class FhirEngineImplTest {
     val emittedProgress = mutableListOf<SyncUploadProgress>()
     val uploadError = ResourceSyncException(ResourceType.Patient, FHIRException("Did not work"))
     fhirEngine
-      .syncUpload(UploadStrategy.AllChangesSquashedBundlePut) {
+      .syncUpload(UploadStrategy.AllChangesSquashedBundlePut) { lcs, _ ->
         flowOf(
           UploadRequestResult.Failure(
-            it,
+            lcs,
             uploadError,
           ),
         )
@@ -767,12 +767,12 @@ class FhirEngineImplTest {
   fun `test local changes are consumed when using POST upload strategy`() = runBlocking {
     assertThat(services.database.getLocalChangesCount()).isEqualTo(1)
     fhirEngine
-      .syncUpload(UploadStrategy.SingleResourcePost) {
+      .syncUpload(UploadStrategy.SingleResourcePost) { lcs, _ ->
         flowOf(
           UploadRequestResult.Success(
             listOf(
               ResourceUploadResponseMapping(
-                it,
+                lcs,
                 TEST_PATIENT_1,
               ),
             ),

--- a/engine/src/test/java/com/google/android/fhir/sync/FhirSynchronizerTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/FhirSynchronizerTest.kt
@@ -70,7 +70,7 @@ class FhirSynchronizerTest {
   fun `synchronize should return Success on successful download and upload`() =
     runTest(UnconfinedTestDispatcher()) {
       `when`(downloader.download()).thenReturn(flowOf(DownloadState.Success(listOf(), 10, 10)))
-      `when`(uploader.upload(any()))
+      `when`(uploader.upload(any(), any()))
         .thenReturn(
           flowOf(UploadRequestResult.Success(listOf())),
         )
@@ -97,7 +97,7 @@ class FhirSynchronizerTest {
     runTest(UnconfinedTestDispatcher()) {
       val error = ResourceSyncException(ResourceType.Patient, Exception("Download error"))
       `when`(downloader.download()).thenReturn(flowOf(DownloadState.Failure(error)))
-      `when`(uploader.upload(any()))
+      `when`(uploader.upload(any(), any()))
         .thenReturn(
           flowOf(UploadRequestResult.Success(listOf())),
         )
@@ -122,7 +122,7 @@ class FhirSynchronizerTest {
     runTest(UnconfinedTestDispatcher()) {
       `when`(downloader.download()).thenReturn(flowOf(DownloadState.Success(listOf(), 10, 10)))
       val error = ResourceSyncException(ResourceType.Patient, Exception("Upload error"))
-      `when`(uploader.upload(any()))
+      `when`(uploader.upload(any(), any()))
         .thenReturn(flowOf(UploadRequestResult.Failure(listOf(), error)))
 
       val emittedValues = mutableListOf<SyncJobStatus>()
@@ -148,7 +148,7 @@ class FhirSynchronizerTest {
   fun `synchronize multiple invocations should execute in order`() =
     runTest(UnconfinedTestDispatcher()) {
       `when`(downloader.download()).thenReturn(flowOf(DownloadState.Success(listOf(), 0, 0)))
-      `when`(uploader.upload(any()))
+      `when`(uploader.upload(any(), any()))
         .thenReturn(
           flowOf(
             UploadRequestResult.Success(

--- a/engine/src/test/java/com/google/android/fhir/sync/upload/UploaderTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/sync/upload/UploaderTest.kt
@@ -65,9 +65,8 @@ class UploaderTest {
     MockitoAnnotations.openMocks(this)
     runTest { whenever(database.getLocalChangeResourceReferences(any())).thenReturn(emptyList()) }
 
-    perResourcePatchGenerator =
-      PatchGeneratorFactory.byMode(PatchGeneratorMode.PerResource, database)
-    perChangePatchGenerator = PatchGeneratorFactory.byMode(PatchGeneratorMode.PerChange, database)
+    perResourcePatchGenerator = PatchGeneratorFactory.byMode(PatchGeneratorMode.PerResource)
+    perChangePatchGenerator = PatchGeneratorFactory.byMode(PatchGeneratorMode.PerChange)
   }
 
   @Test
@@ -98,7 +97,7 @@ class UploaderTest {
             perResourcePatchGenerator,
             bundleUploadRequestGenerator,
           )
-          .upload(localChangesToTestSuccess)
+          .upload(localChangesToTestSuccess, emptyList())
           .toList()
 
       // With BundleUploadRequestGenerator, all patches will be squashed into 1 request (default
@@ -156,7 +155,7 @@ class UploaderTest {
             perChangePatchGenerator,
             bundleUploadRequestGenerator,
           )
-          .upload(localChangesToTestSuccess)
+          .upload(localChangesToTestSuccess, emptyList())
           .toList()
 
       // With BundleUploadRequestGenerator, all patches will be squashed into 1 request (default
@@ -196,7 +195,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           bundleUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -221,7 +220,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           bundleUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -236,7 +235,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           bundleUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -252,7 +251,7 @@ class UploaderTest {
             perResourcePatchGenerator,
             bundleUploadRequestGenerator,
           )
-          .upload(localChangesToTestFail)
+          .upload(localChangesToTestFail, emptyList())
           .toList()
 
       assertThat(result).hasSize(1)
@@ -267,7 +266,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           bundleUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -299,7 +298,7 @@ class UploaderTest {
             perResourcePatchGenerator,
             urlUploadRequestGenerator,
           )
-          .upload(localChangesToTestSuccess)
+          .upload(localChangesToTestSuccess, emptyList())
           .toList()
 
       // With UrlUploadRequestGenerator, patch-per-resource is mapped to one url request. So total
@@ -359,7 +358,7 @@ class UploaderTest {
             perChangePatchGenerator,
             urlUploadRequestGenerator,
           )
-          .upload(localChangesToTestSuccess)
+          .upload(localChangesToTestSuccess, emptyList())
           .toList()
 
       // With UrlUploadRequestGenerator, patch-per-resource is mapped to one url request. So total
@@ -405,7 +404,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           urlUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -430,7 +429,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           urlUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -445,7 +444,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           urlUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -460,7 +459,7 @@ class UploaderTest {
           perResourcePatchGenerator,
           urlUploadRequestGenerator,
         )
-        .upload(localChangesToTestFail)
+        .upload(localChangesToTestFail, emptyList())
         .toList()
 
     assertThat(result).hasSize(1)
@@ -504,7 +503,7 @@ class UploaderTest {
             perResourcePatchGenerator,
             bundleUploadRequestGeneratorWithUnityBundleSize,
           )
-          .upload(localChangesToTestSuccess)
+          .upload(localChangesToTestSuccess, emptyList())
           .toList()
 
       // With BundleUploadRequestGenerator and bundleSize=1, each patch is mapped to a bundle


### PR DESCRIPTION
To ensure all database operations originate from the `FhirEngineImpl` class, the synchronization functions should be refactored.  Instead of directly accessing the database within the PatchGenerator class, the lambda functions used in the synchronization process should be modified to accept a `List<LocalChangeResourceReference>` object as input. This list will contain references to the resources that require synchronization, allowing FhirEngineImpl to handle the necessary database interactions.

This approach centralizes database access in `FhirEngineImpl`, improving code organization and maintainability.

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Clear and concise code change description.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**

- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
