### PR TITLE
Fix code formatting for data capture getting started

### DIFF
--- a/build-docs.bash
+++ b/build-docs.bash
@@ -28,4 +28,5 @@ mkdir -p site/
 # is up-to-date with the Pipfile before installing. If it's not, it will fail the
 # installation. This is useful for ensuring strict dependency control during CI.
 pipenv install --deploy
+pipenv run pip install -U setuptools
 pipenv run mkdocs build --strict

--- a/docs/use/SDCL/Getting-Started.md
+++ b/docs/use/SDCL/Getting-Started.md
@@ -45,7 +45,7 @@ file. If you need one, the FHIR specification has
 See the QuestionnaireFragment guide for details. To render a questionnaire in
 your app, follow these steps:
 
-* Add a `FragmentContainerView` to your activity's layout to contain the
+1. Add a `FragmentContainerView` to your activity's layout to contain the
     Questionnaire.
 
 ```xml

--- a/docs/use/SDCL/Getting-Started.md
+++ b/docs/use/SDCL/Getting-Started.md
@@ -76,7 +76,7 @@ val bundle = bundleOf( QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to
 questionnaireJsonString )
 ```
 
-* Set the fragment to the `FragmentContainerView`.
+1. Set the fragment to the `FragmentContainerView`.
 
 ```kotlin
 if (savedInstanceState == null) {

--- a/docs/use/SDCL/Getting-Started.md
+++ b/docs/use/SDCL/Getting-Started.md
@@ -62,7 +62,7 @@ your app, follow these steps:
 </androidx.constraintlayout.widget.ConstraintLayout>
 ```
 
-* Create a bundle with the JSON questionnaire content for the fragment, in
+1. Create a bundle with the JSON questionnaire content for the fragment, in
     this case as a `String` read from a JSON file stored in the `assets` folder.
 
 ```kotlin

--- a/docs/use/SDCL/Getting-Started.md
+++ b/docs/use/SDCL/Getting-Started.md
@@ -45,47 +45,47 @@ file. If you need one, the FHIR specification has
 See the QuestionnaireFragment guide for details. To render a questionnaire in
 your app, follow these steps:
 
-1. Add a `FragmentContainerView` to your activity's layout to contain the
+* Add a `FragmentContainerView` to your activity's layout to contain the
     Questionnaire.
 
-    ```xml
-    <?xml version="1.0" encoding="utf-8"?>
-    <androidx.constraintlayout.widget.ConstraintLayout
-    ... >
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+... >
 
-    <androidx.fragment.app.FragmentContainerView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/fragment_container_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    ```
+</androidx.constraintlayout.widget.ConstraintLayout>
+```
 
-1. Create a bundle with the JSON questionnaire content for the fragment, in
+* Create a bundle with the JSON questionnaire content for the fragment, in
     this case as a `String` read from a JSON file stored in the `assets` folder.
 
-    ```kotlin
-    // Small questionnaires can be read directly as a string, larger ones
-    // should be passed as a URI instead.
-    val questionnaireJsonString =
-    application.assets.open("questionnaire.json")
-        .bufferedReader().use { it.readText() }
+```kotlin
+// Small questionnaires can be read directly as a string, larger ones
+// should be passed as a URI instead.
+val questionnaireJsonString =
+application.assets.open("questionnaire.json")
+    .bufferedReader().use { it.readText() }
 
-    val bundle = bundleOf( QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to
-    questionnaireJsonString )
-    ```
+val bundle = bundleOf( QuestionnaireFragment.EXTRA_QUESTIONNAIRE_JSON_STRING to
+questionnaireJsonString )
+```
 
-1. Set the fragment to the `FragmentContainerView`.
+* Set the fragment to the `FragmentContainerView`.
 
-    ```kotlin
-    if (savedInstanceState == null) {
-        supportFragmentManager.commit {
-            setReorderingAllowed(true)
-            add<QuestionnaireFragment>(R.id.fragment_container_view, args = bundle)
-        }
+```kotlin
+if (savedInstanceState == null) {
+    supportFragmentManager.commit {
+        setReorderingAllowed(true)
+        add<QuestionnaireFragment>(R.id.fragment_container_view, args = bundle)
     }
-    ```
+}
+```
 
 ## Get a QuestionnaireResponse
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Straightforward changes for documentation format, so it doesn't attach any issue.

**Description**
  
Mkdocs doesn't support fenced code block in number list,
so this CL changes number list to unordered lists and
removes indent for fenced code block to make it work.

This Cl also fixes running error of `build-docs.bash` on Ubuntu 22.04 that I faced
by updating setuptools before building mkdocs.

**Alternative(s) considered**
Not.

**Type**
Documentation

**Screenshots (if applicable)**

**Checklist**

- [X] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [X] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [X] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [X] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
