### PR TITLE
Isolate unsafe code in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
   # Build will compile APK, test APK and run tests, lint, etc.
   build:
     runs-on: ubuntu-22.04-8core
+    container:
+      image: ubuntu:22.04
+      options: --security-opt=no-new-privileges
     timeout-minutes: 60
     permissions:
       actions: read


### PR DESCRIPTION
**Description**
I have introduced isolation for self-hosted runner, so it is not possible for malicious attacker to persist in the self-hosted runner. Otherwise it might lead to backdoors.

**Alternative(s) considered**
Probably we could use VMs or github-hosted runners, but this solution seems more trivial.

**Type**
Choose one: Other

**Screenshots (if applicable)**

**Checklist**

- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
