### PR TITLE
Fix version number under Questionnaire basics section

### DIFF
--- a/docs/use/SDCL/Author-questionnaires.md
+++ b/docs/use/SDCL/Author-questionnaires.md
@@ -93,7 +93,7 @@ Let's look at a more complex Questionnaire, focused on the top-level `item` elem
 
 There are [several options](https://www.hl7.org/fhir/valueset-item-type.html) for the `type` member of `item` objects. The Structured Data Capture Library selects the UI component to use when rendering based on the type. This example also uses the `group` type where `text` acts as section headers and child item objects are logically grouped.
 
-Some Questionnaire elements control validation or rendering logic. For example, item `1.1` is required, and item `2.1.1` is only shown if item `2.1` is `true`.
+Some Questionnaire elements control validation or rendering logic. For example, item `1.1` is required, and item `2.2` is only shown if item `2.1` is `true`.
 
 The next example of an item object uses extensions from the SDC implementation guide and also demonstrates the `choice` type:
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Update version number to `2.2` instead of `2.1.1` in documentation under `Questionnaire basics` section as according to the JSON snippet provided, item `2.2` is only shown if item `2.1` is `true`

**Type**
Documentation

**Screenshots (if applicable)**
N/A

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
