### PR TITLE
Set up Compose interop interface for Questionnaire ViewHolderFactories

### DIFF
--- a/contrib/barcode/src/main/java/com/google/android/fhir/datacapture/contrib/views/barcode/BarCodeReaderViewHolderFactory.kt
+++ b/contrib/barcode/src/main/java/com/google/android/fhir/datacapture/contrib/views/barcode/BarCodeReaderViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,16 +24,16 @@ import com.google.android.fhir.datacapture.contrib.views.barcode.mlkit.md.LiveBa
 import com.google.android.fhir.datacapture.extensions.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.extensions.tryUnwrapContext
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderDelegate
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderFactory
+import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemAndroidViewHolderDelegate
+import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemAndroidViewHolderFactory
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 
 object BarCodeReaderViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.questionnaire_item_bar_code_reader_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.questionnaire_item_bar_code_reader_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var prefixTextView: TextView
       private lateinit var textQuestion: TextView
       private lateinit var barcodeTextView: TextView

--- a/contrib/locationwidget/src/main/java/com/google/android/fhir/datacapture/contrib/views/locationwidget/LocationGpsCoordinateViewHolderFactory.kt
+++ b/contrib/locationwidget/src/main/java/com/google/android/fhir/datacapture/contrib/views/locationwidget/LocationGpsCoordinateViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2024-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import com.google.android.fhir.datacapture.extensions.tryUnwrapContext
 import com.google.android.fhir.datacapture.validation.ValidationResult
 import com.google.android.fhir.datacapture.views.HeaderView
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderDelegate
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderFactory
+import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemAndroidViewHolderDelegate
+import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemAndroidViewHolderFactory
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.launch
@@ -36,11 +36,11 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 
 object LocationGpsCoordinateViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(
+  QuestionnaireItemAndroidViewHolderFactory(
     R.layout.location_gps_coordinate_view,
   ) {
-  override fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate =
-    object : QuestionnaireItemViewHolderDelegate {
+  override fun getQuestionnaireItemViewHolderDelegate() =
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       override lateinit var questionnaireViewItem: QuestionnaireViewItem
 
       private lateinit var header: HeaderView

--- a/contrib/locationwidget/src/main/java/com/google/android/fhir/datacapture/contrib/views/locationwidget/LocationWidgetViewHolderFactory.kt
+++ b/contrib/locationwidget/src/main/java/com/google/android/fhir/datacapture/contrib/views/locationwidget/LocationWidgetViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,15 @@ import com.google.android.fhir.datacapture.extensions.itemControlCode
 import com.google.android.fhir.datacapture.extensions.tryUnwrapContext
 import com.google.android.fhir.datacapture.views.GroupHeaderView
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderDelegate
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderFactory
+import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemAndroidViewHolderDelegate
+import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemAndroidViewHolderFactory
 import com.google.android.material.button.MaterialButton
 import org.hl7.fhir.r4.model.Questionnaire
 
 object LocationWidgetViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.location_widget_view) {
-  override fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate =
-    object : QuestionnaireItemViewHolderDelegate {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.location_widget_view) {
+  override fun getQuestionnaireItemViewHolderDelegate() =
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var headerView: GroupHeaderView
       private lateinit var locationWidgetButton: MaterialButton
 

--- a/datacapture/build.gradle.kts
+++ b/datacapture/build.gradle.kts
@@ -4,6 +4,7 @@ import java.net.URL
 plugins {
   id(Plugins.BuildPlugins.androidLib)
   id(Plugins.BuildPlugins.kotlinAndroid)
+  id(Plugins.BuildPlugins.kotlinCompose)
   id(Plugins.BuildPlugins.mavenPublish)
   jacoco
   id(Plugins.BuildPlugins.dokka).version(Plugins.Versions.dokka)
@@ -24,7 +25,10 @@ android {
     consumerProguardFile("proguard-rules.pro")
   }
 
-  buildFeatures { viewBinding = true }
+  buildFeatures {
+    viewBinding = true
+    compose = true
+  }
 
   buildTypes {
     release {
@@ -101,6 +105,21 @@ dependencies {
   implementation(libs.kotlin.stdlib)
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.material)
+  implementation(libs.androidx.recyclerview)
+
+  // Androidx Compose
+  implementation(libs.androidx.activity.compose)
+  implementation(platform(libs.androidx.compose.bom))
+  implementation(libs.androidx.compose.ui)
+  implementation(libs.androidx.compose.ui.graphics)
+  implementation(libs.androidx.compose.ui.tooling.preview)
+  implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.navigation.compose)
+  implementation(libs.accompanist.themeadapter.material3)
+
+  androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+  debugImplementation(libs.androidx.compose.ui.tooling)
+  debugImplementation(libs.androidx.compose.ui.test.manifest)
 
   testImplementation(Dependencies.mockitoInline)
   testImplementation(Dependencies.mockitoKotlin)

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/contrib/views/PhoneNumberViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/contrib/views/PhoneNumberViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,16 @@ import android.text.InputType
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.extensions.getValidationErrorMessage
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
+import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemAndroidViewHolderFactory
 import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemEditTextViewHolderDelegate
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderDelegate
-import com.google.android.fhir.datacapture.views.factories.QuestionnaireItemViewHolderFactory
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 
 object PhoneNumberViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.edit_text_single_line_view) {
-  override fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate =
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.edit_text_single_line_view) {
+  override fun getQuestionnaireItemViewHolderDelegate() =
     object : QuestionnaireItemEditTextViewHolderDelegate(InputType.TYPE_CLASS_PHONE) {
 
       override suspend fun handleInput(

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/AttachmentViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/AttachmentViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object AttachmentViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.attachment_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.attachment_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       override lateinit var questionnaireViewItem: QuestionnaireViewItem
       private lateinit var header: HeaderView
       private lateinit var errorTextView: TextView

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/AutoCompleteViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/AutoCompleteViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,10 +44,10 @@ import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object AutoCompleteViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.edit_text_auto_complete_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.edit_text_auto_complete_view) {
 
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var context: AppCompatActivity
       private lateinit var header: HeaderView
       private lateinit var autoCompleteTextView: MaterialAutoCompleteTextView

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/BooleanChoiceViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/BooleanChoiceViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,9 @@ import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object BooleanChoiceViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.boolean_choice_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.boolean_choice_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var context: AppCompatActivity
       private lateinit var header: HeaderView
       private lateinit var radioGroup: ConstraintLayout

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/CheckBoxGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/CheckBoxGroupViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@ import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object CheckBoxGroupViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.checkbox_group_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.checkbox_group_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private var appContext: AppCompatActivity? = null
       private lateinit var header: HeaderView
       private lateinit var checkboxGroup: ConstraintLayout

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DatePickerViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,9 +58,9 @@ import org.hl7.fhir.r4.model.DateType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object DatePickerViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.date_picker_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.date_picker_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var context: AppCompatActivity
       private lateinit var header: HeaderView
       private lateinit var textInputLayout: TextInputLayout

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DateTimePickerViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,9 @@ import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object DateTimePickerViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.date_time_picker_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.date_time_picker_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var context: AppCompatActivity
       private lateinit var header: HeaderView
       private lateinit var dateInputLayout: TextInputLayout

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DialogSelectViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DialogSelectViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,10 +48,10 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.StringType
 
 internal object QuestionnaireItemDialogSelectViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.option_select_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.option_select_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
     @SuppressLint("StaticFieldLeak")
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var holder: DialogSelectViewHolder
       override lateinit var questionnaireViewItem: QuestionnaireViewItem
       private var selectedOptionsJob: Job? = null

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DisplayViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DisplayViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ import com.google.android.fhir.datacapture.views.HeaderView
 import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
 
 internal object DisplayViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.display_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.display_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var header: HeaderView
       override lateinit var questionnaireViewItem: QuestionnaireViewItem
 

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DropDownViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/DropDownViewHolderFactory.kt
@@ -50,9 +50,9 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse
 import timber.log.Timber
 
 internal object DropDownViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.drop_down_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.drop_down_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var header: HeaderView
       private lateinit var textInputLayout: TextInputLayout
       private lateinit var autoCompleteTextView: MaterialAutoCompleteTextView

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/EditTextViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,13 +42,13 @@ import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.launch
 
 internal abstract class EditTextViewHolderFactory(@LayoutRes override val resId: Int) :
-  QuestionnaireItemViewHolderFactory(resId) {
+  QuestionnaireItemAndroidViewHolderFactory(resId) {
   abstract override fun getQuestionnaireItemViewHolderDelegate():
     QuestionnaireItemEditTextViewHolderDelegate
 }
 
 abstract class QuestionnaireItemEditTextViewHolderDelegate(private val rawInputType: Int) :
-  QuestionnaireItemViewHolderDelegate {
+  QuestionnaireItemAndroidViewHolderDelegate {
   override lateinit var questionnaireViewItem: QuestionnaireViewItem
 
   private lateinit var context: AppCompatActivity

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/GroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/GroupViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,9 @@ import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object GroupViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.group_header_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.group_header_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var context: AppCompatActivity
       private lateinit var header: GroupHeaderView
       private lateinit var error: TextView

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/QuantityViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/QuantityViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,9 +49,9 @@ import org.hl7.fhir.r4.model.Quantity
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object QuantityViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.quantity_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.quantity_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       override lateinit var questionnaireViewItem: QuestionnaireViewItem
 
       private lateinit var header: HeaderView
@@ -67,7 +67,7 @@ internal object QuantityViewHolderFactory :
         header = itemView.findViewById(R.id.header)
         textInputLayout = itemView.findViewById(R.id.text_input_layout)
         textInputEditText =
-          itemView.findViewById<TextInputEditText?>(R.id.text_input_edit_text).apply {
+          itemView.findViewById<TextInputEditText>(R.id.text_input_edit_text).apply {
             setRawInputType(QUANTITY_INPUT_TYPE)
             // Override `setOnEditorActionListener` to avoid crash with `IllegalStateException` if
             // it's not possible to move focus forward.
@@ -99,7 +99,7 @@ internal object QuantityViewHolderFactory :
 
         unitTextInputLayout = itemView.findViewById(R.id.unit_text_input_layout)
         unitAutoCompleteTextView =
-          itemView.findViewById<MaterialAutoCompleteTextView?>(R.id.unit_auto_complete).apply {
+          itemView.findViewById<MaterialAutoCompleteTextView>(R.id.unit_auto_complete).apply {
             onItemClickListener =
               AdapterView.OnItemClickListener { _, _, position, _ ->
                 appContext.lifecycleScope.launch {

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/QuestionnaireItemViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/QuestionnaireItemViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.RecyclerView
+import com.google.accompanist.themeadapter.material3.Mdc3Theme
 import com.google.android.fhir.datacapture.QuestionnaireAdapterItem
 import com.google.android.fhir.datacapture.R
 import com.google.android.fhir.datacapture.views.MediaView
@@ -32,8 +35,9 @@ import com.google.android.fhir.datacapture.views.QuestionnaireViewItem
  *
  * @param resId the layout resource for the view
  */
-abstract class QuestionnaireItemViewHolderFactory(@LayoutRes open val resId: Int) {
-  fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
+abstract class QuestionnaireItemAndroidViewHolderFactory(@LayoutRes open val resId: Int) :
+  QuestionnaireItemViewHolderFactory {
+  override fun create(parent: ViewGroup): QuestionnaireItemViewHolder {
     return QuestionnaireItemViewHolder(
       LayoutInflater.from(parent.context).inflate(resId, parent, false),
       getQuestionnaireItemViewHolderDelegate(),
@@ -44,7 +48,21 @@ abstract class QuestionnaireItemViewHolderFactory(@LayoutRes open val resId: Int
    * Returns a [QuestionnaireItemViewHolderDelegate] that handles the initialization of views and
    * binding of items in [RecyclerView].
    */
-  abstract fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate
+  abstract fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemAndroidViewHolderDelegate
+}
+
+interface QuestionnaireItemComposeViewHolderFactory : QuestionnaireItemViewHolderFactory {
+  override fun create(parent: ViewGroup): QuestionnaireItemViewHolder =
+    QuestionnaireItemViewHolder(
+      ComposeView(parent.context),
+      getQuestionnaireItemViewHolderDelegate(),
+    )
+
+  fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemComposeViewHolderDelegate
+}
+
+sealed interface QuestionnaireItemViewHolderFactory {
+  fun create(parent: ViewGroup): QuestionnaireItemViewHolder
 }
 
 /**
@@ -57,18 +75,27 @@ class QuestionnaireItemViewHolder(
   private val delegate: QuestionnaireItemViewHolderDelegate,
 ) : RecyclerView.ViewHolder(itemView) {
 
-  private var itemMediaView: MediaView
-
   init {
-    delegate.init(itemView)
-    itemMediaView = itemView.findViewById(R.id.item_media)
+    if (delegate is QuestionnaireItemAndroidViewHolderDelegate) {
+      delegate.init(itemView)
+    }
   }
 
   fun bind(questionnaireViewItem: QuestionnaireViewItem) {
-    delegate.questionnaireViewItem = questionnaireViewItem
-    delegate.bind(questionnaireViewItem)
-    itemMediaView.bind(questionnaireViewItem.questionnaireItem)
-    delegate.setReadOnly(questionnaireViewItem.questionnaireItem.readOnly)
+    when (delegate) {
+      is QuestionnaireItemAndroidViewHolderDelegate -> {
+        delegate.questionnaireViewItem = questionnaireViewItem
+        delegate.bind(questionnaireViewItem)
+        itemView
+          .findViewById<MediaView>(R.id.item_media)
+          .bind(questionnaireViewItem.questionnaireItem)
+        delegate.setReadOnly(questionnaireViewItem.questionnaireItem.readOnly)
+      }
+      is QuestionnaireItemComposeViewHolderDelegate -> {
+        require(itemView is ComposeView)
+        delegate.bind(itemView as ComposeView, questionnaireViewItem)
+      }
+    }
   }
 }
 
@@ -101,7 +128,7 @@ internal class RepeatedGroupHeaderItemViewHolder(
  * is a unique [QuestionnaireItemViewHolderDelegate] for each [QuestionnaireItemViewHolder]. This is
  * critical for the correctness of the recycler view.
  */
-interface QuestionnaireItemViewHolderDelegate {
+interface QuestionnaireItemAndroidViewHolderDelegate : QuestionnaireItemViewHolderDelegate {
 
   var questionnaireViewItem: QuestionnaireViewItem
 
@@ -120,3 +147,13 @@ interface QuestionnaireItemViewHolderDelegate {
   /** Sets view read only if [isReadOnly] is true. */
   fun setReadOnly(isReadOnly: Boolean)
 }
+
+interface QuestionnaireItemComposeViewHolderDelegate : QuestionnaireItemViewHolderDelegate {
+  fun bind(composeView: ComposeView, questionnaireViewItem: QuestionnaireViewItem) {
+    composeView.setContent { Mdc3Theme { Content(questionnaireViewItem) } }
+  }
+
+  @Composable fun Content(questionnaireViewItem: QuestionnaireViewItem)
+}
+
+sealed interface QuestionnaireItemViewHolderDelegate

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/RadioGroupViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/RadioGroupViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@ import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 
 internal object RadioGroupViewHolderFactory :
-  QuestionnaireItemViewHolderFactory(R.layout.radio_group_view) {
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.radio_group_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var appContext: AppCompatActivity
       private lateinit var header: HeaderView
       private lateinit var radioGroup: ConstraintLayout

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/ReviewViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/ReviewViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,9 +37,10 @@ import org.hl7.fhir.r4.model.Questionnaire
  * This view is a container that contains the question and answer obtained from
  * questionnaireItemViewItem [QuestionnaireViewItem].
  */
-internal object ReviewViewHolderFactory : QuestionnaireItemViewHolderFactory(R.layout.review_view) {
+internal object ReviewViewHolderFactory :
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.review_view) {
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var header: ConstraintLayout
       private lateinit var flyOverTextView: TextView
       private lateinit var errorView: View

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/SliderViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/SliderViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,10 @@ import org.hl7.fhir.r4.model.IntegerType
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.Type
 
-internal object SliderViewHolderFactory : QuestionnaireItemViewHolderFactory(R.layout.slider_view) {
-  override fun getQuestionnaireItemViewHolderDelegate(): QuestionnaireItemViewHolderDelegate =
-    object : QuestionnaireItemViewHolderDelegate {
+internal object SliderViewHolderFactory :
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.slider_view) {
+  override fun getQuestionnaireItemViewHolderDelegate() =
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private lateinit var appContext: AppCompatActivity
       private lateinit var header: HeaderView
       private lateinit var slider: Slider

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/TimePickerViewHolderFactory.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/views/factories/TimePickerViewHolderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2024-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,10 +41,11 @@ import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.TimeType
 
-object TimePickerViewHolderFactory : QuestionnaireItemViewHolderFactory(R.layout.time_picker_view) {
+object TimePickerViewHolderFactory :
+  QuestionnaireItemAndroidViewHolderFactory(R.layout.time_picker_view) {
 
   override fun getQuestionnaireItemViewHolderDelegate() =
-    object : QuestionnaireItemViewHolderDelegate {
+    object : QuestionnaireItemAndroidViewHolderDelegate {
       private val TAG = "time-picker"
       private lateinit var context: AppCompatActivity
       private lateinit var header: HeaderView

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 # see https://docs.gradle.org/current/userguide/platforms.html
 
 [versions]
+accompanist-themeadapter-material3 = "0.36.0"
 android-fhir-common = "0.1.0-alpha05"
 android-fhir-engine = "0.1.0-beta05"
 android-fhir-knowledge = "0.1.0-beta01"
@@ -10,7 +11,7 @@ androidx-appcompat = "1.6.1"
 androidx-arch-core = "2.2.0"
 androidx-benchmark = "1.4.0-rc01"
 androidx-benchmark-macro = "1.4.0-rc01"
-androidx-compose-bom = "2025.04.01"
+androidx-compose-bom = "2025.07.00"
 androidx-constraintlayout = "2.1.4"
 androidx-core = "1.10.1"
 androidx-datastore = "1.0.0"
@@ -20,7 +21,7 @@ androidx-lifecycle = "2.8.7"
 androidx-navigation = "2.6.0"
 androidx-navigation-compose = "2.8.9"
 androidx-profilerinstaller = "1.4.1"
-androidx-recyclerview = "1.3.2"
+androidx-recyclerview = "1.4.0"
 androidx-room = "2.7.1"
 androidx-sqlite = "2.5.0"
 androidx-test-core = "1.6.1"
@@ -35,12 +36,13 @@ kotlin = "2.1.20"
 kotlinx-coroutines = "1.8.1"
 kotlinx-serialization-json = "1.8.1"
 logback-android = "3.0.0"
-material = "1.9.0"
+material = "1.12.0"
 opencds-cqf-fhir = "3.8.0"
 truth = "1.1.5"
 uiautomator = "2.3.0"
 
 [libraries]
+accompanist-themeadapter-material3 = { module = "com.google.accompanist:accompanist-themeadapter-material3", version.ref = "accompanist-themeadapter-material3"}
 android-fhir-common = { module = "com.google.android.fhir:common", version.ref = "android-fhir-common" }
 android-fhir-engine = { module = "com.google.android.fhir:engine", version.ref = "android-fhir-engine" }
 android-fhir-knowledge = { module = "com.google.android.fhir:knowledge", version.ref = "android-fhir-knowledge" }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #

**Description**
Sets up an interface to support compose for viewholder factories used in the QuestionnaireEditAdapter 

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**

- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
