### PR TITLE
Fixed to prevent checkbox crashes#2661

### DIFF
--- a/catalog/src/main/assets/component_multi_select_choice.json
+++ b/catalog/src/main/assets/component_multi_select_choice.json
@@ -8,7 +8,7 @@
       "linkId": "1.0.0",
       "text": "What’s the reason for today’s visit?",
       "type": "choice",
-      "repeats": true,
+      "repeats": false,
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/CheckBoxGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/CheckBoxGroupViewHolderFactory.kt
@@ -127,6 +127,9 @@ internal object CheckBoxGroupViewHolderFactory :
                     val newAnswers = questionnaireViewItem.answers.toMutableList()
                     newAnswers +=
                       QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                        if(!questionnaireViewItem.questionnaireItem.repeats){
+                          newAnswers.clear()
+                        }
                         value = answerOption.value
                       }
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2661 

**Description**
fixed to prevent checkbox crashed.
I have cleared the checkbox list if repeat is false.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [x] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [x] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
