### PR TITLE
Update enqueued state as current state after iteration completion in the periodic sync.

### DIFF
--- a/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
+++ b/engine/src/androidTest/java/com/google/android/fhir/sync/SyncInstrumentedTest.kt
@@ -237,7 +237,7 @@ class SyncInstrumentedTest {
         .transformWhile {
           states.add(it)
           emit(it)
-          it.currentSyncJobStatus !is CurrentSyncJobStatus.Succeeded
+          it.currentSyncJobStatus !is CurrentSyncJobStatus.Enqueued
         }
         .shareIn(this, SharingStarted.Eagerly, 5)
     }
@@ -246,7 +246,7 @@ class SyncInstrumentedTest {
       .isInstanceOf(CurrentSyncJobStatus.Running::class.java)
     assertThat(states.first().lastSyncJobStatus).isNull()
     assertThat(states.last().currentSyncJobStatus)
-      .isInstanceOf(CurrentSyncJobStatus.Succeeded::class.java)
+      .isInstanceOf(CurrentSyncJobStatus.Enqueued::class.java)
     assertThat(states.last().lastSyncJobStatus)
       .isInstanceOf(LastSyncJobStatus.Succeeded::class.java)
   }
@@ -268,7 +268,7 @@ class SyncInstrumentedTest {
         .transformWhile {
           states.add(it)
           emit(it)
-          it.currentSyncJobStatus !is CurrentSyncJobStatus.Failed
+          it.currentSyncJobStatus !is CurrentSyncJobStatus.Enqueued
         }
         .shareIn(this, SharingStarted.Eagerly, 5)
     }
@@ -277,7 +277,7 @@ class SyncInstrumentedTest {
       .isInstanceOf(CurrentSyncJobStatus.Running::class.java)
     assertThat(states.first().lastSyncJobStatus).isNull()
     assertThat(states.last().currentSyncJobStatus)
-      .isInstanceOf(CurrentSyncJobStatus.Failed::class.java)
+      .isInstanceOf(CurrentSyncJobStatus.Enqueued::class.java)
     assertThat(states.last().lastSyncJobStatus).isInstanceOf(LastSyncJobStatus.Failed::class.java)
   }
 
@@ -297,7 +297,7 @@ class SyncInstrumentedTest {
         )
         .transformWhile {
           emit(it)
-          it.currentSyncJobStatus !is CurrentSyncJobStatus.Succeeded
+          it.currentSyncJobStatus !is CurrentSyncJobStatus.Enqueued
         }
         .shareIn(this, SharingStarted.Eagerly, 5)
     }

--- a/engine/src/main/java/com/google/android/fhir/sync/Sync.kt
+++ b/engine/src/main/java/com/google/android/fhir/sync/Sync.kt
@@ -272,8 +272,7 @@ object Sync {
         when (workRequest) {
           WorkRequest.ONE_TIME ->
             handleNullWorkManagerStatusForOneTimeSync(workInfoState, syncJobStatusFromDataStore)
-          WorkRequest.PERIODIC ->
-            handleNullWorkManagerStatusForPeriodicSync(workInfoState, syncJobStatusFromDataStore)
+          WorkRequest.PERIODIC -> handleNullWorkManagerStatusForPeriodicSync(workInfoState)
         }
       }
       else -> error("Inconsistent syncJobStatus: $syncJobStatusFromWorkManager.")
@@ -320,14 +319,10 @@ object Sync {
    */
   private fun handleNullWorkManagerStatusForPeriodicSync(
     workInfoState: WorkInfo.State,
-    syncJobStatusFromDataStore: SyncJobStatus?,
   ): CurrentSyncJobStatus =
     when (workInfoState) {
       RUNNING -> Running(SyncJobStatus.Started())
-      ENQUEUED -> {
-        syncJobStatusFromDataStore?.let { mapDataStoreSyncJobStatusToCurrentSyncJobStatus(it) }
-          ?: Enqueued
-      }
+      ENQUEUED -> Enqueued
       CANCELLED -> Cancelled
       BLOCKED -> CurrentSyncJobStatus.Blocked
       else -> error("Inconsistent WorkInfo.State in periodic sync : $workInfoState.")


### PR DESCRIPTION
…the periodic sync.

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Update enqueued state as current state after iteration completion in the periodic sync.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
