### PR TITLE
Replace designation with translation extension in the demo questionnaire

### DIFF
--- a/demo/src/main/assets/new-patient-registration-paginated.json
+++ b/demo/src/main/assets/new-patient-registration-paginated.json
@@ -172,6 +172,23 @@
           "definition": "http://hl7.org/fhir/StructureDefinition/Patient#Patient.gender",
           "type": "choice",
           "text": "Gender",
+          "_text": {
+            "extension": [
+              {
+                "extension": [
+                  {
+                    "url": "lang",
+                    "valueCode": "sw"
+                  },
+                  {
+                    "url": "content",
+                    "valueString": "Jinsia"
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/translation"
+              }
+            ]
+          },
           "extension": [
             {
               "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
@@ -205,11 +222,23 @@
                 "system": "http://hl7.org/fhir/administrative-gender",
                 "code": "female",
                 "display": "Female",
-                "designation": [
-                  {
-                    "language": "sw",
-                    "value": "Mwanamke"
-                  }]
+                "_display": {
+                  "extension": [
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "sw"
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Mwanamke"
+                        }
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                    }
+                  ]
+                }
               }
             },
             {
@@ -217,11 +246,23 @@
                 "system": "http://hl7.org/fhir/administrative-gender",
                 "code": "male",
                 "display": "Male",
-                "designation": [
-                  {
-                    "language": "sw",
-                    "value": "Mwanaume"
-                  }]
+                "_display": {
+                  "extension": [
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "sw"
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Mwanaume"
+                        }
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                    }
+                  ]
+                }
               }
             },
             {
@@ -229,11 +270,23 @@
                 "system": "http://hl7.org/fhir/administrative-gender",
                 "code": "other",
                 "display": "Other",
-                "designation": [
-                  {
-                    "language": "sw",
-                    "value": "Nyingine"
-                  }]
+                "_display": {
+                  "extension": [
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "sw"
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Nyingine"
+                        }
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                    }
+                  ]
+                }
               }
             },
             {
@@ -241,11 +294,23 @@
                 "system": "http://hl7.org/fhir/administrative-gender",
                 "code": "unknown",
                 "display": "Unknown",
-                "designation": [
-                  {
-                    "language": "sw",
-                    "value": "Haijulikani"
-                  }]
+                "_display": {
+                  "extension": [
+                    {
+                      "extension": [
+                        {
+                          "url": "lang",
+                          "valueCode": "sw"
+                        },
+                        {
+                          "url": "content",
+                          "valueString": "Haijulikani"
+                        }
+                      ],
+                      "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                    }
+                  ]
+                }
               }
             }
           ]


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2882

**Description**
Replaces designation in `gender` answerOptions value with the `translation` extension

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**

- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
