### PR TITLE
Add performance and pagination guidance to FhirEngine.search KDoc (#2684)

### DIFF
--- a/engine/src/main/java/com/google/android/fhir/search/Search.kt
+++ b/engine/src/main/java/com/google/android/fhir/search/Search.kt
@@ -34,6 +34,25 @@ import org.hl7.fhir.r4.model.ResourceType
  *  })
  * }
  * ```
+ * ### Performance Tip:
+ * Avoid requesting all resources at once — especially if they number in the thousands — as it can
+ * significantly impact performance due to memory use and JSON deserialization overhead.
+ *
+ * ### Recommended Usage:
+ * Always paginate queries using `.count()` and `.from()` in [Search] to fetch only the number of
+ * results needed for the UI.
+ *
+ * Example (Paginated Search):
+ * ```
+ * val results = fhirEngine.search<Patient> {
+ *   count = 20  // Limit to 20 results
+ *   from = 0    // Offset for pagination
+ * }
+ * ```
+ *
+ * For technical context, see:
+ * - Issue: https://github.com/google/android-fhir/issues/2684
+ * - PR with performance metrics: https://github.com/google/android-fhir/pull/2669
  *
  * @param init The lambda expression used to configure the [Search] object.
  * @return A list of [SearchResult] objects containing the matching resources and any included


### PR DESCRIPTION
### Summary

This PR improves the documentation for the `FhirEngine.search()` function by adding performance tips and usage recommendations. It guides developers to avoid fetching large datasets in a single call and instead use `.count()` and `.from()` for paginated queries.

### Changes

- Merged the basic usage example and performance best practices into the KDoc for `FhirEngine.search`.
- Linked to relevant issue and metrics PR for context.

### References

- Closes #2684
- Related PR: https://github.com/google/android-fhir/pull/2669
