### PR TITLE
Use toSpanned in validation error dialog text

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,9 +91,12 @@ internal class QuestionnaireValidationErrorMessageDialogFragment(
           val viewModel: QuestionnaireValidationErrorViewModel by
             activityViewModels(factoryProducer = factoryProducer)
           text =
-            viewModel.getItemsTextWithValidationErrors().joinToString(separator = "\n") {
-              context.getString(R.string.questionnaire_validation_error_item_text_with_bullet, it)
-            }.toSpanned()
+            viewModel
+              .getItemsTextWithValidationErrors()
+              .joinToString(separator = "\n") {
+                context.getString(R.string.questionnaire_validation_error_item_text_with_bullet, it)
+              }
+              .toSpanned()
         }
       }
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.fhir.datacapture.extensions.flattened
 import com.google.android.fhir.datacapture.extensions.localizedFlyoverSpanned
+import com.google.android.fhir.datacapture.extensions.toSpanned
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -92,7 +93,7 @@ internal class QuestionnaireValidationErrorMessageDialogFragment(
           text =
             viewModel.getItemsTextWithValidationErrors().joinToString(separator = "\n") {
               context.getString(R.string.questionnaire_validation_error_item_text_with_bullet, it)
-            }
+            }.toSpanned()
         }
       }
   }

--- a/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
+++ b/datacapture/src/test/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragmentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ class QuestionnaireValidationErrorMessageDialogFragmentTest {
       assertThat(result.findViewById<TextView>(R.id.dialog_title).text).isEqualTo("Errors found")
       assertThat(result.findViewById<TextView>(R.id.dialog_subtitle).text)
         .isEqualTo("Fix the following questions:")
-      assertThat(result.findViewById<TextView>(R.id.body).text).isEqualTo("• First Name")
+      assertThat(result.findViewById<TextView>(R.id.body).text.toString()).isEqualTo("• First Name")
     }
   }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2797

**Description**
Use toSpanned in validation error dialog text

**Alternative(s) considered**
Another way is to remove the HTML, to only extract the text content.
But, just using toSpanned is much simpler.

**Type**
Bug fix

**Screenshots (if applicable)**
<img width="350" alt="Screen Shot 2025-02-21 at 15 31 57" src="https://github.com/user-attachments/assets/abfc32e4-dca2-4a87-b40a-3d71d0cfc81b" />


**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
