### PR TITLE
Upgrade Gradle Build Tools, Update Gradle Wrapper, and Migrate JVM Toolchain to Java 17

### DIFF
--- a/codelabs/datacapture/app/build.gradle.kts
+++ b/codelabs/datacapture/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
     }
 
     packaging { resources.excludes.addAll(listOf("META-INF/ASL-2.0.txt", "META-INF/LGPL-3.0.txt")) }
-    kotlin { jvmToolchain(11) }
+    kotlin { jvmToolchain(17) }
 }
 
 dependencies {

--- a/codelabs/datacapture/build.gradle.kts
+++ b/codelabs/datacapture/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.2")
+        classpath("com.android.tools.build:gradle:8.7.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/codelabs/datacapture/gradle/wrapper/gradle-wrapper.properties
+++ b/codelabs/datacapture/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/codelabs/engine/app/build.gradle.kts
+++ b/codelabs/engine/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 
     packaging { resources.excludes.addAll(listOf("META-INF/ASL-2.0.txt", "META-INF/LGPL-3.0.txt")) }
-    kotlin { jvmToolchain(11) }
+    kotlin { jvmToolchain(17) }
 }
 
 dependencies {
@@ -51,4 +51,5 @@ dependencies {
 
     implementation("com.google.android.fhir:engine:1.1.0")
     implementation("androidx.fragment:fragment-ktx:1.8.3")
+    implementation("com.google.android.fhir:engine:1.1.0")
 }

--- a/codelabs/engine/build.gradle.kts
+++ b/codelabs/engine/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.2")
+        classpath("com.android.tools.build:gradle:8.7.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/codelabs/engine/gradle/wrapper/gradle-wrapper.properties
+++ b/codelabs/engine/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade Gradle build tools to version 8.7.1
- Update Gradle wrapper to version 8.9
- Migrate JVM toolchain from Java 11 to Java 17

Fixes #1616

I mean create a better detailed PR description - Upgrade Gradle build tools to version 8.7.1 - Update Gradle wrapper to version 8.9 - Migrate JVM toolchain from Java 11 to Java 17 Fixes #1616

Upgrade Gradle Build Tools to Version 8.7.1:
- Updated the build.gradle.kts files to use Gradle build tools version 8.7.1. This upgrade includes various bug fixes and performance improvements that enhance the overall build process.

Update Gradle Wrapper to Version 8.9:
- Updated the gradle-wrapper.properties files to use Gradle wrapper version 8.9. This update ensures that the project benefits from the latest Gradle features and improvements.

Migrate JVM Toolchain from Java 11 to Java 17:
- Modified the build.gradle.kts files to migrate the JVM toolchain from Java 11 to Java 17. This migration leverages the new language features and performance enhancements introduced in Java 17, ensuring the project remains up-to-date with the latest Java developments.