### PR TITLE
Fix validation message for number fields to consider min and max values

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextDecimalViewHolderFactory.kt
@@ -76,8 +76,14 @@ internal object EditTextDecimalViewHolderFactory :
           )
         // Update error message if draft answer present
         if (questionnaireViewItem.draftAnswer != null) {
+          val minValue = questionnaireViewItem.minAnswerValue?.toString() ?: DecimalType(Int.MIN_VALUE).toString()
+          val maxValue = questionnaireViewItem.maxAnswerValue?.toString() ?: DecimalType(Int.MAX_VALUE).toString()
           textInputLayout.error =
-            textInputLayout.context.getString(R.string.decimal_format_validation_error_msg)
+            textInputLayout.context.getString(
+              R.string.decimal_format_validation_error_msg,
+              minValue,
+              maxValue
+            )
         }
       }
     }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextIntegerViewHolderFactory.kt
@@ -92,11 +92,13 @@ internal object EditTextIntegerViewHolderFactory :
           )
         // Update error message if draft answer present
         if (questionnaireViewItem.draftAnswer != null) {
+          val minValue = questionnaireViewItem.minAnswerValue?.toString() ?: IntegerType(Int.MIN_VALUE).toString()
+          val maxValue = questionnaireViewItem.maxAnswerValue?.toString() ?: IntegerType(Int.MAX_VALUE).toString()
           textInputLayout.error =
             textInputLayout.context.getString(
               R.string.integer_format_validation_error_msg,
-              formatInteger(Int.MIN_VALUE),
-              formatInteger(Int.MAX_VALUE),
+              minValue,
+              maxValue
             )
         }
       }


### PR DESCRIPTION
Update validation messages for number fields to consider min and max values from the questionnaire item.

* Modify `EditTextDecimalViewHolderFactory.kt` to include min and max values in the validation message for decimal fields.
* Modify `EditTextIntegerViewHolderFactory.kt` to include min and max values in the validation message for integer fields.
