### PR TITLE
Localize text for QuestionnaireValidationErrorMessageDialog items

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -33,7 +33,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.fhir.datacapture.extensions.flattened
 import com.google.android.fhir.datacapture.extensions.localizedFlyoverSpanned
+import com.google.android.fhir.datacapture.extensions.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.extensions.localizedTextSpanned
+import com.google.android.fhir.datacapture.extensions.takeIfNotBlank
 import com.google.android.fhir.datacapture.extensions.toSpanned
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.ValidationResult
@@ -139,7 +141,11 @@ internal class QuestionnaireValidationErrorViewModel : ViewModel() {
       ?.flattened()
       ?.filter { invalidFields.contains(it.linkId) }
       ?.mapNotNull {
-        if (it.text.isNullOrEmpty()) it.localizedFlyoverSpanned else it.localizedTextSpanned
+        // Use the question text if available, otherwise fall back to the fly-over and then the
+        // prefix.
+        it.localizedTextSpanned?.takeIfNotBlank()
+          ?: it.localizedFlyoverSpanned?.takeIfNotBlank()
+            ?: it.localizedPrefixSpanned?.takeIfNotBlank()
       }
       ?: emptyList()
   }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -18,6 +18,7 @@ package com.google.android.fhir.datacapture
 
 import android.app.Dialog
 import android.os.Bundle
+import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
@@ -32,6 +33,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.fhir.datacapture.extensions.flattened
 import com.google.android.fhir.datacapture.extensions.localizedFlyoverSpanned
+import com.google.android.fhir.datacapture.extensions.localizedTextSpanned
 import com.google.android.fhir.datacapture.extensions.toSpanned
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.ValidationResult
@@ -129,14 +131,16 @@ internal class QuestionnaireValidationErrorViewModel : ViewModel() {
   }
 
   /** @return Texts associated with the failing [Questionnaire.QuestionnaireItemComponent]s. */
-  fun getItemsTextWithValidationErrors(): List<String> {
+  fun getItemsTextWithValidationErrors(): List<Spanned> {
     val invalidFields =
       validation?.filterValues { it.filterIsInstance<Invalid>().isNotEmpty() } ?: emptyMap()
     return questionnaire
       ?.item
       ?.flattened()
       ?.filter { invalidFields.contains(it.linkId) }
-      ?.map { if (it.text.isNullOrEmpty()) it.localizedFlyoverSpanned.toString() else it.text }
+      ?.mapNotNull {
+        if (it.text.isNullOrEmpty()) it.localizedFlyoverSpanned else it.localizedTextSpanned
+      }
       ?: emptyList()
   }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -96,7 +96,7 @@ internal class QuestionnaireValidationErrorMessageDialogFragment(
           text =
             viewModel
               .getItemsTextWithValidationErrors()
-              .joinToString(separator = "\n") {
+              .joinToString(separator = "<br>") {
                 context.getString(R.string.questionnaire_validation_error_item_text_with_bullet, it)
               }
               .toSpanned()

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/QuestionnaireValidationErrorMessageDialogFragment.kt
@@ -35,7 +35,6 @@ import com.google.android.fhir.datacapture.extensions.flattened
 import com.google.android.fhir.datacapture.extensions.localizedFlyoverSpanned
 import com.google.android.fhir.datacapture.extensions.localizedPrefixSpanned
 import com.google.android.fhir.datacapture.extensions.localizedTextSpanned
-import com.google.android.fhir.datacapture.extensions.takeIfNotBlank
 import com.google.android.fhir.datacapture.extensions.toSpanned
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.ValidationResult
@@ -149,4 +148,6 @@ internal class QuestionnaireValidationErrorViewModel : ViewModel() {
       }
       ?: emptyList()
   }
+
+  private fun Spanned.takeIfNotBlank(): Spanned? = takeIf { it.isNotBlank() }
 }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Google LLC
+ * Copyright 2023-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -378,7 +378,7 @@ val QuestionnaireItemComponent.hasHelpButton: Boolean
 
 /** Converts Text with HTML Tag to formatted text. */
 internal fun String.toSpanned(): Spanned {
-  return HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_COMPACT)
+  return HtmlCompat.fromHtml(this.replace("\n", "<br>"), HtmlCompat.FROM_HTML_MODE_COMPACT)
 }
 
 internal fun Spanned.takeIfNotBlank(): Spanned? = takeIf { it.isNotBlank() }

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Google LLC
+ * Copyright 2023-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -380,6 +380,8 @@ val QuestionnaireItemComponent.hasHelpButton: Boolean
 internal fun String.toSpanned(): Spanned {
   return HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_COMPACT)
 }
+
+internal fun Spanned.takeIfNotBlank(): Spanned? = takeIf { it.isNotBlank() }
 
 /**
  * Localized and spanned value of [Questionnaire.QuestionnaireItemComponent.text] if translation is

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -378,7 +378,7 @@ val QuestionnaireItemComponent.hasHelpButton: Boolean
 
 /** Converts Text with HTML Tag to formatted text. */
 internal fun String.toSpanned(): Spanned {
-  return HtmlCompat.fromHtml(this.replace("\n", "<br>"), HtmlCompat.FROM_HTML_MODE_COMPACT)
+  return HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_COMPACT)
 }
 
 /**

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireItemComponents.kt
@@ -381,8 +381,6 @@ internal fun String.toSpanned(): Spanned {
   return HtmlCompat.fromHtml(this.replace("\n", "<br>"), HtmlCompat.FROM_HTML_MODE_COMPACT)
 }
 
-internal fun Spanned.takeIfNotBlank(): Spanned? = takeIf { it.isNotBlank() }
-
 /**
  * Localized and spanned value of [Questionnaire.QuestionnaireItemComponent.text] if translation is
  * present. Default value otherwise.


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2886

**Description**
Replace `QuestionnaireItem.text` with `QuestionnaireItem.localizedTextSpanned `to show translated version of `text` in validation dialog

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Choose one: (Bug fix | Feature | Documentation | Testing | Code health | Builds | Releases | Other)

**Screenshots (if applicable)**

**Checklist**

- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://google.github.io/android-fhir/contrib/) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
