### PR TITLE
Migrate to kotlin v2 compiler

### DIFF
--- a/.github/actions/commonSetup/action.yml
+++ b/.github/actions/commonSetup/action.yml
@@ -3,11 +3,11 @@ description: "Prepares the machine"
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: "17"
+        java-version: "21"
 
     - name: "Setup Gradle"
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
   # Build will compile APK, test APK and run tests, lint, etc.
   build:
     runs-on: 'ubuntu-24.04-8core'
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       actions: read
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ site/
 # (which is slightly confusing, but helps mkdocs to validate links)
 # so we ignore that here, as it's a built artifact that should not be committed
 docs/use/api/*/**
+
+# Kotlin 2.0
+.kotlin/

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 dependencies {
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.22.0")
 
-  implementation("com.android.tools.build:gradle:8.5.0")
+  implementation("com.android.tools.build:gradle:8.9.2")
 
   implementation("app.cash.licensee:licensee-gradle-plugin:1.8.0")
   implementation("com.osacky.flank.gradle:fladle:0.17.4")

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,12 @@ fun Project.configureFirebaseTestLabForLibraries() {
         ),
         mapOf(
           "model" to "MediumPhone.arm",
-          "version" to "${project.extensions.getByType(LibraryExtension::class.java).compileSdk}",
+          "version" to "33",
+          "locale" to "en_US",
+        ),
+        mapOf(
+          "model" to "MediumPhone.arm",
+          "version" to "34",
           "locale" to "en_US",
         ),
       ),
@@ -67,7 +72,12 @@ fun Project.configureFirebaseTestLabForMicroBenchmark() {
       listOf(
         mapOf(
           "model" to "panther",
-          "version" to "${project.extensions.getByType(LibraryExtension::class.java).compileSdk}",
+          "version" to "33",
+          "locale" to "en_US",
+        ),
+        mapOf(
+          "model" to "shiba",
+          "version" to "34",
           "locale" to "en_US",
         ),
       ),

--- a/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
+++ b/buildSrc/src/main/kotlin/FirebaseTestLabConfig.kt
@@ -46,11 +46,6 @@ fun Project.configureFirebaseTestLabForLibraries() {
           "version" to "33",
           "locale" to "en_US",
         ),
-        mapOf(
-          "model" to "MediumPhone.arm",
-          "version" to "34",
-          "locale" to "en_US",
-        ),
       ),
     )
   }
@@ -73,11 +68,6 @@ fun Project.configureFirebaseTestLabForMicroBenchmark() {
         mapOf(
           "model" to "panther",
           "version" to "33",
-          "locale" to "en_US",
-        ),
-        mapOf(
-          "model" to "shiba",
-          "version" to "34",
           "locale" to "en_US",
         ),
       ),

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -35,7 +35,7 @@ object Plugins {
   const val androidGradlePlugin = "com.android.tools.build:gradle:${Versions.androidGradlePlugin}"
   const val benchmarkGradlePlugin =
     "androidx.benchmark:benchmark-gradle-plugin:${Versions.benchmarkPlugin}"
-  const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22"
+  const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
   const val navSafeArgsGradlePlugin = "androidx.navigation:navigation-safe-args-gradle-plugin:2.6.0"
   const val rulerGradlePlugin = "com.spotify.ruler:ruler-gradle-plugin:1.2.1"
   const val flankGradlePlugin = "com.osacky.flank.gradle:fladle:0.17.4"
@@ -43,9 +43,10 @@ object Plugins {
     "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:${Versions.kspPlugin}"
 
   object Versions {
-    const val androidGradlePlugin = "8.5.0"
+    const val androidGradlePlugin = "8.9.2"
     const val benchmarkPlugin = "1.1.0"
     const val dokka = "1.9.20"
-    const val kspPlugin = "1.9.22-1.0.18"
+    const val kspPlugin = "2.1.20-2.0.1"
+    const val kotlin = "2.1.20"
   }
 }

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/Sdk.kt
+++ b/buildSrc/src/main/kotlin/Sdk.kt
@@ -15,8 +15,8 @@
  */
 
 object Sdk {
-  const val COMPILE_SDK = 33
-  const val TARGET_SDK = 31
+  const val COMPILE_SDK = 36
+  const val TARGET_SDK = 36
 
   // Engine and SDC must support API 24.
   // Remove desugaring when upgrading it to 26.

--- a/buildSrc/src/main/kotlin/Sdk.kt
+++ b/buildSrc/src/main/kotlin/Sdk.kt
@@ -16,7 +16,7 @@
 
 object Sdk {
   const val COMPILE_SDK = 36
-  const val TARGET_SDK = 36
+  const val TARGET_SDK = 34
 
   // Engine and SDC must support API 24.
   // Remove desugaring when upgrading it to 26.

--- a/buildSrc/src/main/kotlin/Sdk.kt
+++ b/buildSrc/src/main/kotlin/Sdk.kt
@@ -16,7 +16,7 @@
 
 object Sdk {
   const val COMPILE_SDK = 36
-  const val TARGET_SDK = 34
+  const val TARGET_SDK = 33
 
   // Engine and SDC must support API 24.
   // Remove desugaring when upgrading it to 26.

--- a/buildSrc/src/main/kotlin/Sdk.kt
+++ b/buildSrc/src/main/kotlin/Sdk.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/com/google/android/fhir/db/impl/SQLCipherSupportHelper.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/SQLCipherSupportHelper.kt
@@ -74,7 +74,8 @@ internal class SQLCipherSupportHelper(
       }
     }
 
-  override val databaseName = standardHelper.databaseName
+  override val databaseName
+    get() = standardHelper.databaseName
 
   override fun setWriteAheadLoggingEnabled(enabled: Boolean) {
     standardHelper.setWriteAheadLoggingEnabled(enabled)
@@ -119,7 +120,8 @@ internal class SQLCipherSupportHelper(
     throw lastException ?: DatabaseEncryptionException(Exception(), UNKNOWN)
   }
 
-  override val readableDatabase = writableDatabase
+  override val readableDatabase
+    get() = writableDatabase
 
   override fun close() {
     standardHelper.close()

--- a/engine/src/main/java/com/google/android/fhir/db/impl/SQLCipherSupportHelper.kt
+++ b/engine/src/main/java/com/google/android/fhir/db/impl/SQLCipherSupportHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
+++ b/engine/src/main/java/com/google/android/fhir/testing/Utilities.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,6 @@ internal open class TestDownloadManagerImpl(
 
   override suspend fun getSummaryRequestUrls() =
     queries
-      .stream()
       .map { ResourceType.fromCode(it.substringBefore("?")) to it.plus("?_summary=count") }
       .toList()
       .toMap()

--- a/engine/src/test/java/com/google/android/fhir/index/SearchParameterRepositoryGeneratedTest.kt
+++ b/engine/src/test/java/com/google/android/fhir/index/SearchParameterRepositoryGeneratedTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class SearchParameterRepositoryGeneratedTest(private val resource: Resource) {
         .map {
           SearchParamDefinition(
             it.name,
-            Enumerations.SearchParamType.valueOf(it.type.toUpperCase()),
+            Enumerations.SearchParamType.valueOf(it.type.uppercase()),
             it.path,
           )
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ androidx-fragment = "1.6.0"
 androidx-lifecycle = "2.6.1"
 androidx-navigation = "2.6.0"
 androidx-recyclerview = "1.3.2"
-androidx-room = "2.5.2"
-androidx-sqlite = "2.3.1"
+androidx-room = "2.7.1"
+androidx-sqlite = "2.5.0"
 androidx-test-core = "1.6.1"
 androidx-test-ext-junit = "1.1.5"
 androidx-test-rules = "1.5.0"
@@ -25,8 +25,7 @@ androidx-test-runner = "1.5.0"
 androidx-work = "2.8.1"
 glide = "4.16.0"
 junit = "4.13.2"
-kotlin-stdlib = "1.9.22"
-kotlin-test = "1.9.22"
+kotlin = "2.1.20"
 kotlinx-coroutines = "1.8.1"
 logback-android = "3.0.0"
 opencds-cqf-fhir = "3.8.0"
@@ -68,8 +67,8 @@ androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref
 androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "androidx-work" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 junit = { module = "junit:junit", version.ref = "junit" }
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
-kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin-test" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-playservices = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -35,9 +35,10 @@ set -e
 # Code under repo is checked out to ${KOKORO_ARTIFACTS_DIR}/git.
 # The final directory name in this path is determined by the scm name specified
 # in the job configuration.
-export JAVA_HOME="/usr/lib/jvm/java-1.17.0-openjdk-amd64"
+#export JAVA_HOME="/usr/lib/jvm/java-1.17.0-openjdk-amd64"
 export ANDROID_HOME=${HOME}/android_sdk
-export PATH=$PATH:$JAVA_HOME/bin:${ANDROID_HOME}/cmdline-tools/latest/bin
+#export PATH=$PATH:$JAVA_HOME/bin:${ANDROID_HOME}/cmdline-tools/latest/bin
+export PATH=$PATH:${ANDROID_HOME}/cmdline-tools/latest/bin
 export GCS_BUCKET="android-fhir-build-artifacts"
 
 # Uploads files generated from builds and tests to GCS when this script exits.
@@ -57,13 +58,13 @@ function zip_artifacts() {
 }
 
 function installJdk21() {
-  wget https://download.java.net/openjdk/jdk21/ri/openjdk-21+35_linux-x64_bin.tar.gz
+  wget --quiet https://download.java.net/openjdk/jdk21/ri/openjdk-21+35_linux-x64_bin.tar.gz
   tar xvf openjdk-21+35_linux-x64_bin.tar.gz
-  sudo mv jdk-21/ /opt/jdk-21/
+  sudo mv jdk-21/ /opt/jdk-21/ > /dev/null
   echo 'export JAVA_HOME=/opt/jdk-21' | sudo tee /etc/profile.d/java21.sh
   echo 'export PATH=$JAVA_HOME/bin:$PATH'|sudo tee -a /etc/profile.d/java21.sh
   source /etc/profile.d/java21.sh
-  echo $JAVA_HOME
+#  echo $JAVA_HOME
   java --version
 }
 

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -56,6 +56,17 @@ function zip_artifacts() {
     | sed 's|gs://|https://storage.googleapis.com/|'
 }
 
+function installJdk21() {
+  wget https://download.java.net/openjdk/jdk21/ri/openjdk-21+35_linux-x64_bin.tar.gz
+  tar xvf openjdk-21+35_linux-x64_bin.tar.gz
+  sudo mv jdk-21/ /opt/jdk-21/
+  echo 'export JAVA_HOME=/opt/jdk-21' | sudo tee /etc/profile.d/java21.sh
+  echo 'export PATH=$JAVA_HOME/bin:$PATH'|sudo tee -a /etc/profile.d/java21.sh
+  source /etc/profile.d/java21.sh
+  echo $JAVA_HOME
+  java --version
+}
+
 # Installs dependencies to run CI pipeline. Dependencies are:
 #   1. npm to run spotlessApply
 #   2. Android Command Line tools, accepting its licenses
@@ -64,7 +75,8 @@ function setup() {
   sudo npm cache clean -f
   sudo npm install -g n
   sudo n 16.18.0
-  sudo apt install -y openjdk-17-jdk
+  installJdk21
+#  sudo apt install -y openjdk-17-jdk
 
   gcloud components update --quiet
 

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -60,7 +60,7 @@ function zip_artifacts() {
 function installJdk21() {
   wget --quiet https://download.java.net/openjdk/jdk21/ri/openjdk-21+35_linux-x64_bin.tar.gz
   tar xvf openjdk-21+35_linux-x64_bin.tar.gz
-  sudo mv jdk-21/ /opt/jdk-21/ > /dev/null
+  sudo mv jdk-21/ /opt/jdk-21/
   echo 'export JAVA_HOME=/opt/jdk-21' | sudo tee /etc/profile.d/java21.sh
   echo 'export PATH=$JAVA_HOME/bin:$PATH'|sudo tee -a /etc/profile.d/java21.sh
   source /etc/profile.d/java21.sh

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -64,7 +64,7 @@ function setup() {
   sudo npm cache clean -f
   sudo npm install -g n
   sudo n 16.18.0
-  sudo apt install -y openjdk-17-jdk openjdk-17-jre
+  sudo apt install -y openjdk-17-jdk
 
   gcloud components update --quiet
 


### PR DESCRIPTION
Also updates ksp and room to versions with support for k2

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Migrates to the newer Kotlin K2 compiler to address compatibility issues and conflicts among Compose libraries encountered with Kotlin v1.9.22 when setting up the [benchmarking app](https://github.com/google/android-fhir/issues/2811) to use Compose.

**Description**
Clear and concise code change description.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**

- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
