### PR TITLE
Disable typing when dropdown has answer

### DIFF
--- a/datacapture/src/main/res/drawable/ic_clear.xml
+++ b/datacapture/src/main/res/drawable/ic_clear.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal"
+>
+  <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"
+    />
+</vector>

--- a/datacapture/src/main/res/layout/drop_down_view.xml
+++ b/datacapture/src/main/res/layout/drop_down_view.xml
@@ -35,33 +35,37 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+    >
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/text_input_layout"
             style="?attr/questionnaireDropdownLayoutStyle"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+        >
 
             <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/auto_complete"
                 style="?attr/questionnaireDropDownSelectedTextStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:drawablePadding="@dimen/icon_drawable_padding" />
+                android:drawablePadding="@dimen/icon_drawable_padding"
+            />
 
         </com.google.android.material.textfield.TextInputLayout>
 
-            <ImageView
-                android:id="@+id/clear_input_icon"
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:layout_marginTop="@dimen/drop_down_clear_icon_margin_top"
-                android:layout_marginEnd="@dimen/drop_down_clear_icon_margin_end"
-                android:layout_gravity="end|center_vertical"
-                android:src="@drawable/ic_clear"
-                android:scaleType="fitCenter"
-                app:tint="#999999"/>
+        <ImageView
+            android:id="@+id/clear_input_icon"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_marginTop="@dimen/drop_down_clear_icon_margin_top"
+            android:layout_marginEnd="@dimen/drop_down_clear_icon_margin_end"
+            android:layout_gravity="end|center_vertical"
+            android:src="@drawable/ic_clear"
+            android:scaleType="fitCenter"
+            app:tint="#999999"
+        />
 
     </FrameLayout>
 

--- a/datacapture/src/main/res/layout/drop_down_view.xml
+++ b/datacapture/src/main/res/layout/drop_down_view.xml
@@ -13,6 +13,7 @@
 -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="@dimen/item_margin_horizontal"
@@ -32,21 +33,36 @@
         android:layout_height="wrap_content"
     />
 
-    <com.google.android.material.textfield.TextInputLayout
-        style="?attr/questionnaireDropdownLayoutStyle"
-        android:id="@+id/text_input_layout"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-    >
+        android:layout_height="wrap_content">
 
-        <com.google.android.material.textfield.MaterialAutoCompleteTextView
-            style="?attr/questionnaireDropDownSelectedTextStyle"
-            android:id="@+id/auto_complete"
-            android:drawablePadding="@dimen/icon_drawable_padding"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/text_input_layout"
+            style="?attr/questionnaireDropdownLayoutStyle"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-        />
+            android:layout_height="wrap_content">
 
-    </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/auto_complete"
+                style="?attr/questionnaireDropDownSelectedTextStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawablePadding="@dimen/icon_drawable_padding" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+            <ImageView
+                android:id="@+id/clear_input_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginTop="@dimen/drop_down_clear_icon_margin_top"
+                android:layout_marginEnd="@dimen/drop_down_clear_icon_margin_end"
+                android:layout_gravity="end|center_vertical"
+                android:src="@drawable/ic_clear"
+                android:scaleType="fitCenter"
+                app:tint="#999999"/>
+
+    </FrameLayout>
 
 </LinearLayout>

--- a/datacapture/src/main/res/values/dimens.xml
+++ b/datacapture/src/main/res/values/dimens.xml
@@ -95,6 +95,8 @@
 
     <!--  Dropdown  -->
     <dimen name="drop_down_padding">16dp</dimen>
+    <dimen name="drop_down_clear_icon_margin_end">38dp</dimen>
+    <dimen name="drop_down_clear_icon_margin_top">4dp</dimen>
 
     <!--  Item Answer Media  -->
     <dimen name="item_answer_media_image_size">48dp</dimen>

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/DropDownViewHolderFactoryTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/views/factories/DropDownViewHolderFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.google.android.fhir.datacapture.views.factories
 import android.view.View
 import android.widget.AutoCompleteTextView
 import android.widget.FrameLayout
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.fhir.datacapture.R
@@ -317,6 +318,56 @@ class DropDownViewHolderFactoryTest {
 
     assertThat(viewHolder.itemView.findViewById<TextView>(R.id.error_text_at_header).visibility)
       .isEqualTo(View.GONE)
+  }
+
+  @Test
+  fun shouldHideClearIconWhenTextIsEmpty() {
+    val answerOption =
+      Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+        value =
+          Coding().apply {
+            code = "code"
+            display = "display"
+          }
+      }
+
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { addAnswerOption(answerOption) },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent(),
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      ),
+    )
+
+    val clearIcon = viewHolder.itemView.findViewById<ImageView>(R.id.clear_input_icon)
+    assertThat(clearIcon.visibility).isEqualTo(View.GONE)
+  }
+
+  @Test
+  fun shouldShowClearIconWhenTextIsNotEmpty() {
+    val answerOption =
+      Questionnaire.QuestionnaireItemAnswerOptionComponent().apply {
+        value =
+          Coding().apply {
+            code = "code"
+            display = "display"
+          }
+      }
+
+    viewHolder.bind(
+      QuestionnaireViewItem(
+        Questionnaire.QuestionnaireItemComponent().apply { addAnswerOption(answerOption) },
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          addAnswer().apply { value = answerOption.valueCoding }
+        },
+        validationResult = NotValidated,
+        answersChangedCallback = { _, _, _, _ -> },
+      ),
+    )
+
+    val clearIcon = viewHolder.itemView.findViewById<ImageView>(R.id.clear_input_icon)
+    assertThat(clearIcon.visibility).isEqualTo(View.VISIBLE)
   }
 
   @Test


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2228

**Description**
- Use `questionnaireViewItem.answers` state to check if the AutoComplete is editable or not
- Remove keyListener to make the AutoComplete not editable
- Hide keyboard after typing an option then clicking the shown option
- Show clear icon when answer is selected

**Alternative(s) considered**
N/A

**Type**
Bug fix

**Screenshots (if applicable)**

[dropdown-behavior-demo-2.webm](https://github.com/user-attachments/assets/78b862d4-9e73-458d-b1bf-688ebe82fb23)

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
