### PR TITLE
Include min and max values in the validation message in a number question if the values are in the extension

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
@@ -24,6 +24,8 @@ import android.text.InputType
 import androidx.annotation.RequiresApi
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.getValidationErrorMessage
+import com.google.android.fhir.datacapture.validation.MAX_VALUE_EXTENSION_URL
+import com.google.android.fhir.datacapture.validation.MIN_VALUE_EXTENSION_URL
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -38,6 +40,22 @@ internal object EditTextIntegerViewHolderFactory :
       QuestionnaireItemEditTextViewHolderDelegate(
         InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED,
       ) {
+
+      private val minValue: Int by lazy {
+        getExtensionValueOrDefault(MIN_VALUE_EXTENSION_URL, Int.MIN_VALUE)
+      }
+
+      private val maxValue: Int by lazy {
+        getExtensionValueOrDefault(MAX_VALUE_EXTENSION_URL, Int.MAX_VALUE)
+      }
+
+      private fun getExtensionValueOrDefault(url: String, defaultValue: Int): Int {
+        return questionnaireViewItem.questionnaireItem.extension
+          .find { it.url == url }
+          ?.let { (it.value as? IntegerType)?.value }
+          ?: defaultValue
+      }
+
       override suspend fun handleInput(
         editable: Editable,
         questionnaireViewItem: QuestionnaireViewItem,
@@ -95,8 +113,8 @@ internal object EditTextIntegerViewHolderFactory :
           textInputLayout.error =
             textInputLayout.context.getString(
               R.string.integer_format_validation_error_msg,
-              formatInteger(Int.MIN_VALUE),
-              formatInteger(Int.MAX_VALUE),
+              formatInteger(minValue),
+              formatInteger(maxValue),
             )
         }
       }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2757

**Description**
Show  `number must be between <INT_MIN> and <INT_MAX>` when input is not an integer.
Use the max and min values in the extension if they are defined. 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
