### PR TITLE
Add custom callback for autocomplete

### DIFF
--- a/catalog/src/main/java/com/google/android/fhir/catalog/CatalogApplication.kt
+++ b/catalog/src/main/java/com/google/android/fhir/catalog/CatalogApplication.kt
@@ -21,7 +21,10 @@ import ca.uhn.fhir.context.FhirContext
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.FhirEngineConfiguration
 import com.google.android.fhir.FhirEngineProvider
+import com.google.android.fhir.datacapture.CustomCallback.AutoCompleteCallback
+import com.google.android.fhir.datacapture.CustomCallbackType
 import com.google.android.fhir.datacapture.DataCaptureConfig
+import com.google.android.fhir.datacapture.views.factories.AutoCompleteViewAnswerOption
 import com.google.android.fhir.search.search
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -44,6 +47,15 @@ class CatalogApplication : Application(), DataCaptureConfig.Provider {
         xFhirQueryResolver = { fhirEngine.search(it).map { it.resource } },
         questionnaireItemViewHolderFactoryMatchersProviderFactory =
           ContribQuestionnaireItemViewHolderFactoryMatchersProviderFactory,
+        callbacks = mapOf(Pair(CustomCallbackType.AUTO_COMPLETE, AutoCompleteCallback(
+          callback = { query ->
+            run {
+              listOf(AutoCompleteViewAnswerOption("a", "Type 2 Diabetes Mellitus"),
+                AutoCompleteViewAnswerOption("b", "Test")
+                )
+            }
+          }
+        )))
       )
 
     CoroutineScope(Dispatchers.IO).launch {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/DataCaptureConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,12 @@ data class DataCaptureConfig(
   var questionnaireItemViewHolderFactoryMatchersProviderFactory:
     QuestionnaireItemViewHolderFactoryMatchersProviderFactory? =
     null,
+
+  /**
+   * A [CustomCallback] may be set by the client to override the behaviour of an existing component
+   * in the sdc. Currently only supports [CustomCallbackType.AUTO_COMPLETE].
+   */
+  var callbacks: Map<CustomCallbackType, CustomCallback>? = null,
 ) {
 
   /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireEditAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import com.google.android.fhir.datacapture.extensions.shouldUseDialog
 import com.google.android.fhir.datacapture.views.NavigationViewHolder
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
 import com.google.android.fhir.datacapture.views.factories.AttachmentViewHolderFactory
+import com.google.android.fhir.datacapture.views.factories.AutoCompleteViewAnswerOption
 import com.google.android.fhir.datacapture.views.factories.AutoCompleteViewHolderFactory
 import com.google.android.fhir.datacapture.views.factories.BooleanChoiceViewHolderFactory
 import com.google.android.fhir.datacapture.views.factories.CheckBoxGroupViewHolderFactory
@@ -390,4 +391,13 @@ internal object DiffCallbacks {
           oldItem.item.hasTheSameValidationResult(newItem.item)
       }
     }
+}
+
+sealed class CustomCallback {
+  data class AutoCompleteCallback(val callback: (String) -> List<AutoCompleteViewAnswerOption>) :
+    CustomCallback()
+}
+
+enum class CustomCallbackType {
+  AUTO_COMPLETE,
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,6 +94,10 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
   }
   private val externalValueSetResolver: ExternalAnswerValueSetResolver? by lazy {
     DataCapture.getConfiguration(application).valueSetResolverExternal
+  }
+
+  private val callbacks: Map<CustomCallbackType, CustomCallback>? by lazy {
+    DataCapture.getConfiguration(application).callbacks
   }
 
   /** The current questionnaire as questions are being answered. */
@@ -985,6 +989,7 @@ internal class QuestionnaireViewModel(application: Application, state: SavedStat
               ),
             isHelpCardOpen = isHelpCard && isHelpCardOpen,
             helpCardStateChangedCallback = helpCardStateChangedCallback,
+            callbacks = callbacks,
           ),
         )
       add(question)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireViewItem.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/QuestionnaireViewItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package com.google.android.fhir.datacapture.views
 import android.content.Context
 import android.text.Spanned
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.fhir.datacapture.CustomCallback
+import com.google.android.fhir.datacapture.CustomCallbackType
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.displayString
 import com.google.android.fhir.datacapture.extensions.isHelpCode
@@ -93,6 +95,7 @@ data class QuestionnaireViewItem(
   val helpCardStateChangedCallback: (Boolean, QuestionnaireResponseItemComponent) -> Unit =
     { _, _ ->
     },
+  val callbacks: Map<CustomCallbackType, CustomCallback>? = null,
 ) {
 
   fun getQuestionnaireResponseItem(): QuestionnaireResponseItemComponent = questionnaireResponseItem

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/AutoCompleteViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/AutoCompleteViewHolderFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@
 package com.google.android.fhir.datacapture.views.factories
 
 import android.view.View
+import android.widget.AutoCompleteTextView
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.get
+import com.google.android.fhir.datacapture.CustomCallback.AutoCompleteCallback
+import com.google.android.fhir.datacapture.CustomCallbackType
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.displayString
 import com.google.android.fhir.datacapture.extensions.identifierString
@@ -33,6 +36,7 @@ import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.android.material.textfield.TextInputLayout
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertNotNull
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
@@ -464,5 +468,42 @@ class AutoCompleteViewHolderFactoryTest {
       .isEmpty()
     assertThat(viewHolder.itemView.findViewById<TextView>(R.id.required_optional_text).visibility)
       .isEqualTo(View.GONE)
+  }
+
+  @Test
+  fun givenCustomCallback_thenDisplayCallbackResponse() {
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { text = "Question" },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+        questionViewTextConfiguration = QuestionTextConfiguration(showOptionalText = false),
+        callbacks =
+          mapOf(
+            Pair(
+              CustomCallbackType.AUTO_COMPLETE,
+              AutoCompleteCallback(
+                callback = { _ ->
+                  run {
+                    listOf(
+                      AutoCompleteViewAnswerOption("a", "Answer A"),
+                      AutoCompleteViewAnswerOption("b", "Answer B"),
+                    )
+                  }
+                },
+              ),
+            ),
+          ),
+      ),
+    )
+
+    val autoCompleteTextView =
+      viewHolder.itemView.findViewById<AutoCompleteTextView>(R.id.autoCompleteTextView)
+
+    autoCompleteTextView.setText("t2")
+    val adapter = autoCompleteTextView.adapter
+    assertNotNull(adapter)
+    assertThat(adapter.count).isEqualTo(2)
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2738 

**Description**
Adds the ability for the client to pass a custom callback to AutoComplete for dynamic AutoComplete answer resolution

**Alternative(s) considered**
NA

**Type**
Feature

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
